### PR TITLE
Fixes bug 1136917 - update default user to be 'test' for use in tests

### DIFF
--- a/config/crontabber.ini-dist
+++ b/config/crontabber.ini-dist
@@ -170,7 +170,7 @@
         #database_password=aPassword
 
         # the name of the user within the database
-        #database_username=breakpad_rw
+        database_username=test
 
     [[rabbitmq]]
 
@@ -213,7 +213,7 @@
 
     # the name of the user within the database
     # see "secrets.postgresql.database_username" for the default or override it here
-    #database_username=breakpad_rw
+    database_username=test
 
     # number of seconds to re-attempt a job that failed
     #error_retry_time=300

--- a/socorro/unittest/config/commonconfig.py.dist
+++ b/socorro/unittest/config/commonconfig.py.dist
@@ -25,7 +25,7 @@ oldDatabaseName.default = 'socorro_test'
 
 databaseUserName = cm.Option()
 databaseUserName.doc = 'the user name for the database servers'
-databaseUserName.default = 'breakpad_rw'
+databaseUserName.default = 'test'
 
 databasePassword = cm.Option()
 databasePassword.doc = 'the password for the database user'

--- a/socorro/unittest/config/jenkins.py.dist
+++ b/socorro/unittest/config/jenkins.py.dist
@@ -25,7 +25,7 @@ oldDatabaseName.default = 'socorro_test'
 
 databaseUserName = cm.Option()
 databaseUserName.doc = 'the user name for the database servers'
-databaseUserName.default = 'breakpad_rw'
+databaseUserName.default = 'test'
 
 databasePassword = cm.Option()
 databasePassword.doc = 'the password for the database user'

--- a/socorro/unittest/cron/setup_configman.py
+++ b/socorro/unittest/cron/setup_configman.py
@@ -96,7 +96,7 @@ def get_config_manager_for_crontabber(
         #'resource.redactor.redactor_class': Mock(),
         'resource.postgresql.database_name': 'socorro_integration_test',
         'resource.postgresql.database_hostname': 'localhost',
-        'secrets.postgresql.database_username': 'breakpad_rw',
+        'secrets.postgresql.database_username': 'test',
         'secrets.postgresql.database_password': 'aPassword',
     }
     if jobs:

--- a/socorro/unittest/external/postgresql/test_crash_data.py
+++ b/socorro/unittest/external/postgresql/test_crash_data.py
@@ -131,7 +131,7 @@ class TestIntegrationPostgresCrashData(TestCase):
             'logger': mock_logging,
             'database_name': 'socorro_integration_test',
             'database_hostname': 'localhost',
-            'database_username': 'breakpad_rw',
+            'database_username': 'test',
             'database_password': 'aPassword',
           }}]
         )

--- a/socorro/unittest/external/postgresql/unittestbase.py
+++ b/socorro/unittest/external/postgresql/unittestbase.py
@@ -32,7 +32,7 @@ class PostgreSQLTestCase(TestCase):
 
     required_config.add_option(
         name='database_username',
-        default='breakpad_rw',
+        default='test',
         doc='Username to connect to database',
     )
 


### PR DESCRIPTION
We're using breakpad_rw sometimes and that messes things up once we no longer assume that our core users have superuser privileges.