### PR TITLE
fixes Bug 1117961 - ensure that all passwords are tagged as secret

### DIFF
--- a/socorro/cron/jobs/automatic_emails.py
+++ b/socorro/cron/jobs/automatic_emails.py
@@ -109,6 +109,7 @@ class AutomaticEmailsCronApp(BaseCronApp, ElasticSearchBase):
         default='',
         doc='ExactTarget API password.',
         reference_value_from='secrets.exacttarget',
+        secret=True,
     )
     required_config.add_option(
         'email_template',

--- a/socorro/cron/jobs/fetch_adi_from_hive.py
+++ b/socorro/cron/jobs/fetch_adi_from_hive.py
@@ -156,7 +156,9 @@ class FetchADIFromHiveCronApp(BaseCronApp):
     required_config.add_option(
         'hive_password',
         default='ignored',
-        doc='Password to connect to Hive with')
+        doc='Password to connect to Hive with',
+        secret=True)
+
 
     required_config.add_option(
         'hive_database',

--- a/socorro/external/postgresql/connection_context.py
+++ b/socorro/external/postgresql/connection_context.py
@@ -47,6 +47,7 @@ class ConnectionContext(RequiredConfig):
         default='aPassword',
         doc="the user's database password",
         reference_value_from='secrets.postgresql',
+        secret=True,
     )
 
     # clients of this class may need to detect Exceptions raised in the

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -72,6 +72,7 @@ class SocorroDBApp(App):
         name='database_password',
         default='aPassword',
         doc='Password to connect to database',
+        secret=True,
     )
 
     required_config.add_option(
@@ -84,6 +85,7 @@ class SocorroDBApp(App):
         name='database_superuserpassword',
         default='aPassword',
         doc='Password to connect to database',
+        secret=True,
     )
 
     required_config.add_option(
@@ -155,6 +157,7 @@ class SocorroDBApp(App):
         name='default_password',
         default='aPassword',
         doc='Default password for roles created by setupdb_app.py',
+        secret=True,
     )
 
     required_config.add_option(

--- a/socorro/external/rabbitmq/connection_context.py
+++ b/socorro/external/rabbitmq/connection_context.py
@@ -111,6 +111,7 @@ class ConnectionContext(RequiredConfig):
         default='guest',
         doc="the user's RabbitMQ password",
         reference_value_from='secrets.rabbitmq',
+        secret=True,
     )
     required_config.add_option(
         name='standard_queue_name',


### PR DESCRIPTION
configman can offer sensitive status to options that should not be echoed to stdout, stderr or logs.  Make sure that all Socorro apps use that tagging for sensitive options