### PR TITLE
bug 948644 - add filename and version column to missing_symbols

### DIFF
--- a/alembic/versions/5674c7b2ff01_bug_948644_add_filename_and_version_to_.py
+++ b/alembic/versions/5674c7b2ff01_bug_948644_add_filename_and_version_to_.py
@@ -1,0 +1,33 @@
+"""bug 948644 - add filename and version to missing_symbols
+
+Revision ID: 5674c7b2ff01
+Revises: 556e11f2d00f
+Create Date: 2014-11-26 11:56:44.278539
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5674c7b2ff01'
+down_revision = '556e11f2d00f'
+
+from alembic import op
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
+
+import sqlalchemy as sa
+from sqlalchemy import types
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table, column
+
+
+def upgrade():
+    op.add_column(u'missing_symbols',
+            sa.Column('filename', sa.TEXT(), nullable=True)
+    )
+    op.add_column(u'missing_symbols',
+            sa.Column('version', sa.TEXT(), nullable=True)
+    )
+
+def downgrade():
+    op.drop_column(u'missing_symbols', 'version')
+    op.drop_column(u'missing_symbols', 'filename')

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1545,10 +1545,13 @@ class MissingSymbols(DeclarativeBase):
     __tablename__ = 'missing_symbols'
 
     date_processed = Column(u'date_processed', DATE(), nullable=False)
-    debug_file = Column(u'debug_file', TEXT(), nullable=True, primary_key=True)
+    filename = Column(u'filename', TEXT(), nullable=True)
+    debug_file = Column(u'debug_file', TEXT(), nullable=False)
     debug_id = Column(u'debug_id', TEXT(), nullable=True)
+    version = Column(u'version', TEXT(), nullable=True)
 
-    __mapper_args__ = {'primary_key': (date_processed, debug_file, debug_id)}
+    __mapper_args__ = {'primary_key': (date_processed, filename, debug_file,
+        debug_id, version)}
 
 
 ###########################################

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -764,8 +764,9 @@ class MissingSymbolsRule(Rule):
             self.database,
         )
         self.sql = (
-            "INSERT INTO missing_symbols(date_processed, debug_file, debug_id)"
-            " VALUES (%s, %s, %s)"
+            "INSERT INTO missing_symbols"
+            "(filename, date_processed, debug_file, debug_id, version)"
+            " VALUES (%s, %s, %s, %s, %s)"
         )
 
     #--------------------------------------------------------------------------
@@ -785,11 +786,14 @@ class MissingSymbolsRule(Rule):
             date_processed = processed_crash['date_processed']
             for module in processed_crash['json_dump']['modules']:
                 if 'missing_symbols' in module and module['missing_symbols']:
+                    filename = module['filename']
                     debug_file = module['debug_file']
                     debug_id = module['debug_id']
+                    version = module['version']
                     try:
                         self.transaction(execute_no_results, self.sql,
-                                         (date, debug_file, debug_id))
+                            (date, filename, debug_file, debug_id, version)
+                        )
                     except self.database.ProgrammingError as e:
                         processor_meta.processor_notes.append(
                             "WARNING: missing symbols rule failed for"

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1870,8 +1870,10 @@ class TestMissingSymbols(TestCase):
         processed_crash.json_dump = {
             'modules': [
                 {
+                    "filename": "some-file.dll",
                     "debug_id": "ABCDEFG",
                     "debug_file": "some-file.pdb",
+                    "version": "1.2.3.4",
                     "missing_symbols": True,
                 },
             ]
@@ -1886,5 +1888,6 @@ class TestMissingSymbols(TestCase):
 
         from socorro.external.postgresql.dbapi2_util import execute_no_results
         config.transaction_executor_class.return_value.assert_called_with(
-            execute_no_results, rule.sql, ('now', 'some-file.pdb', 'ABCDEFG')
+            execute_no_results, rule.sql,
+            ('now', 'some-file.dll', 'some-file.pdb', 'ABCDEFG', '1.2.3.4')
         )


### PR DESCRIPTION
r? @selenamarie - technically we don't need these to replace modulelist, but anticipate other reports based on this data (see bug for details)