### PR TITLE
No bug - Cleanup breakpad.tar.gz before downloading it.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -27,6 +27,7 @@ fi
 
 if [ "`uname -sm`" == "Linux x86_64" ]; then
   # pull pre-built, known version of breakpad
+  rm -f breakpad.tar.gz
   wget -N --quiet 'https://ci.mozilla.org/job/breakpad/lastSuccessfulBuild/artifact/breakpad.tar.gz'
   tar -zxf breakpad.tar.gz
   rm -rf stackwalk


### PR DESCRIPTION
@rhelmer this is constantly causing errors for me, forcing me to ``rm -f breakpad.tar.gz`` manually every time I want to run ``make test``. Adding it to the script would make me less frustrated. :-)