### PR TITLE
fixes Bug 1118269 - added separate transaction executor for gets to BotoS3CrashStore

### DIFF
--- a/socorro/database/transaction_executor.py
+++ b/socorro/database/transaction_executor.py
@@ -19,6 +19,8 @@ def string_to_list_of_ints(a_string):
 class TransactionExecutor(RequiredConfig):
     required_config = Namespace()
 
+    is_infinite = False
+
     #--------------------------------------------------------------------------
     def __init__(self, config, db_conn_context_source,
                  quit_check_callback=None):
@@ -71,6 +73,8 @@ class TransactionExecutorWithInfiniteBackoff(TransactionExecutor):
     required_config.add_option('wait_log_interval',
                                default=10,
                                doc='seconds between log during retries')
+
+    is_infinite = True
 
     #--------------------------------------------------------------------------
     def backoff_generator(self):
@@ -165,3 +169,5 @@ class TransactionExecutorWithLimitedBackoff(
         between retries."""
         for x in self.config.backoff_delays:
             yield x
+
+


### PR DESCRIPTION
this PR add dual transaction executors to the BotoS3 class.  This allows ```gets``` and ```saves``` to have different transactional behaviors.  On re-tryable Exceptions, ```saves``` should retry forever until they succeed.  However, on reads, the  retry behavior should be less forgiving and give up after a while.  

In the processors, the default ```transaction_executor_class``` should be ```TransactionExecutorWithInfiniteBackoff``` while ```transaction_executor_class_for_get``` should be ```TransactionExecutorWithLimitedBackoff```.    In other places, like the middleware, ```transaction_executor_class_for_get``` likely should be ```TransactionExecutor``` so that it only tries once.