### PR TITLE
fixes Bug 1138488 - added supplemental processing to ProcessorApp

### DIFF
--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -310,7 +310,7 @@ class HybridCrashProcessor(RequiredConfig):
             os.unlink(file_pathname)
 
     #--------------------------------------------------------------------------
-    def convert_raw_crash_to_processed_crash(self, raw_crash, raw_dumps):
+    def process_crash(self, raw_crash, raw_dumps, ignored_processed_crash):
         """ This function is run only by a worker thread.
             Given a job, fetch a thread local database connection and the json
             document.  Use these to create the record in the 'reports' table,
@@ -1419,8 +1419,8 @@ class HybridCrashProcessor(RequiredConfig):
                     )
 
     #--------------------------------------------------------------------------
-    def __call__(self, raw_crash, raw_dumps):
-        self.convert_raw_crash_to_processed_crash(raw_crash, raw_dumps)
+    def __call__(self, raw_crash, raw_dumps, processed_crash):
+        self.process_crash(raw_crash, raw_dumps, processed_crash)
 
     #--------------------------------------------------------------------------
     def _log_job_start(self, crash_id):

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -285,7 +285,7 @@ class LegacyCrashProcessor(RequiredConfig):
         self._log_job_end(utc_now(), False, crash_id)
 
     #--------------------------------------------------------------------------
-    def convert_raw_crash_to_processed_crash(self, raw_crash, raw_dumps):
+    def process_crash(self, raw_crash, raw_dumps, ignored_processed_crash):
         """ This function is run only by a worker thread.
             Given a job, fetch a thread local database connection and the json
             document.  Use these to create the record in the 'reports' table,
@@ -1212,8 +1212,8 @@ class LegacyCrashProcessor(RequiredConfig):
                 )
 
     #--------------------------------------------------------------------------
-    def __call__(self, raw_crash, raw_dumps):
-        self.convert_raw_crash_to_processed_crash(raw_crash, raw_dumps)
+    def __call__(self, raw_crash, raw_dumps, processed_crash):
+        self.process_crash(raw_crash, raw_dumps, processed_crash)
 
     #--------------------------------------------------------------------------
     def _log_job_start(self, crash_id):

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -177,7 +177,7 @@ class Processor2015(RequiredConfig):
             )
 
     #--------------------------------------------------------------------------
-    def convert_raw_crash_to_processed_crash(self, raw_crash, raw_dumps):
+    def process_crash(self, raw_crash, raw_dumps, processed_crash):
         """Take a raw_crash and its associated raw_dumps and return a
         processed_crash.
         """
@@ -193,8 +193,19 @@ class Processor2015(RequiredConfig):
         processor_meta_data.processor = self
         processor_meta_data.config = self.config
 
-        # create the empty processed crash
-        processed_crash = DotDict()
+        if "processor_notes" in processed_crash:
+            original_processor_notes = [
+                x.strip() for x in processed_crash.processor_notes.split(";")
+            ]
+            processor_meta_data.processor_notes.append(
+                "earlier processing: %s" % processed_crash.get(
+                    "started_datetime",
+                    'Unknown Date'
+                )
+            )
+        else:
+            original_processor_notes = []
+
         processed_crash.success = False
         processed_crash.started_datetime = utc_now()
         # for backwards compatibility:
@@ -242,6 +253,7 @@ class Processor2015(RequiredConfig):
 
         # the processor notes are in the form of a list.  Join them all
         # together to make a single string
+        processor_meta_data.processor_notes.extend(original_processor_notes)
         processed_crash.processor_notes = '; '.join(
             processor_meta_data.processor_notes
         )

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -257,7 +257,7 @@ class TestHybridProcessor(TestCase):
             )
             eq_(m_transform.call_count, 4)
 
-    def test_convert_raw_crash_to_processed_crash_basic(self):
+    def test_process_crash_basic(self):
         config = setup_config_with_mocks()
         mocked_transform_rules_str = \
             'socorro.processor.hybrid_processor.TransformRuleSystem'
@@ -305,9 +305,10 @@ class TestHybridProcessor(TestCase):
 
                  # Here's the call being tested
                 processed_crash = \
-                    leg_proc.convert_raw_crash_to_processed_crash(
+                    leg_proc.process_crash(
                       raw_crash,
-                      raw_dump
+                      raw_dump,
+                      {}
                     )
 
                 # test the result
@@ -410,7 +411,7 @@ class TestHybridProcessor(TestCase):
                     any_order=True
                 )
 
-    def test_convert_raw_crash_to_processed_crash_unexpected_error(self):
+    def test_process_crash_unexpected_error(self):
         config = setup_config_with_mocks()
         mocked_transform_rules_str = \
             'socorro.processor.hybrid_processor.TransformRuleSystem'
@@ -458,9 +459,10 @@ class TestHybridProcessor(TestCase):
 
                  # Here's the call being tested
                 processed_crash = \
-                    leg_proc.convert_raw_crash_to_processed_crash(
+                    leg_proc.process_crash(
                       raw_crash,
-                      raw_dump
+                      raw_dump,
+                      {}
                     )
 
                 eq_(1, leg_proc._log_job_end.call_count)

--- a/socorro/unittest/processor/test_legacy_processor.py
+++ b/socorro/unittest/processor/test_legacy_processor.py
@@ -256,7 +256,7 @@ class TestLegacyProcessor(TestCase):
             )
             eq_(m_transform.call_count, 2)
 
-    def test_convert_raw_crash_to_processed_crash_basic(self):
+    def test_process_crash_basic(self):
         config = setup_config_with_mocks()
         mocked_transform_rules_str = \
             'socorro.processor.legacy_processor.TransformRuleSystem'
@@ -303,9 +303,10 @@ class TestLegacyProcessor(TestCase):
 
                  # Here's the call being tested
                 processed_crash = \
-                    leg_proc.convert_raw_crash_to_processed_crash(
+                    leg_proc.process_crash(
                       raw_crash,
-                      raw_dump
+                      raw_dump,
+                      {}
                     )
 
                 # test the result
@@ -408,7 +409,7 @@ class TestLegacyProcessor(TestCase):
                     any_order=True
                 )
 
-    def test_convert_raw_crash_to_processed_crash_unexpected_error(self):
+    def test_process_crash_unexpected_error(self):
         config = setup_config_with_mocks()
         mocked_transform_rules_str = \
             'socorro.processor.legacy_processor.TransformRuleSystem'
@@ -456,9 +457,10 @@ class TestLegacyProcessor(TestCase):
 
                  # Here's the call being tested
                 processed_crash = \
-                    leg_proc.convert_raw_crash_to_processed_crash(
+                    leg_proc.process_crash(
                       raw_crash,
-                      raw_dump
+                      raw_dump,
+                      {}
                     )
 
                 eq_(1, leg_proc._log_job_end.call_count)


### PR DESCRIPTION
originally slated to create a new processor type, instead this PR modifies the existing processor_app.  It adds the ability for the processor to fetch an existing processed crash along with the raw crash and dumps.  The existing processed crash is then passed on to the configured processor algorithm.  For processor2015, the rules may work with the processed crash at will or ignore it entirely.  

This method of expanding the abilities of the existing processor_app class cuts down significantly on the amount of redundant code in comparison with my original solution.  

