### PR TITLE
fix bug 1118224 - check for existing buildID before trying to insert

### DIFF
--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -432,6 +432,7 @@ class FTPScraperCronApp(BaseCronApp, ScrapersMixin):
                         self._is_final_beta(version)
                         and build_type == 'release'
                         and version > '26.0'
+                        and kvpairs.get('buildID')
                     ):
                         logger.debug('is final beta version %s', version)
                         repository = 'mozilla-beta'


### PR DESCRIPTION
r? @selenamarie 