### PR TITLE
Fixes bug 1117911 crontabber to truncate raw/processed crash partitions >2 weeks

### DIFF
--- a/alembic/versions/1023855cf1ad_fixes_bug_1117911_load_truncate_.py
+++ b/alembic/versions/1023855cf1ad_fixes_bug_1117911_load_truncate_.py
@@ -8,7 +8,7 @@ Create Date: 2015-01-16 10:58:35.975923
 
 # revision identifiers, used by Alembic.
 revision = '1023855cf1ad'
-down_revision = '5387d590bc45'
+down_revision = '2cdb9abe6291'
 
 from alembic import op
 from socorro.lib import citexttype, jsontype, buildtype

--- a/alembic/versions/1023855cf1ad_fixes_bug_1117911_load_truncate_.py
+++ b/alembic/versions/1023855cf1ad_fixes_bug_1117911_load_truncate_.py
@@ -1,0 +1,28 @@
+"""Fixes bug 1117911 - load truncate_partitions() function
+
+Revision ID: 1023855cf1ad
+Revises: 5387d590bc45
+Create Date: 2015-01-16 10:58:35.975923
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1023855cf1ad'
+down_revision = '5387d590bc45'
+
+from alembic import op
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
+
+import sqlalchemy as sa
+from sqlalchemy import types
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table, column
+
+
+def upgrade():
+    load_stored_proc(op, ['truncate_partitions.sql'])
+
+
+def downgrade():
+    load_stored_proc(op, ['truncate_partitions.sql'])

--- a/docs/development/databaseadminfunctions.rst
+++ b/docs/development/databaseadminfunctions.rst
@@ -296,7 +296,7 @@ of tables and views.
 weekly_report_partitions
 ------------------------
 
-Purpose: to create new paritions for the reports table and its  child
+Purpose: to create new paritions for the reports table and its child
 tables every week.
 
 Called By: weekly cron job
@@ -549,3 +549,16 @@ release_throttle
 	If throttling back the number of release crashes processed, set here
 
 Notes: add_new_product will return FALSE rather than erroring if the product already exists.
+
+truncate_partitions
+-------------------
+
+Purpose: Truncates crash report partitions for raw_crashes and processed_crashes
+
+Called By: crontabber job TruncatePartitionsCronApp on a weekly basis
+
+::
+     truncate_partitions(weeks_to_keep INTEGER) RETURNS BOOLEAN
+
+weeks_to_keep
+    Number of weeks of data to preserve

--- a/docs/development/databaseadminfunctions.rst
+++ b/docs/development/databaseadminfunctions.rst
@@ -296,7 +296,7 @@ of tables and views.
 weekly_report_partitions
 ------------------------
 
-Purpose: to create new paritions for the reports table and its child
+Purpose: to create new partitions for the reports table and its child
 tables every week.
 
 Called By: weekly cron job

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -52,12 +52,15 @@ DEFAULT_JOBS = '''
   socorro.cron.jobs.matviews.CorrelationsCoreCronApp|1d|07:30
   socorro.cron.jobs.matviews.CorrelationsModuleCronApp|1d|08:00
   socorro.cron.jobs.drop_old_partitions.DropOldPartitionsCronApp|7d
+  socorro.cron.jobs.truncate_partitions.TruncatePartitionsCronApp|7d
 '''
 
 
 # this class is for eventual support of CronTabber with the universal
 # socorro app.
 from socorro.app.socorro_app import App as App
+
+
 #==============================================================================
 class CronTabberApp(CronTabberBase, App):
     #--------------------------------------------------------------------------

--- a/socorro/cron/jobs/drop_old_partitions.py
+++ b/socorro/cron/jobs/drop_old_partitions.py
@@ -17,8 +17,8 @@ class DropOldPartitionsCronApp(BaseCronApp):
     app_name = 'drop-old-partitions'
     app_version = '1.0'
     app_description = """See
-    http://socorro.readthedocs.org/en/latest/databaseadminfunctions.html#drop
-    -old-partitions
+    http://socorro.readthedocs.org/en/latest/development
+    /databaseadminfunctions.html#drop-old-partitions
     See https://bugzilla.mozilla.org/show_bug.cgi?id=1014128
     """
 

--- a/socorro/cron/jobs/truncate_partitions.py
+++ b/socorro/cron/jobs/truncate_partitions.py
@@ -16,8 +16,8 @@ class TruncatePartitionsCronApp(BaseCronApp):
     app_name = 'truncate-partitions'
     app_version = '1.0'
     app_description = """See
-    http://socorro.readthedocs.org/en/latest/databaseadminfunctions.html#truncate
-    -partitions
+    http://socorro.readthedocs.org/en/latest/development
+    /databaseadminfunctions.html#truncate-partitions
     See https://bugzilla.mozilla.org/show_bug.cgi?id=1117911
     """
     required_config = Namespace()

--- a/socorro/cron/jobs/truncate_partitions.py
+++ b/socorro/cron/jobs/truncate_partitions.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from configman import Namespace
 from crontabber.base import BaseCronApp
 from crontabber.mixins import (
     with_postgres_transactions,
@@ -19,13 +20,15 @@ class TruncatePartitionsCronApp(BaseCronApp):
     -partitions
     See https://bugzilla.mozilla.org/show_bug.cgi?id=1117911
     """
+    required_config = Namespace()
+    required_config.add_option(
+        'weeks_to_keep',
+        default=2,
+        doc='Number of weeks of raw crash data to keep in Postgres')
 
     def run(self, connection):
-        # number of weeks of partitions to keep
-        weeks = 2
-
         cursor = connection.cursor()
         # Casting to date because stored procs in psql are strongly typed.
         cursor.execute(
-            "select truncate_partitions(%s)", (weeks,)
+            "select truncate_partitions(%s)", (self.config.weeks_to_keep,)
         )

--- a/socorro/cron/jobs/truncate_partitions.py
+++ b/socorro/cron/jobs/truncate_partitions.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from crontabber.base import BaseCronApp
+from crontabber.mixins import (
+    with_postgres_transactions,
+    with_single_postgres_transaction,
+)
+
+
+@with_postgres_transactions()
+@with_single_postgres_transaction()
+class TruncatePartitionsCronApp(BaseCronApp):
+    app_name = 'truncate-partitions'
+    app_version = '1.0'
+    app_description = """See
+    http://socorro.readthedocs.org/en/latest/databaseadminfunctions.html#truncate
+    -partitions
+    See https://bugzilla.mozilla.org/show_bug.cgi?id=1117911
+    """
+
+    def run(self, connection):
+        # number of weeks of partitions to keep
+        weeks = 2
+
+        cursor = connection.cursor()
+        # Casting to date because stored procs in psql are strongly typed.
+        cursor.execute(
+            "select truncate_partitions(%s)", (weeks,)
+        )

--- a/socorro/cron/jobs/truncate_partitions.py
+++ b/socorro/cron/jobs/truncate_partitions.py
@@ -23,7 +23,7 @@ class TruncatePartitionsCronApp(BaseCronApp):
     required_config = Namespace()
     required_config.add_option(
         'weeks_to_keep',
-        default=2,
+        default=26, # default to 6 months
         doc='Number of weeks of raw crash data to keep in Postgres')
 
     def run(self, connection):

--- a/socorro/cron/jobs/weekly_reports_partitions.py
+++ b/socorro/cron/jobs/weekly_reports_partitions.py
@@ -15,8 +15,8 @@ class WeeklyReportsPartitionsCronApp(BaseCronApp):
     app_name = 'weekly-reports-partitions'
     app_version = '1.0'
     app_description = """See
-    http://socorro.readthedocs.org/en/latest/databaseadminfunctions.html#weekly
-    -report-partitions
+    http://socorro.readthedocs.org/en/latest/development
+    /databaseadminfunctions.html#weekly-report-partitions
     See https://bugzilla.mozilla.org/show_bug.cgi?id=701253
     """
 

--- a/socorro/external/postgresql/raw_sql/procs/truncate_partitions.sql
+++ b/socorro/external/postgresql/raw_sql/procs/truncate_partitions.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION truncate_partitions(
+    weeks_to_keep INTEGER
+) RETURNS boolean
+    LANGUAGE plpgsql
+    AS $_X$
+DECLARE
+    tabname TEXT;
+    mastername TEXT;
+    basenames TEXT;
+    listnames TEXT;
+    cutoffdate DATE;
+    safety_weeks TEXT;
+BEGIN
+
+IF weeks_to_keep < 1 THEN
+    RAISE NOTICE 'Must specify more than 1 week of data to keep';
+    RETURN FALSE;
+END IF;
+
+-- Casting weeks_to_keep to weeks for safety
+safety_weeks := weeks_to_keep::text || ' weeks'; 
+
+SELECT into cutoffdate (now() - safety_weeks::interval)::date;
+
+-- Currently only truncating raw_crashes and processed_crashes
+basenames := $q$SELECT table_name FROM report_partition_info
+        WHERE partition_column = 'date_processed'
+        AND table_name IN ('raw_crashes', 'processed_crashes')
+        order by build_order desc$q$;
+
+for mastername IN EXECUTE basenames LOOP
+
+    -- Dig into our table list and pull out partitions matching
+    -- our cutoffdate
+    listnames := $q$SELECT relname FROM pg_stat_user_tables
+        WHERE relname LIKE '$q$ || mastername || $q$_%'
+        AND relname < '$q$ || mastername || '_'
+        || to_char(cutoffdate, 'YYYYMMDD') || $q$'$q$;
+
+    -- Lock the table and then truncate it
+    FOR tabname IN EXECUTE listnames LOOP
+        IF try_lock_table(tabname,'ACCESS EXCLUSIVE') THEN
+            EXECUTE 'TRUNCATE TABLE ' || tabname;
+        ELSE
+            RAISE NOTICE 'Unable to lock table %; try again later', tabname;
+            RETURN FALSE;
+        END IF;
+    END LOOP;
+END LOOP;
+
+RETURN TRUE;
+END;
+$_X$;

--- a/socorro/unittest/cron/jobs/test_truncate_partitions.py
+++ b/socorro/unittest/cron/jobs/test_truncate_partitions.py
@@ -1,0 +1,87 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.plugins.attrib import attr
+from nose.tools import eq_
+from crontabber.app import CronTabber
+from socorro.unittest.cron.jobs.base import IntegrationTestBase
+from socorro.unittest.cron.setup_configman import (
+    get_config_manager_for_crontabber,
+)
+
+
+@attr(integration='postgres')
+class TestTruncatePartitions(IntegrationTestBase):
+
+    def _setup_config_manager(self):
+        super(TestTruncatePartitions, self)._setup_config_manager
+        return get_config_manager_for_crontabber(
+            jobs='socorro.cron.jobs.truncate_partitions.'
+            'TruncatePartitionsCronApp|1m',
+        )
+
+    def setUp(self):
+        super(TestTruncatePartitions, self).setUp()
+
+        cur = self.conn.cursor()
+
+        # Ensure the test database and partition entry exist.
+        statement = """
+        CREATE TABLE raw_crashes_20120102(foo TEXT);
+        INSERT INTO report_partition_info (table_name, partition_column,
+        timetype) VALUES ('raw_crashes', 'date_processed', 'TIMESTAMPTZ');
+        INSERT INTO raw_crashes_20120102 VALUES ('things'), ('bother');
+        """
+        cur.execute(statement)
+
+        self.conn.commit()
+
+    def tearDown(self):
+        cur = self.conn.cursor()
+
+        # Ensure that the test partition entry and table no longer exist.
+        statement = """
+        DELETE FROM report_partition_info WHERE table_name = 'raw_crashes';
+        DROP TABLE IF EXISTS raw_crashes_20120102;
+        """
+        cur.execute(statement)
+
+        self.conn.commit()
+
+        super(TestTruncatePartitions, self).tearDown()
+
+    def test_run_drop_old_partitions(self):
+        cur = self.conn.cursor()
+
+        # Ensure test table is present.
+        statement = """
+        SELECT COUNT(*) FROM raw_crashes_20120102;
+        """
+        cur.execute(statement)
+        result = cur.fetchone()
+        eq_(result[0], 2L)
+        # need to get out of this transaction to
+        # allow crontabber to acquire a lock
+        self.conn.commit()
+
+        # Run the crontabber job to remove the test table.
+        config_manager = self._setup_config_manager()
+        with config_manager.context() as config:
+            tab = CronTabber(config)
+            tab.run_all()
+
+        # Basic assertion test of stored procedure.
+        information = self._load_structure()
+        print information['truncate-partitions']['last_error']
+        assert information['truncate-partitions']
+        assert not information['truncate-partitions']['last_error']
+        assert information['truncate-partitions']['last_success']
+
+        # Ensure test table was removed.
+        statement = """
+        SELECT COUNT(*) FROM raw_crashes_20120102;
+        """
+        cur.execute(statement)
+        result = cur.fetchone()
+        eq_(result[0], 0)


### PR DESCRIPTION
We may not want to make this a default for our open source users.

Maybe what I should do is add configuration that sets the default number of weeks to something much larger, and then our local config is 2 weeks.  Thoughts?