### PR TITLE
fixes bug 1085530 - store uploaded symbols to S3

### DIFF
--- a/docs/configuring-socorro.rst
+++ b/docs/configuring-socorro.rst
@@ -152,3 +152,58 @@ All of these jobs can be enabled or disabled in crontabber configuration or by m
 DEFAULT_JOBS in:
 
 https://github.com/mozilla/socorro/blob/master/socorro/cron/crontabber_app.py
+
+
+Symbols S3 uploads
+------------------
+
+The webapp has support for uploading symbols. This can be done by the user
+either using an upload form or you can HTTP POST directly in. E.g. with curl.
+
+For this to work you need to configure the S3 bucket details. The file
+``webapp-django/crashstats/settings/base.py`` specifies the defaults which
+are all pretty much empty.
+
+First of all, you need to configure the AWS credentials. This is done by
+overriding the following keys::
+
+    AWS_ACCESS_KEY
+    AWS_SECRET_ACCESS_KEY
+
+These settings can not be empty.
+
+Next you have to set up the bucket name. When doing so, if you haven't already
+created the bucket over on the AWS console or other management tools you
+also have to define the location. The bucket name is set by setting the
+following key::
+
+    SYMBOLS_BUCKET_DEFAULT_NAME
+
+And the location is set by setting the following key::
+
+    SYMBOLS_BUCKET_DEFAULT_LOCATION
+
+If you're wondering what the format of the location should be,
+you can see `a list of the constants here <http://boto.readthedocs.org/en/latest/ref/s3.html#boto.s3.connection.Location>`_.
+For example ``us-west-2``.
+
+If you want to have a different bucket name for different user you can
+populate the following setting as per this example:
+
+.. code-block:: python
+
+    SYMBOLS_BUCKET_EXCEPTIONS = {
+        'joe.bloggs@example.com': 'private-crashes.my-bucket',
+    }
+
+That means that when ``joe.bloggs@example.com`` uploads symbols they are
+stored in a different bucket called ``private-crashes.my-bucket``.
+
+If you additionally want to use a different location for this user you
+can enter it as a tuple like this:
+
+.. code-block:: python
+
+    SYMBOLS_BUCKET_EXCEPTIONS = {
+        'joe.bloggs@example.com': ('private-crashes.my-bucket', 'us-east-1'),
+    }

--- a/webapp-django/crashstats/manage/templates/manage/symbols_uploads.html
+++ b/webapp-django/crashstats/manage/templates/manage/symbols_uploads.html
@@ -47,12 +47,7 @@
             <td><a href="{{ url('manage:user', upload.user.pk) }}">{{ upload.user.email }}</a></td>
             <td>{{ upload.filename }}</td>
             <td>
-              <a href="{{ url('symbols:preview', upload.pk) }}">List content</a>
-              {% if upload.file_exists %}
-                <a href="{{ url('symbols:download', upload.pk) }}">Download</a>
-              {% else %}
-                <em>File no longer exists</em>
-              {% endif %}
+              <a href="{{ url('symbols:content', upload.pk) }}">List content</a>
             </td>
             <td>{{ upload.size | filesizeformat }}</td>
             <td><time class="ago" data-date="{{ upload.created.isoformat() }}">{{ upload.created.isoformat() }}</time></td>

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -375,3 +375,21 @@ DATASERVICE_CONFIG_BASE = {
 # We trust that syncdb matches what you'd get if you install
 # all the migrations.
 SOUTH_TESTS_MIGRATE = False
+
+# Credentials for being able to make an S3 connection
+AWS_ACCESS_KEY = ''
+AWS_SECRET_ACCESS_KEY = ''
+
+# Information for uploading symbols to S3
+SYMBOLS_BUCKET_DEFAULT_NAME = ''
+# To set overriding exceptions by email, use:
+SYMBOLS_BUCKET_EXCEPTIONS = {
+    # e.g.
+    # 'joe.bloggs@example.com': 'private-crashes.my-bucket'
+    # or you can specify it as a tuple of (name, location)
+    # 'joe@example.com': ('my-bucket', 'USWest1')
+}
+SYMBOLS_FILE_PREFIX = 'v1'
+# e.g. "us-west-2" see boto.s3.connection.Location
+# Only needed if the bucket has never been created
+SYMBOLS_BUCKET_DEFAULT_LOCATION = None

--- a/webapp-django/crashstats/symbols/forms.py
+++ b/webapp-django/crashstats/symbols/forms.py
@@ -1,19 +1,15 @@
 from django import forms
-from crashstats.crashstats.forms import BaseModelForm
-from . import models
+from crashstats.crashstats.forms import BaseForm
 
 
-class UploadForm(BaseModelForm):
+class UploadForm(BaseForm):
+    file = forms.fields.FileField()
 
     valid_content_types = (
         'application/zip',
         'application/x-tar',
         'application/x-gzip',
     )
-
-    class Meta:
-        model = models.SymbolsUpload
-        fields = ('file',)
 
     def clean_file(self):
         upload = self.cleaned_data['file']

--- a/webapp-django/crashstats/symbols/migrations/0002_auto__del_field_symbolsupload_file.py
+++ b/webapp-django/crashstats/symbols/migrations/0002_auto__del_field_symbolsupload_file.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'SymbolsUpload.file'
+        db.delete_column(u'symbols_symbolsupload', 'file')
+
+
+    def backwards(self, orm):
+        # Adding field 'SymbolsUpload.file'
+        db.add_column(u'symbols_symbolsupload', 'file',
+                      self.gf('django.db.models.fields.files.FileField')(max_length=100, null=True),
+                      keep_default=False)
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'symbols.symbolsupload': {
+            'Meta': {'object_name': 'SymbolsUpload'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['symbols']

--- a/webapp-django/crashstats/symbols/models.py
+++ b/webapp-django/crashstats/symbols/models.py
@@ -1,40 +1,18 @@
-import datetime
-import hashlib
-import os
-import unicodedata
-
 from django.db import models
 from django.contrib.auth.models import User
 from django.utils import timezone
-
-
-def uploader(instance, filename):
-    if isinstance(filename, unicode):
-        filename = (
-            unicodedata
-            .normalize('NFD', filename)
-            .encode('ascii', 'ignore')
-        )
-    now = datetime.datetime.now()
-    path = os.path.join(now.strftime('%Y'), now.strftime('%m'),
-                        now.strftime('%d'))
-    hashed_filename = (hashlib.md5(filename +
-                       str(now.microsecond)).hexdigest())
-    __, extension = os.path.splitext(filename)
-    return os.path.join('symbols_upload', path, hashed_filename + extension)
 
 
 class SymbolsUpload(models.Model):
     user = models.ForeignKey(User)
     content = models.TextField()
     filename = models.CharField(max_length=100)
-    file = models.FileField(null=True, upload_to=uploader)
     size = models.IntegerField()
     created = models.DateTimeField(default=timezone.now)
 
     def __repr__(self):
-        return '<%s: %r...>' % (self.__class__.__name__, self.content[:100])
-
-    @property
-    def file_exists(self):
-        return self.file and os.path.isfile(self.file.path)
+        return '<%s: %s (%d)...>' % (
+            self.__class__.__name__,
+            self.filename,
+            self.size
+        )

--- a/webapp-django/crashstats/symbols/templates/symbols/api_upload.html
+++ b/webapp-django/crashstats/symbols/templates/symbols/api_upload.html
@@ -57,7 +57,7 @@ curl -X POST -H "Auth-Token: XXXYOURAPITOKENXXX" --form myfile.zip=@path/to/myfi
         <h4>Example using <b>Python</b> and <a href="http://requests.readthedocs.org/">requests</a></h4>
         <pre>
 >>> url = '{{ absolute_base_url }}{{ url('symbols:upload') }}'
->>> files = {'myfile.zip': open('path/to/myfile.zip', 'rb').read()}
+>>> files = {'myfile.zip': open('path/to/myfile.zip', 'rb')}
 >>> response = requests.post(url, files=files, headers={'Auth-token': 'XXXYOURAPITOKENXXX'})
 >>> request.status_code
 201</pre>

--- a/webapp-django/crashstats/symbols/templates/symbols/home.html
+++ b/webapp-django/crashstats/symbols/templates/symbols/home.html
@@ -63,12 +63,7 @@
               <tr>
                 <td>{{ upload.filename }}</td>
                 <td>
-                  <a href="{{ url('symbols:preview', upload.pk) }}">List content</a>
-                  {% if upload.file_exists %}
-                    <a href="{{ url('symbols:download', upload.pk) }}">Download</a>
-                  {% else %}
-                    <em>File no longer exists</em>
-                  {% endif %}
+                  <a href="{{ url('symbols:content', upload.pk) }}">List content</a>
                 </td>
                 <td>{{ upload.size | filesizeformat }}</td>
                 <td><time class="ago" data-date="{{ upload.created.isoformat() }}">{{ upload.created.isoformat() }}</time></td>

--- a/webapp-django/crashstats/symbols/tests/test_models.py
+++ b/webapp-django/crashstats/symbols/tests/test_models.py
@@ -1,11 +1,8 @@
-import shutil
-import tempfile
 import os
 
 from nose.tools import ok_
 
 from django.contrib.auth.models import User
-from django.core.files import File
 
 from crashstats.base.tests.testbase import DjangoTestCase
 from crashstats.symbols import models
@@ -14,27 +11,12 @@ from .base import ZIP_FILE
 
 class TestModels(DjangoTestCase):
 
-    def setUp(self):
-        super(TestModels, self).setUp()
-        self.tmp_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        super(TestModels, self).tearDown()
-        shutil.rmtree(self.tmp_dir)
-
     def test_create_symbols_upload(self):
         user = User.objects.create(username='user')
-        assert os.path.isfile(ZIP_FILE), ZIP_FILE
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
-            with open(ZIP_FILE, 'rb') as file_object:
-                upload = models.SymbolsUpload.objects.create(
-                    user=user,
-                    file=File(file_object),
-                    filename=os.path.basename(ZIP_FILE),
-                    size=12345,
-                    content='Content'
-                )
-            ok_(upload.file_exists)
-            ok_(os.path.isdir(os.path.join(self.tmp_dir, 'symbols_upload')))
-            os.remove(upload.file.path)
-            ok_(not upload.file_exists)
+        upload = models.SymbolsUpload.objects.create(
+            user=user,
+            filename=os.path.basename(ZIP_FILE),
+            size=12345,
+            content='Content'
+        )
+        ok_(os.path.basename(ZIP_FILE) in repr(upload))

--- a/webapp-django/crashstats/symbols/tests/test_views.py
+++ b/webapp-django/crashstats/symbols/tests/test_views.py
@@ -2,11 +2,15 @@ import os
 import shutil
 import tempfile
 
-from nose.tools import eq_, ok_
+import boto
+import boto.exception
+from nose.tools import eq_, ok_, assert_raises
+import mock
 
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User, Permission
-from django.core.files import File
+from django.core.exceptions import ImproperlyConfigured
+from django.conf import settings
 
 from crashstats.tokens.models import Token
 from crashstats.crashstats.tests.test_views import BaseTestViews
@@ -14,6 +18,7 @@ from crashstats.symbols import models
 from crashstats.symbols.views import check_symbols_archive_content
 
 from .base import ZIP_FILE, TARGZ_FILE, TGZ_FILE, TAR_FILE
+from crashstats.symbols.views import unpack_and_upload
 
 
 class EmptyFile(object):
@@ -34,29 +39,76 @@ class TestViews(BaseTestViews):
         super(TestViews, self).setUp()
         self.tmp_dir = tempfile.mkdtemp()
 
+        self.patcher = mock.patch('crashstats.symbols.views.boto.connect_s3')
+        self.uploaded_keys = {}
+        self.known_bucket_keys = {}
+        self.created_buckets = []
+        mocked_connect_s3 = self.patcher.start()
+
+        def mocked_get_bucket(*a, **k):
+            raise boto.exception.S3ResponseError(404, "Not found")
+
+        def mocked_create_bucket(name, location):
+
+            def mocked_new_key(key_name):
+                mocked_key = mock.Mock()
+
+                def mocked_set(string):
+                    self.uploaded_keys[key_name] = string
+                    return len(string)
+
+                mocked_key.set_contents_from_string.side_effect = mocked_set
+                mocked_key.key = key_name
+                mocked_key.bucket = mocked_bucket
+                return mocked_key
+
+            def mocked_get_key(key_name):
+                # return None there is no known fixture by this name
+                if key_name in self.known_bucket_keys:
+                    mocked_key = mock.Mock()
+                    mocked_key.key = key_name
+                    mocked_key.size = self.known_bucket_keys[key_name]
+                    mocked_key.bucket = mocked_bucket
+                    return mocked_key
+                return None
+
+            mocked_bucket = mock.Mock()
+            mocked_bucket.name = name
+            self.created_buckets.append((name, location))
+            mocked_bucket.new_key.side_effect = mocked_new_key
+            mocked_bucket.get_key.side_effect = mocked_get_key
+            return mocked_bucket
+
+        mocked_connect_s3().get_bucket = mocked_get_bucket
+        mocked_connect_s3().create_bucket = mocked_create_bucket
+
     def tearDown(self):
         super(TestViews, self).tearDown()
         shutil.rmtree(self.tmp_dir)
+        self.patcher.stop()
 
     def _login(self):
         user = User.objects.create_user('test', 'test@mozilla.com', 'secret')
         assert self.client.login(username='test', password='secret')
         return user
 
+    def test_unpack_and_upload_misconfigured(self):
+        with self.settings(AWS_ACCESS_KEY=''):
+            assert_raises(
+                ImproperlyConfigured,
+                unpack_and_upload,
+                [],
+                None,
+                'some-name',
+                None
+            )
+
     def test_check_symbols_archive_content(self):
         content = """
-        HEADER 1
-        HEADER 2
         Line 1
         Line Two
         Line Three
         """
-
-        # check that the header is not checked
-        disallowed = ('HEADER',)
-        with self.settings(DISALLOWED_SYMBOLS_SNIPPETS=disallowed):
-            error = check_symbols_archive_content(content.strip())
-            ok_(not error)
 
         # match something
         disallowed = ('Two', '2')
@@ -113,28 +165,15 @@ class TestViews(BaseTestViews):
             filename='sample.zip',
             size=10000
         )
-        with open(ZIP_FILE) as f:
-            upload2.file.save('sample.zip', File(f))
 
         response = self.client.get(url)
         eq_(response.status_code, 200)
-        # note that the file for upload1 does not exist
         ok_(
-            reverse('symbols:download', args=(upload1.pk,))
-            not in response.content
-        )
-        # but you can for upload 2
-        ok_(
-            reverse('symbols:download', args=(upload2.pk,))
-            in response.content
-        )
-        # but you can preview both
-        ok_(
-            reverse('symbols:preview', args=(upload1.pk,))
+            reverse('symbols:content', args=(upload1.pk,))
             in response.content
         )
         ok_(
-            reverse('symbols:preview', args=(upload2.pk,))
+            reverse('symbols:content', args=(upload2.pk,))
             in response.content
         )
 
@@ -160,7 +199,41 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 200)
 
         # now we can post
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
+        with open(ZIP_FILE) as file_object:
+            response = self.client.post(
+                url,
+                {'file': file_object}
+            )
+            eq_(response.status_code, 302)
+
+        symbol_upload = models.SymbolsUpload.objects.get(user=user)
+        eq_(symbol_upload.filename, os.path.basename(ZIP_FILE))
+        ok_(symbol_upload.size)
+        # We expect the content to be a `+` because it was new,
+        # followed by the bucket name, followed by a comma, followed
+        # by the symbols prefix + filename.
+        line = "+%s,%s/%s\n" % (
+            settings.SYMBOLS_BUCKET_DEFAULT_NAME,
+            settings.SYMBOLS_FILE_PREFIX,
+            'south-africa-flag.jpeg'
+        )
+        eq_(symbol_upload.content, line)
+        ok_(self.uploaded_keys)
+        eq_(self.created_buckets, [
+            (
+                settings.SYMBOLS_BUCKET_DEFAULT_NAME,
+                settings.SYMBOLS_BUCKET_DEFAULT_LOCATION
+            )
+        ])
+
+    def test_web_upload_different_bucket_by_user(self):
+        url = reverse('symbols:web_upload')
+        user = self._login()
+        self._add_permission(user, 'upload_symbols')
+        exception_names = {
+            user.email: 'my-special-bucket-name',
+        }
+        with self.settings(SYMBOLS_BUCKET_EXCEPTIONS=exception_names):
             with open(ZIP_FILE) as file_object:
                 response = self.client.post(
                     url,
@@ -171,9 +244,150 @@ class TestViews(BaseTestViews):
             symbol_upload = models.SymbolsUpload.objects.get(user=user)
             eq_(symbol_upload.filename, os.path.basename(ZIP_FILE))
             ok_(symbol_upload.size)
-            ok_(symbol_upload.file)
-            ok_(symbol_upload.file_exists)
-            ok_(symbol_upload.content)
+            line = "+%s,%s/%s\n" % (
+                'my-special-bucket-name',
+                settings.SYMBOLS_FILE_PREFIX,
+                'south-africa-flag.jpeg'
+            )
+            eq_(symbol_upload.content, line)
+            eq_(self.created_buckets, [
+                (
+                    'my-special-bucket-name',
+                    settings.SYMBOLS_BUCKET_DEFAULT_LOCATION
+                )
+            ])
+
+    def test_web_upload_different_bucket_by_user_different_location(self):
+        url = reverse('symbols:web_upload')
+        user = self._login()
+        self._add_permission(user, 'upload_symbols')
+        exception_names = {
+            user.email: (
+                'my-special-bucket-name',
+                'us-north-1'
+            )
+        }
+        with self.settings(SYMBOLS_BUCKET_EXCEPTIONS=exception_names):
+            with open(ZIP_FILE) as file_object:
+                response = self.client.post(
+                    url,
+                    {'file': file_object}
+                )
+                eq_(response.status_code, 302)
+
+            symbol_upload = models.SymbolsUpload.objects.get(user=user)
+            eq_(symbol_upload.filename, os.path.basename(ZIP_FILE))
+            ok_(symbol_upload.size)
+            line = "+%s,%s/%s\n" % (
+                'my-special-bucket-name',
+                settings.SYMBOLS_FILE_PREFIX,
+                'south-africa-flag.jpeg'
+            )
+            eq_(symbol_upload.content, line)
+            eq_(self.created_buckets, [
+                (
+                    'my-special-bucket-name',
+                    'us-north-1'
+                )
+            ])
+
+    def test_upload_different_bucket_by_user_different_location(self):
+        url = reverse('symbols:upload')
+        user = self._login()
+        self._add_permission(user, 'upload_symbols')
+        token = Token.objects.create(
+            user=user,
+        )
+        token.permissions.add(
+            Permission.objects.get(codename='upload_symbols')
+        )
+
+        exception_names = {
+            user.email: (
+                'my-special-bucket-name',
+                'us-north-1'
+            )
+        }
+        with self.settings(SYMBOLS_BUCKET_EXCEPTIONS=exception_names):
+            with open(ZIP_FILE) as file_object:
+                response = self.client.post(
+                    url,
+                    {'file.zip': file_object},
+                    HTTP_AUTH_TOKEN=token.key
+                )
+                eq_(response.status_code, 201)
+
+            symbol_upload = models.SymbolsUpload.objects.get(user=user)
+            eq_(symbol_upload.filename, 'file.zip')
+            line = "+%s,%s/%s\n" % (
+                'my-special-bucket-name',
+                settings.SYMBOLS_FILE_PREFIX,
+                'south-africa-flag.jpeg'
+            )
+            eq_(symbol_upload.content, line)
+            eq_(self.created_buckets, [
+                (
+                    'my-special-bucket-name',
+                    'us-north-1'
+                )
+            ])
+
+    def test_web_upload_existing_upload(self):
+        """what if the file already is uploaded"""
+        url = reverse('symbols:web_upload')
+        user = self._login()
+        self._add_permission(user, 'upload_symbols')
+
+        # We know the size of the file `south-africa-flag.jpeg` inside the
+        # fixture ZIP_FILE is 69183
+        key_name = '%s/south-africa-flag.jpeg' % settings.SYMBOLS_FILE_PREFIX
+        self.known_bucket_keys[key_name] = 69183
+
+        with open(ZIP_FILE) as file_object:
+            response = self.client.post(
+                url,
+                {'file': file_object}
+            )
+            eq_(response.status_code, 302)
+        symbol_upload = models.SymbolsUpload.objects.get(user=user)
+        # Now we expect it to be a prefixed with a `=` because it's not
+        # new and thus didn't cause an upload.
+        line = "=%s,%s/%s\n" % (
+            settings.SYMBOLS_BUCKET_DEFAULT_NAME,
+            settings.SYMBOLS_FILE_PREFIX,
+            'south-africa-flag.jpeg'
+        )
+        eq_(symbol_upload.content, line)
+        ok_(not self.uploaded_keys)  # nothing was uploaded
+
+    def test_web_upload_existing_upload_but_different_size(self):
+        """what if the file already is uploaded"""
+        url = reverse('symbols:web_upload')
+        user = self._login()
+        self._add_permission(user, 'upload_symbols')
+
+        # We know the size of the file `south-africa-flag.jpeg` inside the
+        # fixture ZIP_FILE is 69183
+        key_name = '%s/south-africa-flag.jpeg' % settings.SYMBOLS_FILE_PREFIX
+        # deliberately different from 69183
+        self.known_bucket_keys[key_name] = 1000
+
+        with open(ZIP_FILE) as file_object:
+            response = self.client.post(
+                url,
+                {'file': file_object}
+            )
+            eq_(response.status_code, 302)
+        symbol_upload = models.SymbolsUpload.objects.get(user=user)
+        # Now we expect it to be a prefixed with a `=` because it's not
+        # new and thus didn't cause an upload.
+        line = "+%s,%s/%s\n" % (
+            settings.SYMBOLS_BUCKET_DEFAULT_NAME,
+            settings.SYMBOLS_FILE_PREFIX,
+            'south-africa-flag.jpeg'
+        )
+        eq_(symbol_upload.content, line)
+        ok_(key_name in self.uploaded_keys)
 
     def test_web_upload_disallowed_content(self):
         url = reverse('symbols:web_upload')
@@ -198,20 +412,17 @@ class TestViews(BaseTestViews):
         self._add_permission(user, 'upload_symbols')
 
         # now we can post
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
-            with open(TARGZ_FILE) as file_object:
-                response = self.client.post(
-                    url,
-                    {'file': file_object}
-                )
-                eq_(response.status_code, 302)
+        with open(TARGZ_FILE) as file_object:
+            response = self.client.post(
+                url,
+                {'file': file_object}
+            )
+            eq_(response.status_code, 302)
 
-            symbol_upload = models.SymbolsUpload.objects.get(user=user)
-            eq_(symbol_upload.filename, os.path.basename(TARGZ_FILE))
-            ok_(symbol_upload.size)
-            ok_(symbol_upload.file)
-            ok_(symbol_upload.file_exists)
-            ok_(symbol_upload.content)
+        symbol_upload = models.SymbolsUpload.objects.get(user=user)
+        eq_(symbol_upload.filename, os.path.basename(TARGZ_FILE))
+        ok_(symbol_upload.size)
+        ok_(symbol_upload.content)
 
     def test_web_upload_tgz_file(self):
         url = reverse('symbols:web_upload')
@@ -219,20 +430,17 @@ class TestViews(BaseTestViews):
         self._add_permission(user, 'upload_symbols')
 
         # now we can post
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
-            with open(TGZ_FILE) as file_object:
-                response = self.client.post(
-                    url,
-                    {'file': file_object}
-                )
-                eq_(response.status_code, 302)
+        with open(TGZ_FILE) as file_object:
+            response = self.client.post(
+                url,
+                {'file': file_object}
+            )
+            eq_(response.status_code, 302)
 
-            symbol_upload = models.SymbolsUpload.objects.get(user=user)
-            eq_(symbol_upload.filename, os.path.basename(TGZ_FILE))
-            ok_(symbol_upload.size)
-            ok_(symbol_upload.file)
-            ok_(symbol_upload.file_exists)
-            ok_(symbol_upload.content)
+        symbol_upload = models.SymbolsUpload.objects.get(user=user)
+        eq_(symbol_upload.filename, os.path.basename(TGZ_FILE))
+        ok_(symbol_upload.size)
+        ok_(symbol_upload.content)
 
     def test_web_upload_tar_file(self):
         url = reverse('symbols:web_upload')
@@ -240,20 +448,19 @@ class TestViews(BaseTestViews):
         self._add_permission(user, 'upload_symbols')
 
         # now we can post
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
-            with open(TAR_FILE) as file_object:
-                response = self.client.post(
-                    url,
-                    {'file': file_object}
-                )
-                eq_(response.status_code, 302)
+        with open(TAR_FILE) as file_object:
+            response = self.client.post(
+                url,
+                {'file': file_object}
+            )
+            eq_(response.status_code, 302)
 
-            symbol_upload = models.SymbolsUpload.objects.get(user=user)
-            eq_(symbol_upload.filename, os.path.basename(TAR_FILE))
-            ok_(symbol_upload.size)
-            ok_(symbol_upload.file)
-            ok_(symbol_upload.file_exists)
-            ok_(symbol_upload.content)
+        symbol_upload = models.SymbolsUpload.objects.get(user=user)
+        eq_(symbol_upload.filename, os.path.basename(TAR_FILE))
+        ok_(symbol_upload.size)
+        ok_(symbol_upload.content)
+
+        assert self.uploaded_keys
 
     def test_api_upload_about(self):
         url = reverse('symbols:api_upload')
@@ -336,9 +543,28 @@ class TestViews(BaseTestViews):
                 symbol_upload = models.SymbolsUpload.objects.get(user=user)
                 eq_(symbol_upload.filename, 'file.zip')
                 ok_(symbol_upload.size)
-                ok_(symbol_upload.file)
-                ok_(symbol_upload.file_exists)
                 ok_(symbol_upload.content)
+
+        # the ZIP_FILE contains a file called south-africa-flag.jpeg
+        expected_key = os.path.join(
+            settings.SYMBOLS_FILE_PREFIX,
+            'south-africa-flag.jpeg'
+        )
+        ok_(self.uploaded_keys[expected_key])
+
+    def test_upload_without_multipart_file(self):
+        user = User.objects.create(username='user')
+        self._add_permission(user, 'upload_symbols')
+        token = Token.objects.create(
+            user=user,
+        )
+        token.permissions.add(
+            Permission.objects.get(codename='upload_symbols')
+        )
+
+        url = reverse('symbols:upload')
+        response = self.client.post(url, HTTP_AUTH_TOKEN=token.key)
+        eq_(response.status_code, 400)
 
     def test_upload_disallowed_content(self):
         user = User.objects.create(username='user')
@@ -354,8 +580,7 @@ class TestViews(BaseTestViews):
         # because the file ZIP_FILE contains the word `south-africa-flag.jpeg`
         # it should not be allowed to be uploaded
         disallowed = ('flag',)
-        with self.settings(MEDIA_ROOT=self.tmp_dir,
-                           DISALLOWED_SYMBOLS_SNIPPETS=disallowed):
+        with self.settings(DISALLOWED_SYMBOLS_SNIPPETS=disallowed):
             with open(ZIP_FILE, 'rb') as file_object:
                 response = self.client.post(
                     url,
@@ -364,6 +589,9 @@ class TestViews(BaseTestViews):
                 )
             eq_(response.status_code, 400)
             ok_('flag' in response.content)
+
+        # nothing should have been sent to S3
+        ok_(not self.uploaded_keys)
 
     def test_upload_empty_file(self):
         user = User.objects.create(username='user')
@@ -387,85 +615,42 @@ class TestViews(BaseTestViews):
             )
         eq_(response.status_code, 400)
 
-    def test_download(self):
-        user = User.objects.create_user('test', 'test@mozilla.com', 'secret')
-
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
-            with open(ZIP_FILE, 'rb') as file_object:
-                upload = models.SymbolsUpload.objects.create(
-                    user=user,
-                    file=File(file_object),
-                    filename=os.path.basename(ZIP_FILE),
-                    size=12345,
-                    content='Content'
-                )
-
-            url = reverse('symbols:download', args=(upload.pk,))
-            response = self.client.get(url)
-            eq_(response.status_code, 302)
-            self.assertRedirects(
-                response,
-                reverse('crashstats:login') + '?next=%s' % url
-            )
-            assert self.client.login(username='test', password='secret')
-            response = self.client.get(url)
-            eq_(response.status_code, 200)
-            eq_(response['Content-Type'], 'application/zip')
-            eq_(
-                response['Content-Disposition'],
-                'attachment; filename="sample.zip"'
-            )
-
-            # log in as someone else
-            user = User.objects.create_user(
-                'else', 'else@mozilla.com', 'secret'
-            )
-            assert self.client.login(username='else', password='secret')
-            response = self.client.get(url)
-            eq_(response.status_code, 403)
-
-            user.is_superuser = True
-            user.save()
-            assert self.client.login(username='else', password='secret')
-            response = self.client.get(url)
-            eq_(response.status_code, 200)
+        # nothing should have been sent to S3
+        ok_(not self.uploaded_keys)
 
     def test_preview(self):
         user = User.objects.create_user('test', 'test@mozilla.com', 'secret')
 
-        with self.settings(MEDIA_ROOT=self.tmp_dir):
-            with open(ZIP_FILE, 'rb') as file_object:
-                upload = models.SymbolsUpload.objects.create(
-                    user=user,
-                    file=File(file_object),
-                    filename=os.path.basename(ZIP_FILE),
-                    size=12345,
-                    content='Content'
-                )
+        upload = models.SymbolsUpload.objects.create(
+            user=user,
+            filename=os.path.basename(ZIP_FILE),
+            size=12345,
+            content='Content'
+        )
 
-            url = reverse('symbols:preview', args=(upload.pk,))
-            response = self.client.get(url)
-            eq_(response.status_code, 302)
-            self.assertRedirects(
-                response,
-                reverse('crashstats:login') + '?next=%s' % url
-            )
-            assert self.client.login(username='test', password='secret')
-            response = self.client.get(url)
-            eq_(response.status_code, 200)
-            eq_(response.content, 'Content')
-            eq_(response['Content-Type'], 'text/plain')
+        url = reverse('symbols:content', args=(upload.pk,))
+        response = self.client.get(url)
+        eq_(response.status_code, 302)
+        self.assertRedirects(
+            response,
+            reverse('crashstats:login') + '?next=%s' % url
+        )
+        assert self.client.login(username='test', password='secret')
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+        eq_(response.content, 'Content')
+        eq_(response['Content-Type'], 'text/plain')
 
-            # log in as someone else
-            user = User.objects.create_user(
-                'else', 'else@mozilla.com', 'secret'
-            )
-            assert self.client.login(username='else', password='secret')
-            response = self.client.get(url)
-            eq_(response.status_code, 403)
+        # log in as someone else
+        user = User.objects.create_user(
+            'else', 'else@mozilla.com', 'secret'
+        )
+        assert self.client.login(username='else', password='secret')
+        response = self.client.get(url)
+        eq_(response.status_code, 403)
 
-            user.is_superuser = True
-            user.save()
-            assert self.client.login(username='else', password='secret')
-            response = self.client.get(url)
-            eq_(response.status_code, 200)
+        user.is_superuser = True
+        user.save()
+        assert self.client.login(username='else', password='secret')
+        response = self.client.get(url)
+        eq_(response.status_code, 200)

--- a/webapp-django/crashstats/symbols/urls.py
+++ b/webapp-django/crashstats/symbols/urls.py
@@ -9,6 +9,5 @@ urlpatterns = patterns(
     url('^upload/?$', views.upload, name='upload'),
     url('^upload/web/$', views.web_upload, name='web_upload'),
     url('^upload/api/$', views.api_upload, name='api_upload'),
-    url('^upload/(?P<pk>\d+)/download/$', views.download, name='download'),
-    url('^upload/(?P<pk>\d+)/preview/$', views.preview, name='preview'),
+    url('^upload/(?P<pk>\d+)/content/$', views.content, name='content'),
 )

--- a/webapp-django/crashstats/symbols/utils.py
+++ b/webapp-django/crashstats/symbols/utils.py
@@ -5,35 +5,69 @@ import tarfile
 from cStringIO import StringIO
 
 
-def preview_archive_content(file_object, content_type):
-    """return file listing of the contents of an archive file"""
-    out = StringIO()
-    print >>out, "FILENAME".ljust(70),
-    print >>out, "SIZE".ljust(9)
-    print >>out, "-" * 80
+class _ZipMember(object):
+
+    def __init__(self, member, container):
+        self.name = member.filename
+        self.size = member.file_size
+        self.container = container
+
+    def extractor(self):
+        return self.container.open(self.name)
+
+
+class _TarMember(object):
+
+    def __init__(self, member, container):
+        self.member = member
+        self.name = member.name
+        self.size = member.size
+        self.container = container
+
+    def extractor(self):
+        return self.container.extractfile(self.member)
+
+
+def get_archive_members(file_object, content_type):
     if content_type == 'application/zip':
         zf = zipfile.ZipFile(file_object)
         for member in zf.infolist():
-            print >>out, member.filename.ljust(70),
-            print >>out, str(member.file_size).rjust(9)
+            yield _ZipMember(
+                member,
+                zf
+            )
 
     elif content_type == 'application/x-gzip':
         tar = gzip.GzipFile(fileobj=file_object)
         zf = tarfile.TarFile(fileobj=tar)
         for member in zf.getmembers():
             if member.isfile():
-                print >>out, member.name.ljust(70),
-                print >>out, str(member.size).rjust(9)
+                yield _TarMember(
+                    member,
+                    zf
+                )
 
     elif content_type == 'application/x-tar':
         zf = tarfile.TarFile(fileobj=file_object)
         for member in zf.getmembers():
-            if member.isfile():
-                print >>out, member.name.ljust(70),
-                print >>out, str(member.size).rjust(9)
+            # Sometimes when you make a tar file you get a
+            # smaller index file copy that start with "./._".
+            if member.isfile() and not member.name.startswith('./._'):
+                yield _TarMember(
+                    member,
+                    zf
+                )
 
     else:
         raise NotImplementedError(content_type)
+
+
+def preview_archive_content(file_object, content_type):
+    """return file listing of the contents of an archive file"""
+    out = StringIO()
+    for member in get_archive_members(file_object, content_type):
+        print >>out, member.name.ljust(70),
+        print >>out, str(member.size).rjust(9)
 
     return out.getvalue()
 

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -12,6 +12,10 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib import messages
 from django.db import transaction
+from django.core.exceptions import ImproperlyConfigured
+
+import boto
+import boto.exception
 
 from crashstats.tokens.models import Token
 from . import models
@@ -34,18 +38,89 @@ def api_login_required(view_func):
     return inner
 
 
-def check_symbols_archive_content(content, header_length=2):
+def check_symbols_archive_content(content):
     """return an error if there was something wrong"""
     for i, line in enumerate(content.splitlines()):
-        # the first two lines of the `content` is just headers
-        if i <= (header_length - 1):
-            continue
         for snippet in settings.DISALLOWED_SYMBOLS_SNIPPETS:
             if snippet in line:
                 return (
                     "Content of archive file contains the snippet "
                     "'%s' which is not allowed\n" % snippet
                 )
+
+
+def unpack_and_upload(iterator, symbols_upload, bucket_name, bucket_location):
+    necessary_setting_keys = (
+        'AWS_ACCESS_KEY',
+        'AWS_SECRET_ACCESS_KEY',
+        'SYMBOLS_BUCKET_DEFAULT_LOCATION',
+        'SYMBOLS_BUCKET_DEFAULT_NAME',
+        'SYMBOLS_FILE_PREFIX',
+    )
+    for key in necessary_setting_keys:
+        if not getattr(settings, key):
+            raise ImproperlyConfigured(
+                "Setting %s must be set" % key
+            )
+
+    conn = boto.connect_s3(
+        settings.AWS_ACCESS_KEY,
+        settings.AWS_SECRET_ACCESS_KEY
+    )
+    assert bucket_name
+    try:
+        bucket = conn.get_bucket(bucket_name)
+    except boto.exception.S3ResponseError:
+        bucket = conn.create_bucket(bucket_name, bucket_location)
+
+    total_uploaded = 0
+    for member in iterator:
+        key_name = os.path.join(
+            settings.SYMBOLS_FILE_PREFIX, member.name
+        )
+        key = bucket.get_key(key_name)
+
+        # let's assume first that we need to add a new key
+        prefix = "+"
+        if key:
+            # key already exists, but is it the same size?
+            if key.size != member.size:
+                # file size in S3 is different, upload the new one
+                key = None
+            else:
+                prefix = '='
+
+        if not key:
+            key = bucket.new_key(key_name)
+
+            file = StringIO()
+            file.write(member.extractor().read())
+            uploaded = key.set_contents_from_string(file.getvalue())
+            total_uploaded += uploaded
+
+        symbols_upload.content += '%s%s,%s\n' % (
+            prefix,
+            key.bucket.name,
+            key.key
+        )
+        symbols_upload.save()
+
+    return total_uploaded
+
+
+def get_bucket_name_and_location(user):
+    """return a tuple of (name, location) that might depend on the
+    user."""
+    name = settings.SYMBOLS_BUCKET_DEFAULT_NAME
+    location = settings.SYMBOLS_BUCKET_DEFAULT_LOCATION
+    exception = settings.SYMBOLS_BUCKET_EXCEPTIONS.get(user.email)
+    if isinstance(exception, (list, tuple)):
+        # the exception was a 2-items tuple of name and location
+        name, location = exception
+    elif exception:
+        # then it was just a string
+        name = exception
+    return name, location
 
 
 @login_required
@@ -95,10 +170,22 @@ def web_upload(request):
 
             symbols_upload = models.SymbolsUpload.objects.create(
                 user=request.user,
-                content=content,
+                content='',
                 size=form.cleaned_data['file'].size,
                 filename=os.path.basename(form.cleaned_data['file'].name),
-                file=form.cleaned_data['file'],
+            )
+            form.cleaned_data['file'].file.seek(0)
+            bucket_name, bucket_location = get_bucket_name_and_location(
+                request.user
+            )
+            unpack_and_upload(
+                utils.get_archive_members(
+                    form.cleaned_data['file'].file,
+                    content_type
+                ),
+                symbols_upload,
+                bucket_name,
+                bucket_location
             )
             messages.success(
                 request,
@@ -146,12 +233,15 @@ def upload(request):
     for name in request.FILES:
         upload = request.FILES[name]
         size = upload.size
+        if name.endswith('.tar.gz') or name.endswith('.tgz'):
+            content_type = 'application/x-gzip'
+        elif name.endswith('.zip'):
+            content_type = 'application/zip'
         break
     else:
-        name = 'temp.zip'
-        body = request.body
-        size = len(body)
-        upload = StringIO(body)
+        return http.HttpResponseBadRequest(
+            "Must be multipart form data with key 'file'"
+        )
 
     if not size:
         return http.HttpResponseBadRequest('File size 0')
@@ -164,38 +254,30 @@ def upload(request):
     if error:
         return http.HttpResponseBadRequest(error)
 
-    models.SymbolsUpload.objects.create(
+    symbols_upload = models.SymbolsUpload.objects.create(
         user=request.user,
         size=size,
-        content=content,
+        content='',
         filename=name,
-        file=upload,
+    )
+    bucket_name, bucket_location = get_bucket_name_and_location(
+        request.user
+    )
+    unpack_and_upload(
+        utils.get_archive_members(
+            upload,
+            content_type
+        ),
+        symbols_upload,
+        bucket_name,
+        bucket_location
     )
 
     return http.HttpResponse('OK', status=201)
 
 
 @login_required
-def download(request, pk):
-    symbols_upload = get_object_or_404(
-        models.SymbolsUpload,
-        pk=pk
-    )
-    if not request.user.is_superuser:
-        if symbols_upload.user != request.user:
-            return http.HttpResponseForbidden('Not yours')
-    response = http.HttpResponse(
-        symbols_upload.file.read(),
-        content_type=utils.filename_to_mimetype(symbols_upload.filename)
-    )
-    response['Content-Disposition'] = (
-        'attachment; filename="%s"' % (symbols_upload.filename,)
-    )
-    return response
-
-
-@login_required
-def preview(request, pk):
+def content(request, pk):
     symbols_upload = get_object_or_404(
         models.SymbolsUpload,
         pk=pk

--- a/webapp-django/settings_test.py
+++ b/webapp-django/settings_test.py
@@ -43,3 +43,12 @@ SENTRY_DSN = None
 
 
 BROWSERID_AUDIENCES = ['http://testserver']
+
+# Make sure these have something but something not right
+# so the tests never accidentally manage to connect to AWS
+# for realz.
+AWS_ACCESS_KEY = 'something'
+AWS_SECRET_ACCESS_KEY = 'anything'
+SYMBOLS_BUCKET_DEFAULT_NAME = 'my-lovely-bucket'
+SYMBOLS_FILE_PREFIX = 'v99'
+SYMBOLS_BUCKET_DEFAULT_LOCATION = 'us-west-2'


### PR DESCRIPTION
@rhelmer r? cc @twobraids 

So basically, we stop storing the uploaded file. Instead, we immediately unpack it and send it straight into S3. All within one big request. 
