### PR TITLE
Fixes Bug 1104317 - adds SignatureRunWatchDog rule to processor

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -53,6 +53,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.signature_utilities.StackwalkerErrorSignatureRule, "
         "socorro.processor.signature_utilities.OOMSignature, "
         "socorro.processor.signature_utilities.SigTrunc, "
+        "socorro.processor.signature_utilities.SignatureRunWatchDog, "
     ],
     [   # a set of classifiers for support
         "support_classifiers",

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -366,6 +366,7 @@ class CSignatureTool(CSignatureToolBase):
           'PORT_.*',
           '_PR_.*',
           'PR_.*',
+          '.*ProcessNextEvent.*',
           'pthread_mutex_lock',
           '_purecall',
           'raise',
@@ -823,17 +824,6 @@ class StackwalkerErrorSignatureRule(Rule):
 #==============================================================================
 class SignatureRunWatchDog(SignatureGenerationRule):
     """ensure that the signature contains the stackwalker error message"""
-    required_config = Namespace()
-    required_config.namespace('c_signature')
-    required_config.c_signature.irrelevant_signature_re = change_default(
-        CSignatureTool,
-        'irrelevant_signature_re',
-        "\"%s|%s\"" % (
-            eval(CSignatureTool.get_required_config()
-                .irrelevant_signature_re.default),
-            '.*ProcessNextEvent.*'
-        )
-    )
 
     #--------------------------------------------------------------------------
     def version(self):


### PR DESCRIPTION
as outlined in Bug 1104317, a signature that includes "::RunWatchdog" is not useful.  Check for that signature and, if found, reprocess the signtaure for Thread-0 instead of the crashing thread, and prepend the string "shutdownhang" to the signature.  Make sure that the new signature doesn't ignore the "ProcessNextEvent" but adds it to the prefix regular expression.

