### PR TITLE
fixes Bug 1117590 - removed bogus module on exception

### DIFF
--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -169,7 +169,7 @@ class ProcessorApp(FetchTransformSaveApp):
                     try:
                         if "TEMPORARY" in a_dump_pathname:
                             os.unlink(a_dump_pathname)
-                    except os.OSError, x:
+                    except OSError, x:
                         # the file does not actually exist
                         self.config.logger.info(
                             'deletion of dump failed: %s',


### PR DESCRIPTION
the code that moved the delete of the temporary dump files somehow acquired a module qualifier.  and that prevents the processor from logging file deletion problems.

this is the fix.