### PR TITLE
Fixes bug 1129476 add SQL files to setup.py install for alembic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import codecs
+import glob
 import os
 from setuptools import setup, find_packages
 
@@ -46,4 +47,12 @@ setup(
         },
     test_suite='nose.collector',
     zip_safe=False,
+    data_files=[
+        ('socorro/external/postgresql/raw_sql/procs',
+            glob.glob('socorro/external/postgresql/raw_sql/procs/*.sql')),
+        ('socorro/external/postgresql/raw_sql/views',
+            glob.glob('socorro/external/postgresql/raw_sql/views/*.sql')),
+        ('socorro/external/postgresql/raw_sql/types',
+            glob.glob('socorro/external/postgresql/raw_sql/types/*.sql')),
+    ],
 ),

--- a/socorro/external/postgresql/postgresqlalchemymanager.py
+++ b/socorro/external/postgresql/postgresqlalchemymanager.py
@@ -62,7 +62,9 @@ class PostgreSQLAlchemyManager(object):
     def create_types(self):
         types_dir = os.path.normpath(os.path.join(
             __file__,
-            'raw_sql/types'
+            '..',
+            'raw_sql/types',
+            '*.sql'
         ))
         for myfile in sorted(glob(types_dir)):
             custom_type = open(myfile).read()
@@ -80,7 +82,9 @@ class PostgreSQLAlchemyManager(object):
     def create_procs(self):
         procs_dir = os.path.normpath(os.path.join(
             __file__,
-            'raw_sql/procs'
+            '..',
+            'raw_sql/procs',
+            '*.sql'
         ))
         for file in sorted(glob(procs_dir)):
             procedure = open(file).read()
@@ -94,7 +98,9 @@ class PostgreSQLAlchemyManager(object):
     def create_views(self):
         views_dir = os.path.normpath(os.path.join(
             __file__,
-            'raw_sql/views'
+            '..',
+            'raw_sql/views',
+            '*.sql'
         ))
         for file in sorted(glob(views_dir)):
             procedure = open(file).read()

--- a/socorro/external/postgresql/postgresqlalchemymanager.py
+++ b/socorro/external/postgresql/postgresqlalchemymanager.py
@@ -60,11 +60,11 @@ class PostgreSQLAlchemyManager(object):
         self.session.execute('SET check_function_bodies = false')
 
     def create_types(self):
-        # read files from 'raw_sql' directory
-        app_path = os.getcwd()
-        full_path = app_path + \
-            '/socorro/external/postgresql/raw_sql/types/*.sql'
-        for myfile in sorted(glob(full_path)):
+        types_dir = os.path.normpath(os.path.join(
+            __file__,
+            'raw_sql/types'
+        ))
+        for myfile in sorted(glob(types_dir)):
             custom_type = open(myfile).read()
             try:
                 self.session.execute(custom_type)
@@ -78,11 +78,11 @@ class PostgreSQLAlchemyManager(object):
         return status
 
     def create_procs(self):
-        # read files from 'raw_sql' directory
-        app_path = os.getcwd()
-        full_path = app_path + \
-            '/socorro/external/postgresql/raw_sql/procs/*.sql'
-        for file in sorted(glob(full_path)):
+        procs_dir = os.path.normpath(os.path.join(
+            __file__,
+            'raw_sql/procs'
+        ))
+        for file in sorted(glob(procs_dir)):
             procedure = open(file).read()
             try:
                 self.session.execute(procedure)
@@ -92,10 +92,11 @@ class PostgreSQLAlchemyManager(object):
         return True
 
     def create_views(self):
-        app_path = os.getcwd()
-        full_path = app_path + \
-            '/socorro/external/postgresql/raw_sql/views/*.sql'
-        for file in sorted(glob(full_path)):
+        views_dir = os.path.normpath(os.path.join(
+            __file__,
+            'raw_sql/views'
+        ))
+        for file in sorted(glob(views_dir)):
             procedure = open(file).read()
             try:
                 self.session.execute(procedure)

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -315,14 +315,18 @@ class SocorroDBApp(App):
             if self.no_schema:
                 db.commit()
                 return 0
+            # Order matters with what follows
             db.create_types()
+
             db.create_procs()
             db.set_sequence_owner('breakpad_rw')
             db.commit()
+
             db.create_tables()
             db.set_table_owner('breakpad_rw')
             db.create_views()
             db.commit()
+
             db.set_grants(self.config)  # config has user lists
             if not self.config['no_staticdata']:
                 self.import_staticdata(db)


### PR DESCRIPTION
Adds `data_file` paths for our SQL files so that when the package is installed, `alembic` is able to find the raw SQL files in the `virtualenv`. 