### PR TITLE
fixes bug 1130048 - Tests should pass in python 2.6 and 2.7

### DIFF
--- a/socorro/unittest/external/postgresql/test_signature_urls.py
+++ b/socorro/unittest/external/postgresql/test_signature_urls.py
@@ -212,12 +212,6 @@ class IntegrationTestSignatureURLs(PostgreSQLTestCase):
         super(IntegrationTestSignatureURLs, self).tearDown()
 
     #--------------------------------------------------------------------------
-    def test_python_version_is_26(self):
-        import sys
-        # These tests require python version 2.6
-        eq_(sys.version_info[:2], (2,6))
-
-    #--------------------------------------------------------------------------
     def test_get(self):
         signature_urls = SignatureURLs(config=self.config)
         now = self.now

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -590,11 +590,19 @@ class TestDatesAndTimesRule(TestCase):
             ),
             "2012-05-08T23:26:33.454482+00:00"
         )
+        # The warning message you get comes from a ValueError
+        # which is phrased differently in python 2.6 compared to 2.7.
+        # So we need to expect different things depend on python version.
+        # print repr(processor_notes[0])
+        try:
+            42[:1]
+        except TypeError as err:
+            type_error_value = str(err)
         eq_(
             processor_notes,
             [
                 "WARNING: raw_crash[submitted_timestamp] contains unexpected "
-                "value: 17; 'int' object is unsubscriptable"
+                "value: 17; %s" % type_error_value
             ]
         )
 


### PR DESCRIPTION
To do:
- [x] Make all tests work in 2.6 and 2.7
- [x] Remove 2.7 from the `.travis.yml` file