### PR TITLE
fixes bug 1148587 - 0x221 is the wrong adapter hex

### DIFF
--- a/webapp-django/crashstats/manage/tests/sample-graphics.csv
+++ b/webapp-django/crashstats/manage/tests/sample-graphics.csv
@@ -43,12 +43,15 @@
 	002F	.43 ieee 1394 controller
 	00333	1ACPI\GenuineIntel_-_x86_Family_6_Model_23\_0 1ACPI\GenuineIntel_-_x86_Family_6_Model_23\_0
 	6800	n/a
-	08b2	123abc logitech QuickCam® Pro 4000
+	08b2	123abc logitech QuickCamï¿½ Pro 4000
 	08f0	n/a n/a
 0553	 Aiptek USA
 	0200, 0x0201	DS38xx Oregon Scientific
 	6128_	USB\VID_0C45&PID_6148&REV_0101 USB PC Camera Plus
 	X0X0	Some rubbish
+0407	Lava Computer MFG Inc.
+	0221	LavaPort Quad-650 PCI C/D
+
 ;
 ;============
 ; END OF LIST

--- a/webapp-django/crashstats/manage/tests/test_utils.py
+++ b/webapp-django/crashstats/manage/tests/test_utils.py
@@ -3,7 +3,10 @@ from unittest import TestCase
 
 from nose.tools import eq_
 
-from crashstats.manage.utils import parse_graphics_devices_iterable
+from crashstats.manage.utils import (
+    parse_graphics_devices_iterable,
+    string_hex_to_hex_string
+)
 
 
 SAMPLE_CSV_FILE = os.path.join(
@@ -13,6 +16,14 @@ SAMPLE_CSV_FILE = os.path.join(
 
 
 class TestUtils(TestCase):
+
+    def test_string_hex_to_hex_string(self):
+        eq_(string_hex_to_hex_string('919A'), '0x919a')
+        eq_(string_hex_to_hex_string('0x919A'), '0x919a')
+
+        eq_(string_hex_to_hex_string('221'), '0x0221')
+        eq_(string_hex_to_hex_string('0221'), '0x0221')
+        eq_(string_hex_to_hex_string('0x0221'), '0x0221')
 
     def test_parse_graphics_devices_iterable(self):
         iterable = open(SAMPLE_CSV_FILE)
@@ -27,9 +38,9 @@ class TestUtils(TestCase):
             eq_(
                 things[0],
                 {
-                    'adapter_hex': '0x2f',
+                    'adapter_hex': '0x002f',
                     'adapter_name': '.43 ieee 1394 controller',
-                    'vendor_hex': '0x33',
+                    'vendor_hex': '0x0033',
                     'vendor_name': 'Paradyne Corp.'
                 }
             )
@@ -37,11 +48,11 @@ class TestUtils(TestCase):
             eq_(
                 things[1],
                 {
-                    'adapter_hex': '0x333',
+                    'adapter_hex': '0x0333',
                     'adapter_name': '1ACPI\\GenuineIntel_-_x86_Family_6_Model_'
                                     '23\\_0 1ACPI\\GenuineIntel_-_x86_Family_6'
                                     '_Model_23\\_0',
-                    'vendor_hex': '0x33',
+                    'vendor_hex': '0x0033',
                     'vendor_name': 'Paradyne Corp.'
                 }
             )
@@ -49,9 +60,9 @@ class TestUtils(TestCase):
             eq_(
                 things[2],
                 {
-                    'adapter_hex': '0x8b2',
-                    'adapter_name': u'123abc logitech QuickCam\xae Pro 4000',
-                    'vendor_hex': '0x33',
+                    'adapter_hex': '0x08b2',
+                    'adapter_name': u'123abc logitech QuickCam\ufffd Pro 4000',
+                    'vendor_hex': '0x0033',
                     'vendor_name': 'Paradyne Corp.'
                 }
             )
@@ -59,18 +70,18 @@ class TestUtils(TestCase):
             eq_(
                 things[3],
                 {
-                    'adapter_hex': '0x200',
+                    'adapter_hex': '0x0200',
                     'adapter_name': 'DS38xx Oregon Scientific',
-                    'vendor_hex': '0x553',
+                    'vendor_hex': '0x0553',
                     'vendor_name': 'Aiptek USA'
                 }
             )
             eq_(
                 things[4],
                 {
-                    'adapter_hex': '0x201',
+                    'adapter_hex': '0x0201',
                     'adapter_name': 'DS38xx Oregon Scientific',
-                    'vendor_hex': '0x553',
+                    'vendor_hex': '0x0553',
                     'vendor_name': 'Aiptek USA'
                 }
             )
@@ -81,11 +92,20 @@ class TestUtils(TestCase):
                     'adapter_hex': '0x6128',
                     'adapter_name': 'USB\\VID_0C45&PID_6148&REV_0101 USB PC '
                                     'Camera Plus',
-                    'vendor_hex': '0x553',
+                    'vendor_hex': '0x0553',
                     'vendor_name': 'Aiptek USA'
                 }
             )
-            eq_(len(things), 6)
+            eq_(
+                things[6],
+                {
+                    'adapter_hex': '0x0221',
+                    'adapter_name': 'LavaPort Quad-650 PCI C/D',
+                    'vendor_hex': '0x0407',
+                    'vendor_name': 'Lava Computer MFG Inc.'
+                }
+            )
+            eq_(len(things), 7)
 
         finally:
             iterable.close()

--- a/webapp-django/crashstats/manage/tests/test_views.py
+++ b/webapp-django/crashstats/manage/tests/test_views.py
@@ -927,13 +927,13 @@ class TestViews(BaseTestViews):
             eq_(
                 data[0],
                 {
-                    'vendor_hex': '0x33',
-                    'adapter_hex': '0x2f',
+                    'vendor_hex': '0x0033',
+                    'adapter_hex': '0x002f',
                     'vendor_name': 'Paradyne Corp.',
                     'adapter_name': '.43 ieee 1394 controller'
                 }
             )
-            eq_(len(data), 6)
+            eq_(len(data), 7)
             return Response('true')
 
         rpost.side_effect = mocked_post

--- a/webapp-django/crashstats/manage/utils.py
+++ b/webapp-django/crashstats/manage/utils.py
@@ -1,13 +1,14 @@
-def _string_hex_to_hex_string(snippet):
+def string_hex_to_hex_string(snippet):
     """The PCIDatabase.com uses shortened hex strings (e.g. '919A')
     whereas in Socorro we use the full represenation, but still as a
     string (e.g. '0x919a').
+    Also, note that when converting the snippet to a 16 base int, we
+    can potentially lose the leading zeros, but we want to make sure
+    we always return a 4 character string preceeded by 0x.
     This function tries to make that conversion.
     """
     assert isinstance(snippet, basestring)
-    if not snippet.startswith('0x'):
-        snippet = '0x%s' % snippet
-    return hex(int(snippet, 16))
+    return '0x' + format(int(snippet, 16), '04x')
 
 
 def parse_graphics_devices_iterable(iterable, delimiter='\t'):
@@ -42,7 +43,7 @@ def parse_graphics_devices_iterable(iterable, delimiter='\t'):
         split = [x.strip() for x in line.rstrip().split(delimiter)]
         if len(split) == 2 and split[0]:
             vendor_hex, vendor_name = split
-            vendor_hex = _string_hex_to_hex_string(vendor_hex)
+            vendor_hex = string_hex_to_hex_string(vendor_hex)
         elif len(split) == 3 and not split[0] and split[1] and split[2]:
             if split[2] in ('n/a', 'n/a n/a'):
                 # some adapter names appear to be entered in this
@@ -56,7 +57,7 @@ def parse_graphics_devices_iterable(iterable, delimiter='\t'):
                 if adapter_hex.endswith('_'):
                     adapter_hex = adapter_hex[:-1]
                 try:
-                    adapter_hex = _string_hex_to_hex_string(adapter_hex)
+                    adapter_hex = string_hex_to_hex_string(adapter_hex)
                     yield {
                         'vendor_hex': vendor_hex,
                         'vendor_name': vendor_name,


### PR DESCRIPTION
@selenamarie r? or if you're too busy getting started in your new team, @rhelmer r?

So, if you look at [Adapter Graphics Report](https://crash-stats.mozilla.com/report/list?signature=mozilla%3A%3Alayers%3A%3ADataTextureSourceD3D9%3A%3AUpdateFromTexture%28IDirect3DTexture9*%2C+nsIntRegion+const*%29&range_value=28&range_unit=days) in the Signature Summary you'll see that all the hexes for the adapters we don't recognized are padded as 4 characters. E.g. `0x0221`. And `'0x0221' != '0x221'` even though `hex(int('0x0221', 16)) == hex(int('0x221', 16))` is true. 

So that's why we miss so many adapters in the signature summary that starts with a leading 0. This PR fixes that. 