### PR TITLE
Bug 1133765 - Update forced versions for correlations for Firefox cycle starting 2015-02-24

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="36.0 37.0a2 38.0a1"
+MANUAL_VERSION_OVERRIDE="37.0 38.0a2 39.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
The next version of our usual correlation version bump. Should go into production in the week of 2014-02-23.