### PR TITLE
bug 1134686 - Use setUpClass for more efficient test cases

### DIFF
--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -668,7 +668,7 @@ class IntegrationTestBase(PostgreSQLTestCase):
         ok_('http://mywebsite.com' in results[0])
 
         # A failing query
-        sql = 'SELECT FROM reports'
+        sql = 'SELECT FROM reports LIMIT notanumber'
         assert_raises(DatabaseError, base.query, sql)
 
     #--------------------------------------------------------------------------

--- a/socorro/unittest/external/postgresql/test_crashes.py
+++ b/socorro/unittest/external/postgresql/test_crashes.py
@@ -136,18 +136,19 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
     """Test socorro.external.postgresql.crashes.Crashes class. """
 
     # -------------------------------------------------------------------------
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Set up this test class by populating the reports table with fake
         data. """
-        super(IntegrationTestCrashes, self).setUp()
+        super(IntegrationTestCrashes, cls).setUpClass()
 
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
 
-        self.now = datetimeutil.utc_now()
-        yesterday = self.now - datetime.timedelta(days=1)
+        cls.now = datetimeutil.utc_now()
+        yesterday = cls.now - datetime.timedelta(days=1)
 
-        build_date = self.now - datetime.timedelta(days=30)
-        sunset_date = self.now + datetime.timedelta(days=30)
+        build_date = cls.now - datetime.timedelta(days=30)
+        sunset_date = cls.now + datetime.timedelta(days=30)
 
         # Insert data for frequency test
         cursor.execute("""
@@ -237,7 +238,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
                 '2.0b',
                 'Beta'
             )
-        """ % {"now": self.now})
+        """ % {"now": cls.now})
 
         # Insert data for daily crashes test
 
@@ -397,7 +398,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             VALUES
             (1, '%(now)s', 5, 20, 0.12),
             (2, '%(yesterday)s', 2, 14, 0.12)
-        """ % {"now": self.now, "yesterday": yesterday})
+        """ % {"now": cls.now, "yesterday": yesterday})
 
         cursor.execute("""
             INSERT INTO home_page_graph_build
@@ -406,7 +407,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             (1, '%(now)s', '%(now)s', 5, 200),
             (1, '%(now)s', '%(yesterday)s', 3, 274),
             (2, '%(yesterday)s', '%(now)s', 3, 109)
-        """ % {"now": self.now, "yesterday": yesterday})
+        """ % {"now": cls.now, "yesterday": yesterday})
 
         cursor.execute("""
             INSERT INTO crashes_by_user
@@ -423,7 +424,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             (3, 'lin', 2, '%(now)s', 3, 4000),
             (3, 'mac', 1, '%(now)s', 2, 6000),
             (3, 'mac', 2, '%(now)s', 1, 6000)
-        """ % {"now": self.now, "yesterday": yesterday})
+        """ % {"now": cls.now, "yesterday": yesterday})
 
         cursor.execute("""
             INSERT INTO crashes_by_user_build
@@ -436,7 +437,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             (1, 'lin', 2, '%(now)s', '%(yesterday)s', 4, 5000),
             (1, 'mac', 1, '%(yesterday)s', '%(now)s', 5, 4000),
             (2, 'lin', 1, '%(yesterday)s', '%(now)s', 1, 1000)
-        """ % {"now": self.now, "yesterday": yesterday})
+        """ % {"now": cls.now, "yesterday": yesterday})
 
         cursor.execute("""
             INSERT INTO signatures
@@ -444,7 +445,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             VALUES
             (1, 'canIhaveYourSignature()', 2008120122, '%(now)s'),
             (2, 'ofCourseYouCan()', 2008120122, '%(now)s')
-        """ % {"now": self.now.date()})
+        """ % {"now": cls.now.date()})
 
         # Remember your product versions...
         #   1) Firefox:11.0
@@ -460,7 +461,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             (2, 1, 'ofCourseYouCan()', '%(yesterday)s', 4, 3, 2, 1, 0),
             (2, 4, 'ofCourseYouCan()', '%(now)s', 1, 4, 0, 1, 0),
             (2, 6, 'canIhaveYourSignature()', '%(yesterday)s', 2, 2, 2, 2, 2)
-        """ % {"now": self.now, "yesterday": yesterday})
+        """ % {"now": cls.now, "yesterday": yesterday})
 
         cursor.execute("""
             INSERT INTO signatures
@@ -490,7 +491,7 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
 
             (5, '{yesterday}', 'this-is-suppose-to-be-a-uuid5',
              'Beta', 245, 'Browser', 71, 'Windows', 215, 631719, 11427500)
-        """.format(now=self.now, yesterday=yesterday))
+        """.format(now=cls.now, yesterday=yesterday))
 
         cursor.execute("""
             INSERT INTO crash_adu_by_build_signature
@@ -509,13 +510,14 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
              '201404010101', 4, 1024, 'Windows NT', 'release', 'WaterWolf')
         """.format(yesterday=yesterday))
 
-        self.connection.commit()
+        cls.connection.commit()
         cursor.close()
 
     # -------------------------------------------------------------------------
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """Clean up the database, delete tables and functions. """
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
         cursor.execute("""
             TRUNCATE reports, home_page_graph_build, home_page_graph,
                      crashes_by_user, crashes_by_user_build, crash_types,
@@ -525,9 +527,9 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
                      reports_clean, crash_adu_by_build_signature
             CASCADE
         """)
-        self.connection.commit()
+        cls.connection.commit()
         cursor.close()
-        super(IntegrationTestCrashes, self).tearDown()
+        super(IntegrationTestCrashes, cls).tearDownClass()
 
     # -------------------------------------------------------------------------
     def test_get_comments(self):

--- a/socorro/unittest/external/postgresql/test_crontabber_state.py
+++ b/socorro/unittest/external/postgresql/test_crontabber_state.py
@@ -15,12 +15,18 @@ class IntegrationTestCrontabberStatus(PostgreSQLTestCase):
     """Test socorro.external.postgresql.crontabbers_state.CrontabberState
     class """
 
+    def setUp(self):
+        self.truncate()
+        super(IntegrationTestCrontabberStatus, self).setUp()
+
     def tearDown(self):
-        """Clean up the database. """
+        self.truncate()
+        super(IntegrationTestCrontabberStatus, self).tearDown()
+
+    def truncate(self):
         cursor = self.connection.cursor()
         cursor.execute("TRUNCATE crontabber")
         self.connection.commit()
-        super(IntegrationTestCrontabberStatus, self).tearDown()
 
     def test_get(self):
         cursor = self.connection.cursor()

--- a/socorro/unittest/external/postgresql/test_products.py
+++ b/socorro/unittest/external/postgresql/test_products.py
@@ -18,15 +18,16 @@ class IntegrationTestProducts(PostgreSQLTestCase):
     """Test socorro.external.postgresql.products.Products class. """
 
     #--------------------------------------------------------------------------
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """ Populate product_info table with fake data """
-        super(IntegrationTestProducts, self).setUp()
+        super(IntegrationTestProducts, cls).setUpClass()
 
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
 
         # Insert data
-        self.now = datetimeutil.utc_now()
-        now = self.now.date()
+        cls.now = datetimeutil.utc_now()
+        now = cls.now.date()
         lastweek = now - datetime.timedelta(days=7)
 
         cursor.execute("""
@@ -147,20 +148,21 @@ class IntegrationTestProducts(PostgreSQLTestCase):
             );
         """ % {'now': now, 'lastweek': lastweek})
 
-        self.connection.commit()
+        cls.connection.commit()
 
     #--------------------------------------------------------------------------
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """ Cleanup the database, delete tables and functions """
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
         cursor.execute("""
             TRUNCATE products, product_version_builds, product_versions,
                      product_release_channels, release_channels,
                      product_versions
             CASCADE
         """)
-        self.connection.commit()
-        super(IntegrationTestProducts, self).tearDown()
+        cls.connection.commit()
+        super(IntegrationTestProducts, cls).tearDownClass()
 
     #--------------------------------------------------------------------------
     def test_get(self):
@@ -251,56 +253,56 @@ class IntegrationTestProducts(PostgreSQLTestCase):
         params = {}
         res = products.get(**params)
         res_expected = {
-                "products": ["Firefox", "Thunderbird", "Fennec"],
-                "hits": {
-                    "Firefox": [
-                        {
-                            "product": "Firefox",
-                            "version": "8.0",
-                            "start_date": now_str,
-                            "end_date": now_str,
-                            "throttle": 10.00,
-                            "featured": False,
-                            "release": "Release",
-                            "has_builds": False
-                        }
-                    ],
-                    "Thunderbird": [
-                        {
-                            "product": "Thunderbird",
-                            "version": "10.0.2b",
-                            "start_date": now_str,
-                            "end_date": now_str,
-                            "throttle": 10.00,
-                            "featured": False,
-                            "release": "Release",
-                            "has_builds": False,
-                        }
-                    ],
-                    "Fennec": [
-                        {
-                            "product": "Fennec",
-                            "version": "12.0b1",
-                            "start_date": now_str,
-                            "end_date": now_str,
-                            "throttle": 100.00,
-                            "featured": False,
-                            "release": "Beta",
-                            "has_builds": False
-                        },
-                        {
-                            "product": "Fennec",
-                            "version": "11.0.1",
-                            "start_date": now_str,
-                            "end_date": now_str,
-                            "throttle": 10.00,
-                            "featured": False,
-                            "release": "Release",
-                            "has_builds": False
-                        }
-                    ]
-                },
-                "total": 4
+            "products": ["Firefox", "Thunderbird", "Fennec"],
+            "hits": {
+                "Firefox": [
+                    {
+                        "product": "Firefox",
+                        "version": "8.0",
+                        "start_date": now_str,
+                        "end_date": now_str,
+                        "throttle": 10.00,
+                        "featured": False,
+                        "release": "Release",
+                        "has_builds": False
+                    }
+                ],
+                "Thunderbird": [
+                    {
+                        "product": "Thunderbird",
+                        "version": "10.0.2b",
+                        "start_date": now_str,
+                        "end_date": now_str,
+                        "throttle": 10.00,
+                        "featured": False,
+                        "release": "Release",
+                        "has_builds": False,
+                    }
+                ],
+                "Fennec": [
+                    {
+                        "product": "Fennec",
+                        "version": "12.0b1",
+                        "start_date": now_str,
+                        "end_date": now_str,
+                        "throttle": 100.00,
+                        "featured": False,
+                        "release": "Beta",
+                        "has_builds": False
+                    },
+                    {
+                        "product": "Fennec",
+                        "version": "11.0.1",
+                        "start_date": now_str,
+                        "end_date": now_str,
+                        "throttle": 10.00,
+                        "featured": False,
+                        "release": "Release",
+                        "has_builds": False
+                    }
+                ]
+            },
+            "total": 4
         }
 
         eq_(res['total'], res_expected['total'])
@@ -369,7 +371,6 @@ class IntegrationTestProducts(PostgreSQLTestCase):
     def test_post(self):
         products = Products(config=self.config)
 
-        build_id = self.now.strftime('%Y%m%d%H%M')
         ok_(products.post(
             product='KillerApp',
             version='1.0',
@@ -392,7 +393,6 @@ class IntegrationTestProducts(PostgreSQLTestCase):
     def test_post_bad_product_name(self):
         products = Products(config=self.config)
 
-        build_id = self.now.strftime('%Y%m%d%H%M')
         ok_(not products.post(
             product='Spaces not allowed',
             version='',

--- a/socorro/unittest/external/postgresql/test_report.py
+++ b/socorro/unittest/external/postgresql/test_report.py
@@ -18,7 +18,7 @@ class IntegrationTestReport(PostgreSQLTestCase):
     """Test socorro.external.postgresql.report.Report class. """
 
     @classmethod
-    def setUp(cls):
+    def setUpClass(cls):
         """Set up this test class by populating the reports table with fake
         data. """
         super(IntegrationTestReport, cls).setUpClass()
@@ -276,7 +276,7 @@ class IntegrationTestReport(PostgreSQLTestCase):
         cls.connection.commit()
 
     @classmethod
-    def tearDown(cls):
+    def tearDownClass(cls):
         """Clean up the database, delete tables and functions. """
         cursor = cls.connection.cursor()
         cursor.execute("""

--- a/socorro/unittest/external/postgresql/test_report.py
+++ b/socorro/unittest/external/postgresql/test_report.py
@@ -17,16 +17,17 @@ from unittestbase import PostgreSQLTestCase
 class IntegrationTestReport(PostgreSQLTestCase):
     """Test socorro.external.postgresql.report.Report class. """
 
-    def setUp(self):
+    @classmethod
+    def setUp(cls):
         """Set up this test class by populating the reports table with fake
         data. """
-        super(IntegrationTestReport, self).setUp()
+        super(IntegrationTestReport, cls).setUpClass()
 
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
 
         # Insert data
-        self.now = datetimeutil.utc_now()
-        yesterday = self.now - datetime.timedelta(days=1)
+        cls.now = datetimeutil.utc_now()
+        yesterday = cls.now - datetime.timedelta(days=1)
 
         cursor.execute("""
             INSERT INTO reports
@@ -272,11 +273,12 @@ class IntegrationTestReport(PostgreSQLTestCase):
         """ % {
             'yesterday': yesterday
         })
-        self.connection.commit()
+        cls.connection.commit()
 
-    def tearDown(self):
+    @classmethod
+    def tearDown(cls):
         """Clean up the database, delete tables and functions. """
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
         cursor.execute("""
             TRUNCATE
               reports_duplicates,
@@ -286,8 +288,8 @@ class IntegrationTestReport(PostgreSQLTestCase):
               raw_crashes
             CASCADE
         """)
-        self.connection.commit()
-        super(IntegrationTestReport, self).tearDown()
+        cls.connection.commit()
+        super(IntegrationTestReport, cls).tearDownClass()
 
     def test_get_list(self):
         now = self.now
@@ -496,7 +498,6 @@ class IntegrationTestReport(PostgreSQLTestCase):
     def test_get_list_with_raw_crash(self):
         now = self.now
         yesterday = now - datetime.timedelta(days=1)
-        #yesterday = datetimeutil.date_to_string(yesterday)
         report = Report(config=self.config)
         base_params = {
             'signature': 'sig1',

--- a/socorro/unittest/external/postgresql/test_signature_summary.py
+++ b/socorro/unittest/external/postgresql/test_signature_summary.py
@@ -13,21 +13,22 @@ from socorro.external import BadArgumentError
 from .unittestbase import PostgreSQLTestCase
 
 
-#==============================================================================
+# =============================================================================
 @attr(integration='postgres')  # for nosetests
 class IntegrationTestSignatureSummary(PostgreSQLTestCase):
     """Simple test of SignatureSummary class get() function"""
 
-    #--------------------------------------------------------------------------
-    def setUp(self):
+    # -------------------------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
         """ Populate product_info table with fake data """
-        super(IntegrationTestSignatureSummary, self).setUp()
+        super(IntegrationTestSignatureSummary, cls).setUpClass()
 
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
 
         # Insert data
-        self.now = datetimeutil.utc_now()
-        now = self.now.date()
+        cls.now = datetimeutil.utc_now()
+        now = cls.now.date()
         yesterday = now - datetime.timedelta(days=1)
         lastweek = now - datetime.timedelta(days=7)
 
@@ -381,7 +382,7 @@ class IntegrationTestSignatureSummary(PostgreSQLTestCase):
                'device_id': graphics_device_id,
                'product_version_id': product_version_id})
 
-        self.connection.commit()
+        cls.connection.commit()
 
         def add_product_version_builds(self):
             cursor = self.connection.cursor()
@@ -402,10 +403,11 @@ class IntegrationTestSignatureSummary(PostgreSQLTestCase):
 
             self.connection.commit()
 
-    #--------------------------------------------------------------------------
-    def tearDown(self):
+    # -------------------------------------------------------------------------
+    @classmethod
+    def tearDownClass(cls):
         """ Cleanup the database, delete tables and functions """
-        cursor = self.connection.cursor()
+        cursor = cls.connection.cursor()
         cursor.execute("""
             TRUNCATE products,
                      product_version_builds,
@@ -426,8 +428,8 @@ class IntegrationTestSignatureSummary(PostgreSQLTestCase):
                      graphics_device
             CASCADE
         """)
-        self.connection.commit()
-        super(IntegrationTestSignatureSummary, self).tearDown()
+        cls.connection.commit()
+        super(IntegrationTestSignatureSummary, cls).tearDownClass()
 
     def setup_data(self):
         now = self.now.date()

--- a/socorro/unittest/external/postgresql/unittestbase.py
+++ b/socorro/unittest/external/postgresql/unittestbase.py
@@ -97,10 +97,11 @@ class PostgreSQLTestCase(TestCase):
         from_string_converter=list_converter
     )
 
-    def get_standard_config(self):
+    @classmethod
+    def get_standard_config(cls):
 
         config_manager = ConfigurationManager(
-            [self.required_config,
+            [cls.required_config,
              ],
             app_name='PostgreSQLTestCase',
             app_description=__doc__,
@@ -110,13 +111,18 @@ class PostgreSQLTestCase(TestCase):
         with config_manager.context() as config:
             return config
 
-    def setUp(self):
-        """Create a configuration context and a database connection. """
-        self.config = self.get_standard_config()
+    @classmethod
+    def setUpClass(cls):
+        """Create a configuration context and a database connection.
 
-        self.database = db.Database(self.config)
-        self.connection = self.database.connection()
+        This will create (and later destroy) one connection per test
+        case (aka. test class).
+        """
+        cls.config = cls.get_standard_config()
+        cls.database = db.Database(cls.config)
+        cls.connection = cls.database.connection()
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         """Close the database connection. """
-        self.connection.close()
+        cls.connection.close()


### PR DESCRIPTION
cc @rhelmer @AdrianGaudebert @selenamarie @twobraids 

These changes works locally for me. Instead of creating 93 connections it only creates 23 connections for running the tests in `socorro/unittest/external/postgresql/`.

There are probably many more places where we can reuse fixtures across a whole test case. If you can find more things to tune, please feel free to open a PR against this PR. 