### PR TITLE
Fixes bug 1145173 - Added tabs analytics to the signature report page.

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/analytics.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/analytics.js
@@ -10,7 +10,7 @@ var Analytics = (function() {
     }
 
     return {
-        trackTab: function(page, id) {
+        trackTabSwitch: function(page, id) {
             wrap('send', 'event', 'tab', page, id);
         },
         trackPageview: function(url) {

--- a/webapp-django/crashstats/signature/static/signature/js/signature_report.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_report.js
@@ -32,6 +32,8 @@ $(function () {
         $('.selected', panelsNavSection).removeClass('selected');
         $('.' + tabName, panelsNavSection).addClass('selected');
 
+        Analytics.trackTabSwitch('signature_report', tabName);
+
         loadTab(tabName);
 
         // Hide all main panels.


### PR DESCRIPTION
@peterbe While I was at it, I also fixed the Analytics class, which had an incorrect method name. :-) (I guess testing a patch should never be an option... Silly reviewer, no cookies for me! )