### PR TITLE
bug 1119223 - custom requirements for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==1.2.3
+sphinx-rtd-theme==0.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,9 +161,6 @@ django-compressor==1.4
 django-jsonfield==0.9.13
 # sha256: iTXjRYmmVJstzm7v-uQNInOetVtqmUow9mpCjW-YuBM
 eventlog==0.8.0
-# sha256: Dyn1RPbQN5ifoMdymp6rfk2OpQ1vDvNzY_RydWwe3KY
-# sha256: PYBK7mdyHzjoQO-jo65SiYMo5kcJJZNB8qiQHVvwHNQ
-sphinx_rtd_theme
 # sha256: qZ245ZwSATitinLuztzCS0UQ0u7TzkghO34y8izE7m4
 pyOpenSSL==0.14
 # sha256: 0P40ymJSUdKblkxDRxQBWjBj6MLXTKMLL5ZPXzHTTbM


### PR DESCRIPTION
r? @phrawzty or @rhelmer or @AdrianGaudebert 

So, by default readthedocs will automatically find our `./requirements.txt` and run it. This is problematic in two ways:

1) We don't have `sphinx` in there. We could add it but then we would also have to "peep-add" all of it's 5 other dependencies (there is some overlap with things we already have like `six` and `jinja2`). We could just add it and since readthedocs runs `pip install -r requirements.txt` they would automatically fetch the dependencies. However, it would make our requirements.txt file useless for developers who we encourage to use `peep install -r requirements.txt`. 

2) We have A LOT of stuff in our `requirements.txt` and poor readthedocs will have to install all of them. Some builds simply fail because of problems with `sasl.c` and other unrelated stuff they don't need. It's not our machine or our problem that the builds do excessive work on someone else's dime but it's just not playing nicely. 

By having dedicated `docs/requirements.txt` file specifically for readthedocs.org we just install only what's needed to make a good build. 

Note; as of this change you have to configure readthedocs.org to read in `docs/requirements.txt` instead of picking up the default (i.e. `./requirements.txt`). 

I experimented by pointing our socorro.readthedocs.org to my fork and this branch (...that is this pull request) and then I [got a successful build finally](https://readthedocs.org/builds/socorro/2077016/)