### PR TITLE
fix bug 1142182 - make localhost the default in alembic.ini-dist, make j...

### DIFF
--- a/config/alembic.ini-dist
+++ b/config/alembic.ini-dist
@@ -11,7 +11,7 @@ file_template = %%(rev)s_%%(slug)s
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://test:aPassword@jenkins-pg92/socorro_migration_test
+sqlalchemy.url = postgresql://test:aPassword@localhost/socorro_migration_test
 
 # Logging configuration
 [loggers]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -73,6 +73,7 @@ pushd socorro/unittest/config
 for file in *.py.dist; do
   if [ $WORKSPACE ]; then
     cp $JENKINS_CONF commonconfig.py
+    sed -i 's:localhost:jenkins-pg92:' config/alembic.ini-dist
   else
     cp $file `basename $file .dist`
   fi


### PR DESCRIPTION
...enkins override

r? @phrawzty @selenamarie - we already have a place for jenkins-specific stuff, it uses the fact that ```$WORKSPACE``` is set to detect jenkins, might be better to use ```$USER``` as @erikrose suggests.