### PR TITLE
Bug 1148090 - Update forced versions for correlations for Firefox cycle starting 2015-03-31

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="37.0 38.0a2 39.0a1"
+MANUAL_VERSION_OVERRIDE="38.0 39.0a2 40.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
The next version of our usual correlation version bump. Should go into production in the week of 2014-03-30.