### PR TITLE
fixes Bug 1117168 extended quit check to transform rules

### DIFF
--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -300,7 +300,11 @@ class TransformRuleSystem(RequiredConfig):
     )
 
     #--------------------------------------------------------------------------
-    def __init__(self, config=None):
+    def __init__(self, config=None, quit_check=None):
+        if quit_check:
+            self._quit_check = quit_check
+        else:
+            self._quit_check = self._null_quit_check
         self.rules = []
         if not config:
             config = DotDict()
@@ -321,6 +325,11 @@ class TransformRuleSystem(RequiredConfig):
                     self.rules.append(
                         a_rule_class(config)
                     )
+
+    #--------------------------------------------------------------------------
+    def _null_quit_check(self):
+        "a no-op method to do nothing if no quit check method has been defined"
+        pass
 
     #--------------------------------------------------------------------------
     def load_rules(self, an_iterable):
@@ -345,6 +354,7 @@ class TransformRuleSystem(RequiredConfig):
         returns:
              True - since success or failure is ignored"""
         for x in self.rules:
+            self._quit_check()
             if self.config.chatty_rules:
                 self.config.logger.debug(
                     'apply_all_rules: %s',
@@ -367,6 +377,7 @@ class TransformRuleSystem(RequiredConfig):
            True - if an action is run and succeeds
            False - if no action succeeds"""
         for x in self.rules:
+            self._quit_check()
             if self.config.chatty_rules:
                 self.config.logger.debug(
                     'apply_until_action_succeeds: %s',
@@ -391,6 +402,7 @@ class TransformRuleSystem(RequiredConfig):
             True - an action ran and it failed
             False - no action ever failed"""
         for x in self.rules:
+            self._quit_check()
             if self.config.chatty_rules:
                 self.config.logger.debug(
                     'apply_until_action_fails: %s',
@@ -416,6 +428,7 @@ class TransformRuleSystem(RequiredConfig):
             False - an action ran and it failed
             None - no predicate ever succeeded"""
         for x in self.rules:
+            self._quit_check()
             if self.config.chatty_rules:
                 self.config.logger.debug(
                     'apply_until_predicate_succeeds: %s',
@@ -440,6 +453,7 @@ class TransformRuleSystem(RequiredConfig):
             False - a predicate ran and it failed
             None - no predicate ever failed"""
         for x in self.rules:
+            self._quit_check()
             if self.config.chatty_rules:
                 self.config.logger.debug(
                     'apply_until_predicate_fails: %s',

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -171,7 +171,8 @@ class Processor2015(RequiredConfig):
             )
             self.rule_system[a_rule_set_name] = (
                 config[a_rule_set_name].rule_system_class(
-                    config[a_rule_set_name]
+                    config[a_rule_set_name],
+                    self.quit_check
                 )
             )
 

--- a/socorro/unittest/lib/test_transform_rules.py
+++ b/socorro/unittest/lib/test_transform_rules.py
@@ -289,6 +289,8 @@ class TestTransformRules(TestCase):
 
     def test_TransformRuleSystem_apply_all_rules(self):
 
+        quit_check_mock = Mock()
+
         def assign_1(s, d):
             d['one'] = 1
             return True
@@ -305,14 +307,17 @@ class TestTransformRules(TestCase):
                       (False, '', '', increment_1, '', ''),
                       (True, '', '', increment_1, '', ''),
                      ]
-        rules = transform_rules.TransformRuleSystem()
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
         rules.load_rules(some_rules)
         s = {}
         d = {}
         rules.apply_all_rules(s, d)
         assert_expected(d, {'one': 2})
+        assert_expected(quit_check_mock.call_count, 4)
 
     def test_TransformRuleSystem_apply_all_until_action_succeeds(self):
+
+        quit_check_mock = Mock()
 
         def assign_1(s, d):
             d['one'] = 1
@@ -330,15 +335,18 @@ class TestTransformRules(TestCase):
                       (False, '', '', increment_1, '', ''),
                       (True, '', '', increment_1, '', ''),
                      ]
-        rules = transform_rules.TransformRuleSystem()
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
         rules.load_rules(some_rules)
         s = {}
         d = {}
         rules.apply_until_action_succeeds(s, d)
         assert_expected(d, {'one': 1})
+        assert_expected(quit_check_mock.call_count, 2)
 
 
     def test_TransformRuleSystem_apply_all_until_action_fails(self):
+
+        quit_check_mock = Mock()
 
         def assign_1(s, d):
             d['one'] = 1
@@ -356,15 +364,18 @@ class TestTransformRules(TestCase):
                       (False, '', '', increment_1, '', ''),
                       (True, '', '', increment_1, '', ''),
                      ]
-        rules = transform_rules.TransformRuleSystem()
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
         rules.load_rules(some_rules)
         s = {}
         d = {}
         rules.apply_until_action_fails(s, d)
         assert_expected(d, {})
+        assert_expected(quit_check_mock.call_count, 1)
 
 
     def test_TransformRuleSystem_apply_all_until_predicate_succeeds(self):
+
+        quit_check_mock = Mock()
 
         def assign_1(s, d):
             d['one'] = 1
@@ -382,14 +393,17 @@ class TestTransformRules(TestCase):
                       (False, '', '', increment_1, '', ''),
                       (True, '', '', increment_1, '', ''),
                      ]
-        rules = transform_rules.TransformRuleSystem()
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
         rules.load_rules(some_rules)
         s = {}
         d = {}
         rules.apply_until_predicate_succeeds(s, d)
         assert_expected(d, {})
+        assert_expected(quit_check_mock.call_count, 1)
 
     def test_TransformRuleSystem_apply_all_until_predicate_fails(self):
+
+        quit_check_mock = Mock()
 
         def assign_1(s, d):
             d['one'] = 1
@@ -407,7 +421,7 @@ class TestTransformRules(TestCase):
                       (False, '', '', increment_1, '', ''),
                       (True, '', '', increment_1, '', ''),
                      ]
-        rules = transform_rules.TransformRuleSystem()
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
         rules.load_rules(some_rules)
         s = {}
         d = {}
@@ -437,6 +451,8 @@ class TestTransformRules(TestCase):
         rules.load_rules(some_rules)
         res = rules.apply_until_predicate_fails()
         assert_expected(res, False)
+
+        assert_expected(quit_check_mock.call_count, 9)
 
     def test_is_not_null_predicate(self):
         ok_(
@@ -562,7 +578,3 @@ class TestTransformRules(TestCase):
         ok_(isinstance(trs.rules[1], TestRuleTestDangerous))
         ok_(trs.rules[0].predicate(None))
         ok_(trs.rules[1].action(None))
-
-
-
-

--- a/socorro/unittest/processor/test_processor_2015.py
+++ b/socorro/unittest/processor/test_processor_2015.py
@@ -115,6 +115,7 @@ class TestProcessor2015(TestCase):
         ok_(isinstance(p.rule_system, DotDict))
         eq_(len(p.rule_system), 2)
         ok_('ruleset01' in p.rule_system)
+        print p.rule_system.ruleset01
         ok_(isinstance(p.rule_system.ruleset01, TransformRuleSystem))
         trs = p.rule_system.ruleset01
         eq_(trs.act, trs.apply_all_rules)


### PR DESCRIPTION
Processor2015 is not as responsive to SIGTERM as the HybridProcessor was.  That's because the TransformRule system doesn't honor the quit_check callback function.  

This PR extends the quit_check call back function to the TransformRule system
