### PR TITLE
Fixes bug 1136145 - Control SuperSearch whitelist from Super Search Fiel...

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -58,7 +58,10 @@ def get_api_whitelist(*args, **kwargs):
 
     def get_from_es(namespace, baseline=None):
         # @namespace is something like 'raw_crash' or 'processed_crash'
-        fields = cache.get('api_supersearch_fields_%s' % namespace)
+
+        cache_key = 'api_supersearch_fields_%s' % namespace
+        fields = cache.get(cache_key)
+
         if fields is None:
             # This needs to be imported in runtime because otherwise you'll
             # get a circular import.
@@ -78,6 +81,9 @@ def get_api_whitelist(*args, **kwargs):
                     if meta['in_database_name'] not in fields:
                         fields.append(meta['in_database_name'])
             fields = tuple(fields)
+
+            # Cache for 1 hour.
+            cache.set(cache_key, fields, 60 * 60)
         return fields
 
     return Lazy(


### PR DESCRIPTION
...ds list.

@peterbe r?

Notes: I looked at the current unit tests and thought they were good enough to test this change (we verify that fields with permissions are not exposed in public mode, and are available in unredacted mode, and we verify that some results are available, which proves that the list is correctly loaded). The function ``get_api_whitelist`` was sufficiently different from the one you wrote in ``crashstats.models`` that I chose to copy it instead of making the original one generic. I think it's easier this way, and less confusing. 