### PR TITLE
fixes bug 1133814 - django-appconf sometimes fails to install with peep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -154,9 +154,9 @@ https://github.com/jsocol/commonware/archive/b554418.zip#egg=commonware
 cef==0.5
 # sha256: -fUE8yboUH-tNZdMGuX5HUpzX7M-VWtu2PXsEGBUpHM
 https://github.com/mozilla/nuggets/archive/ce50688.zip#egg=nuggets
-# sha256: 53T3tTehlADKaH9I01KrdGFzKsQThd2I_a1Hie-tKcU
-# sha256: qI7Y-5I6U8cMLEb75FCLX4Fka0sBQB8VaKghZxszIVw
-django-appconf==0.6
+# sha256: uhN1-xAk6OkVR1BNQ5IyF5XJif3lALluvHyTiE94bmA
+# sha256: PZvJY9gAiuFR1sZk-f1VRCcF6puebXznfN1Av5LZHzo
+django-appconf==1.0.1
 # sha256: UE5EGWeseGBKs18DABj8mm-icOam6YRx0jEf139wZ0s
 # sha256: smA0Iw78731g5SZ4kO2mVt_EnFZ_JxJdkH7uT-f5puw
 django-compressor==1.4


### PR DESCRIPTION
@rhelmer r?

So, the strange thing is that we used to depend on version [0.6](https://pypi.python.org/pypi/django-appconf/0.6) and that only had 1 file to download. So I don't see why we had two shas for that when there was only the tarball available. 

We could investigate this deeper and try to understand why it used to have multiple files on pypi but doesn't any more. 

Instead, I thought I'd just put the latest version in and it works. The [latest version](https://pypi.python.org/pypi/django-appconf/1.0.1) does have a tarball and a wheel. 