### PR TITLE
bug 1119525 - fix get-minidump-instructions build in vagrant

### DIFF
--- a/minidump-stackwalk/get-minidump-instructions.cc
+++ b/minidump-stackwalk/get-minidump-instructions.cc
@@ -54,6 +54,10 @@
 using namespace google_breakpad;
 using std::vector;
 
+#if (__GNUC__ == 4) && (__GNUC_MINOR__ < 6)
+#define nullptr __null
+#endif
+
 CURL* curl;
 std::set<string> error_symbols;
 
@@ -86,7 +90,7 @@ enum UnmangleType {
 string unmangle_source_file(const string& source_file, int line,
                             UnmangleType type)
 {
-  string source_and_line = source_file + ":" + std::to_string(line);
+  string source_and_line = source_file + ":" + std::to_string((long long)line);
   if (source_file.compare(0, 3, "hg:") != 0) {
     if (type != Annotate) {
       return "";

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -85,6 +85,7 @@ class socorro::vagrant {
       'httpd',
       'java-1.7.0-openjdk',
       'java-1.7.0-openjdk-devel',
+      'libcurl-devel',
       'libxml2-devel',
       'libxslt-devel',
       'make',


### PR DESCRIPTION
Some simple workarounds to support GCC 4.4.