### PR TITLE
bug 1120551 - bump forced versions correlation thingy for ff 36

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="35.0 36.0a2 37.0a1"
+MANUAL_VERSION_OVERRIDE="36.0 37.0a2 38.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
should go out today or tomorrow. @KaiRo-at can you double check the versions override when you get a chance?