### PR TITLE
fixes Bug 1121462 - add generic external process rule

### DIFF
--- a/socorro/lib/converters.py
+++ b/socorro/lib/converters.py
@@ -105,3 +105,12 @@ def str_to_classes_in_namespaces_converter(
         return InnerClassList  # result of class_list_converter
 
     return class_list_converter  # result of classes_in_namespaces_converter
+
+
+#------------------------------------------------------------------------------
+def change_default(kls, key, new_default):
+    """return a new configman Option object that is a copy of an existing one,
+    giving the new one a different default value"""
+    an_option = kls.get_required_config()[key].copy()
+    an_option.default = new_default
+    return an_option


### PR DESCRIPTION
this PR provides two processor rules (though does not actually set them up for use - separate bug for that).  The first rule is a generic base class for rules that need to invoke an external process.  The second rule is an implementation that uses the base class to invoke ted's dump-lookup tool.

