### PR TITLE
fixes bug 1131398 - move setup of product id map to constructor

### DIFF
--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1175,11 +1175,6 @@ class TestProductRewrite(TestCase):
             ('Chrome', '{ec8030f7-c20a-464f-9b0e-13b3a9e97384}', True),
             ('Safari', '{ec8030f7-c20a-464f-9b0e-13c3a9e97384}', True),
         )
-        config.product_id_map = setup_product_id_map(
-            config,
-            config,
-            []
-        )
 
         raw_crash = copy.copy(canonical_standard_raw_crash)
         raw_dumps = {}
@@ -1205,11 +1200,6 @@ class TestProductRewrite(TestCase):
             ('FennecAndroid', '{ec8030f7-c20a-464f-9b0e-13d3a9e97384}', True),
             ('Chrome', '{ec8030f7-c20a-464f-9b0e-13b3a9e97384}', True),
             ('Safari', '{ec8030f7-c20a-464f-9b0e-13c3a9e97384}', True),
-        )
-        config.product_id_map = setup_product_id_map(
-            config,
-            config,
-            []
         )
 
         raw_crash = copy.copy(canonical_standard_raw_crash)


### PR DESCRIPTION
this fixes the bug where the logger doesn't work properly when the PG password is incorrect: "Nonetype doesn't have..."

the ProductIdMap is set up by a configman aggregation just like logging is setup by an aggregation.  they are order dependent, but configman does not guarantee order.  the solution is to move the ProductIdMap to the constructor of the rule rather than as an aggregation.