### PR TITLE
DO NOT MERGE! use SCL python 2.7

### DIFF
--- a/puppet/modules/socorro/files/home/bashrc
+++ b/puppet/modules/socorro/files/home/bashrc
@@ -11,6 +11,12 @@ if [ -f $SCL_PY ] && [ -r $SCL_PY ]; then
     source $SCL_PY
 fi
 
+NODE_SCL="/opt/rh/nodejs010/enable"
+if [ -f $NODE_SCL ] && [ -r $NODE_SCL ]; then
+    # Suppress warning about v8314 package.
+    source $NODE_SCL > /dev/null
+fi
+
 VENV="${HOME}/socorro/socorro-virtualenv/bin/activate"
 if [ -f $VENV ] && [ -r $VENV ]; then
     . $VENV

--- a/puppet/modules/socorro/files/home/bashrc
+++ b/puppet/modules/socorro/files/home/bashrc
@@ -6,6 +6,11 @@ if [ -f /etc/bashrc ]; then
 fi
 
 # User specific aliases and functions
+SCL_PY="/opt/rh/python27/enable"
+if [ -f $SCL_PY ] && [ -r $SCL_PY ]; then
+    source $SCL_PY
+fi
+
 VENV="${HOME}/socorro/socorro-virtualenv/bin/activate"
 if [ -f $VENV ] && [ -r $VENV ]; then
     . $VENV

--- a/puppet/modules/socorro/manifests/init.pp
+++ b/puppet/modules/socorro/manifests/init.pp
@@ -69,6 +69,7 @@ class socorro::vagrant {
   package {
     [
       'ca-certificates',
+      'centos-release-SCL',
       'daemonize',
       'gcc-c++',
       'git',
@@ -103,6 +104,12 @@ class socorro::vagrant {
     ]:
     ensure  => latest,
     require => Yumrepo['PGDG']
+  }
+
+  package {
+    'python27':
+      ensure  => latest,
+      require => Package['centos-release-SCL']
   }
 
   exec {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,10 @@
 #! /bin/bash -ex
 
+SCL_PY="/opt/rh/python27/enable"
+if [ -f $SCL_PY ] && [ -r $SCL_PY ]; then
+    source $SCL_PY
+fi
+
 source scripts/defaults
 
 git submodule update --init --recursive
@@ -9,7 +14,7 @@ if [[ ! "$(type -p lessc)" ]]; then
 fi
 
 if [ ! -d "$VIRTUAL_ENV" ]; then
-    virtualenv -p python2.6 ${VIRTUAL_ENV}
+    virtualenv -p python ${VIRTUAL_ENV}
 fi
 source "$VIRTUAL_ENV/bin/activate"
 

--- a/socorro/unittest/external/postgresql/test_signature_urls.py
+++ b/socorro/unittest/external/postgresql/test_signature_urls.py
@@ -212,10 +212,10 @@ class IntegrationTestSignatureURLs(PostgreSQLTestCase):
         super(IntegrationTestSignatureURLs, self).tearDown()
 
     #--------------------------------------------------------------------------
-    def test_python_version_is_26(self):
+    def test_python_version_is_27(self):
         import sys
-        # These tests require python version 2.6
-        eq_(sys.version_info[:2], (2,6))
+        # These tests require python version 2.7
+        eq_(sys.version_info[:2], (2,7))
 
     #--------------------------------------------------------------------------
     def test_get(self):

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -594,7 +594,7 @@ class TestDatesAndTimesRule(TestCase):
             processor_notes,
             [
                 "WARNING: raw_crash[submitted_timestamp] contains unexpected "
-                "value: 17; 'int' object is unsubscriptable"
+                "value: 17; 'int' object has no attribute '__getitem__'"
             ]
         )
 


### PR DESCRIPTION
**FOR REVIEW ONLY.** ping @rhelmer re [bug 1121637](https://bugzilla.mozilla.org/show_bug.cgi?id=1121637).

This is probably the cleanest way to get Python 2.7 on CentOS 6.  It's in stable, supported upstream, and fairly well documented.  