### PR TITLE
fixes bug 1122319 - south migration problem in jenkins

### DIFF
--- a/webapp-django/bin/ci.sh
+++ b/webapp-django/bin/ci.sh
@@ -14,7 +14,5 @@ echo "Linting..."
 git ls-files crashstats | xargs check.py | bin/linting.py
 
 echo "Starting tests..."
-python manage.py syncdb --noinput
-python manage.py migrate --noinput
 FORCE_DB=true python manage.py test --noinput
 echo "Tests finished."


### PR DESCRIPTION
@rhelmer or @AdrianGaudebert r?

I tested this locally. I created a brand new database (e.g `socorro_webapp_new` with `createdb`) and put this in my `settings/local.py`. Then without running either `syncdb` or `migrate` I just went straight to `FORCE_DB=true ./manage.py test` and it works. 

Let's just check this is how it's expected to work in travis. 