### PR TITLE
Nobug add starting elasticsearch to production install docs

### DIFF
--- a/docs/production-install.rst
+++ b/docs/production-install.rst
@@ -69,6 +69,11 @@ Enable RabbitMQ on startup:
   sudo service rabbitmq-server start
   sudo chkconfig rabbitmq-server on
 
+Enable RabbitMQ on startup:
+::
+  sudo service elasticsearch start
+  sudo chkconfig elasticsearch on 
+
 Initialize and enable PostgreSQL on startup:
 ::
   sudo service postgresql-9.3 initdb


### PR DESCRIPTION
ES is now a requirement so... maybe we should have this in our production install docs. 