### PR TITLE
fixes Bug 1147519 - remove "Apache" from names

### DIFF
--- a/socorro/collector/collector_app.py
+++ b/socorro/collector/collector_app.py
@@ -18,7 +18,7 @@ from configman.converters import class_converter
 
 # an app running under modwsgi needs to have a name at the module level called
 # application.  The value is set in the App's 'main' function below.  Only the
-# modwsgi version actually makes use of this variable.
+# wsgi version actually makes use of this variable.
 application = None
 
 

--- a/socorro/collector/collector_app.py
+++ b/socorro/collector/collector_app.py
@@ -18,7 +18,7 @@ from configman.converters import class_converter
 
 # an app running under modwsgi needs to have a name at the module level called
 # application.  The value is set in the App's 'main' function below.  Only the
-# modwsgi Apache version actually makes use of this variable.
+# modwsgi version actually makes use of this variable.
 application = None
 
 
@@ -83,7 +83,7 @@ class CollectorApp(App):
 
     #--------------------------------------------------------------------------
     def main(self):
-        # Apache modwsgi requireds a module level name 'application'
+        # modwsgi requireds a module level name 'application'
         global application
 
         services_list = (
@@ -101,9 +101,9 @@ class CollectorApp(App):
         )
 
 
-        # for modwsgi the 'run' method returns the wsgi function that Apache
-        # will use.  For other webservers, the 'run' method actually starts
-        # the standalone web server.
+        # for modwsgi the 'run' method returns the wsgi function that the web
+        # server will use.  For other webservers, the 'run' method actually
+        # starts the standalone web server.
         application = self.web_server.run()
 
 

--- a/socorro/dataservice/dataservice_app.py
+++ b/socorro/dataservice/dataservice_app.py
@@ -27,7 +27,7 @@ SERVICES_LIST = (
 
 # an app running under modwsgi needs to have a name at the module level called
 # application.  The value is set in the App's 'main' function below.  Only the
-# modwsgi version actually makes use of this variable.
+# wsgi version actually makes use of this variable.
 application = None
 
 

--- a/socorro/dataservice/dataservice_app.py
+++ b/socorro/dataservice/dataservice_app.py
@@ -27,7 +27,7 @@ SERVICES_LIST = (
 
 # an app running under modwsgi needs to have a name at the module level called
 # application.  The value is set in the App's 'main' function below.  Only the
-# modwsgi Apache version actually makes use of this variable.
+# modwsgi version actually makes use of this variable.
 application = None
 
 
@@ -84,7 +84,7 @@ class DataserviceApp(App):
 
     #--------------------------------------------------------------------------
     def main(self):
-        # Apache modwsgi requireds a module level name 'application'
+        # modwsgi requireds a module level name 'application'
         global application
 
         services_list = []
@@ -107,7 +107,7 @@ class DataserviceApp(App):
             services_list
         )
 
-        # for modwsgi the 'run' method returns the wsgi function that Apache
+        # for modwsgi the 'run' method returns the wsgi function that
         # will use.  For other webservers, the 'run' method actually starts
         # the standalone web server.
         application = self.web_server.run()

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -84,7 +84,7 @@ DONT_TERM_SPLIT = re.compile("""
 
 # an app running under modwsgi needs to have a name at the module level called
 # application.  The value is set in the App's 'main' function below.  Only the
-# modwsgi version actually makes use of this variable.
+# wsgi version actually makes use of this variable.
 application = None
 
 

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -84,7 +84,7 @@ DONT_TERM_SPLIT = re.compile("""
 
 # an app running under modwsgi needs to have a name at the module level called
 # application.  The value is set in the App's 'main' function below.  Only the
-# modwsgi Apache version actually makes use of this variable.
+# modwsgi version actually makes use of this variable.
 application = None
 
 
@@ -430,7 +430,7 @@ class MiddlewareApp(App):
 
     #--------------------------------------------------------------------------
     def main(self):
-        # Apache modwsgi requireds a module level name 'application'
+        # modwsgi requires a module level name 'application'
         global application
 
         # 1 turn these names of classes into real references to classes
@@ -494,7 +494,7 @@ class MiddlewareApp(App):
             services_list
         )
 
-        # for modwsgi the 'run' method returns the wsgi function that Apache
+        # for modwsgi the 'run' method returns the wsgi function that
         # will use.  For other webservers, the 'run' method actually starts
         # the standalone web server.
         application = self.web_server.run()

--- a/socorro/webapi/servers.py
+++ b/socorro/webapi/servers.py
@@ -52,12 +52,13 @@ class WebServerBase(RequiredConfig):
 
 
 #==============================================================================
-class ApacheModWSGI(WebServerBase):
-    """When running Apache, modwsgi requires a reference to a "wsgifunc" In
-    this varient of the WebServer class, the run function returns the result of
-    the webpy framework's wsgifunc.  Applications that use this class must
-    provide a module level variable 'application' in the module given to Apache
-    modwsgi configuration.  The value of the variable must be the _wsgi_func.
+class ModWSGIServer(WebServerBase):
+    """When running under a modwsgi compatible Web server, modwsgi requires a
+    reference to a "wsgifunc" In this varient of the WebServer class, the run
+    function returns the result of the webpy framework's wsgifunc.
+    Applications that use this class must provide a module level variable
+    'application' in the module given to the Web server modwsgi configuration.
+    The value of the variable must be the _wsgi_func.
     """
 
     #--------------------------------------------------------------------------
@@ -66,7 +67,7 @@ class ApacheModWSGI(WebServerBase):
 
     #--------------------------------------------------------------------------
     def _identify(self):
-        self.config.logger.info('this is ApacheModWSGI')
+        self.config.logger.info('this is ModWSGIServer')
 
     #--------------------------------------------------------------------------
     @staticmethod
@@ -74,6 +75,8 @@ class ApacheModWSGI(WebServerBase):
         wsgi_path = os.path.dirname(os.path.realpath(wsgi_file))
         config_path = os.path.join(wsgi_path, '..', 'config')
         return os.path.abspath(config_path)
+
+ApacheModWSGI = ModWSGIServer  # for backwards compatiblity
 
 
 #==============================================================================

--- a/socorro/webapi/servers.py
+++ b/socorro/webapi/servers.py
@@ -52,8 +52,8 @@ class WebServerBase(RequiredConfig):
 
 
 #==============================================================================
-class ModWSGIServer(WebServerBase):
-    """When running under a modwsgi compatible Web server, modwsgi requires a
+class WSGIServer(WebServerBase):
+    """When running under a wsgi compatible Web server, modwsgi requires a
     reference to a "wsgifunc" In this varient of the WebServer class, the run
     function returns the result of the webpy framework's wsgifunc.
     Applications that use this class must provide a module level variable
@@ -67,7 +67,7 @@ class ModWSGIServer(WebServerBase):
 
     #--------------------------------------------------------------------------
     def _identify(self):
-        self.config.logger.info('this is ModWSGIServer')
+        self.config.logger.info('this is WSGIServer')
 
     #--------------------------------------------------------------------------
     @staticmethod
@@ -76,7 +76,7 @@ class ModWSGIServer(WebServerBase):
         config_path = os.path.join(wsgi_path, '..', 'config')
         return os.path.abspath(config_path)
 
-ApacheModWSGI = ModWSGIServer  # for backwards compatiblity
+ApacheModWSGI = WSGIServer  # for backwards compatiblity
 
 
 #==============================================================================

--- a/wsgi/collector.py
+++ b/wsgi/collector.py
@@ -1,7 +1,7 @@
 import os
 from socorro.app.generic_app import main
 from socorro.collector.collector_app import CollectorApp
-from socorro.webapi.servers import ModWSGIServer
+from socorro.webapi.servers import WSGIServer
 import socorro.collector.collector_app
 
 from configman import (
@@ -12,7 +12,7 @@ from configman import (
 if os.path.isfile('/etc/socorro/collector.ini'):
     config_path = '/etc/socorro'
 else:
-    config_path = ModWSGIServer.get_socorro_config_path(__file__)
+    config_path = WSGIServer.get_socorro_config_path(__file__)
 
 # invoke the generic main function to create the configman app class and which
 # will then create the wsgi app object.

--- a/wsgi/collector.py
+++ b/wsgi/collector.py
@@ -1,7 +1,7 @@
 import os
 from socorro.app.generic_app import main
 from socorro.collector.collector_app import CollectorApp
-from socorro.webapi.servers import ApacheModWSGI
+from socorro.webapi.servers import ModWSGIServer
 import socorro.collector.collector_app
 
 from configman import (
@@ -12,7 +12,7 @@ from configman import (
 if os.path.isfile('/etc/socorro/collector.ini'):
     config_path = '/etc/socorro'
 else:
-    config_path = ApacheModWSGI.get_socorro_config_path(__file__)
+    config_path = ModWSGIServer.get_socorro_config_path(__file__)
 
 # invoke the generic main function to create the configman app class and which
 # will then create the wsgi app object.

--- a/wsgi/middleware.py
+++ b/wsgi/middleware.py
@@ -1,7 +1,7 @@
 import os
 from socorro.app.generic_app import main
 from socorro.middleware.middleware_app import MiddlewareApp
-from socorro.webapi.servers import ApacheModWSGI
+from socorro.webapi.servers import ModWSGIServer
 import socorro.middleware.middleware_app
 
 from configman import (
@@ -12,7 +12,7 @@ from configman import (
 if os.path.isfile('/etc/socorro/middleware.ini'):
     config_path = '/etc/socorro'
 else:
-    config_path = ApacheModWSGI.get_socorro_config_path(__file__)
+    config_path = ModWSGIServer.get_socorro_config_path(__file__)
 
 # invoke the generic main function to create the configman app class and which
 # will then create the wsgi app object.

--- a/wsgi/middleware.py
+++ b/wsgi/middleware.py
@@ -1,7 +1,7 @@
 import os
 from socorro.app.generic_app import main
 from socorro.middleware.middleware_app import MiddlewareApp
-from socorro.webapi.servers import ModWSGIServer
+from socorro.webapi.servers import WSGIServer
 import socorro.middleware.middleware_app
 
 from configman import (
@@ -12,7 +12,7 @@ from configman import (
 if os.path.isfile('/etc/socorro/middleware.ini'):
     config_path = '/etc/socorro'
 else:
-    config_path = ModWSGIServer.get_socorro_config_path(__file__)
+    config_path = WSGIServer.get_socorro_config_path(__file__)
 
 # invoke the generic main function to create the configman app class and which
 # will then create the wsgi app object.


### PR DESCRIPTION
the Socorro code often links the words Apache and ModWSGI. Since modwsgi works under more than just Apache, the names that label modwsgi things ought not be saddled with the name Apache, too.