### PR TITLE
Fixes Bug 1149587 - enable crontabber to use socorro_app framework

### DIFF
--- a/socorro/app/for_application_defaults.py
+++ b/socorro/app/for_application_defaults.py
@@ -48,8 +48,7 @@ class ApplicationDefaultsProxy(object):
             'crashmover': 'socorro.collector.crashmover_app.CrashMoverApp',
             'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDBApp',
             'submitter': 'socorro.collector.submitter_app.SubmitterApp',
-            # crontabber not yet supported in this environment
-            #'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',
+            'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',
             'middleware': 'socorro.middleware.middleware_app.MiddlewareApp',
             'processor': 'socorro.processor.processor_app.ProcessorApp',
             'fetch': 'socorro.external.fetch_app.FetchApp',

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -71,25 +71,11 @@ class CronTabberApp(CronTabberBase, App):
             'socorro.external.postgresql.connection_context.ConnectionContext',
             'crontabber.transaction_executor_class':
             'socorro.database.transaction_executor.TransactionExecutor',
-            'crontabber.job_state_db_class.database_class':
-            'socorro.external.postgresql.connection_context.ConnectionContext',
-
         }
 
 #------------------------------------------------------------------------------
 
 from crontabber.app import CronTabber
-
-# These settings should ideally be done in config, but because, at
-# the moment, it's easier for us to maintain python we're doing it here.
-CronTabber.required_config.crontabber.jobs.default = DEFAULT_JOBS
-CronTabber.required_config.crontabber.database_class.default = (
-    'socorro.external.postgresql.connection_context.ConnectionContext'
-)
-CronTabber.required_config.crontabber.job_state_db_class.default \
-    .required_config.database_class.default = (
-        'socorro.external.postgresql.connection_context.ConnectionContext'
-    )
 
 if __name__ == '__main__':  # pragma: no cover
     from crontabber.app import main


### PR DESCRIPTION
when the socorro_app system was created, crontabber_app did not work with that system.  It derived from an earlier version of the app class system.  Since it split off from the Socorro, it took a copy of that earlier app system with it.  

this PR ought to bring crontabber into the modern app system fold...