### PR TITLE
do not accept crashes on Rahukaalam

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -184,3 +184,5 @@ flake8==2.4.0
 mccabe==0.3
 # sha256: Qe3TI-mz8cZzF-Ix1GDaaLPTjGUzLAOD7etvu996wh0
 astral==0.8.1
+# sha256: PhW0FsmiA5waUSCLLNO7T_15bNGeYBsdJlevy3fD3JA
+pytz==2015.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -182,3 +182,5 @@ flake8==2.4.0
 # sha256: ic9r9P9kT_i5EuL6fiq7aNV6jn6Rjjk8coQNMNLrzws
 # sha256: PYypv2XFAU9GkYBUTR3Vu1ud9wmq1jBPnC5DcK4Ke3w
 mccabe==0.3
+# sha256: Qe3TI-mz8cZzF-Ix1GDaaLPTjGUzLAOD7etvu996wh0
+astral==0.8.1

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -36,6 +36,7 @@ class TestCollectorApp(TestCase):
         config.collector.accept_submitted_crash_id = False
         config.collector.accept_submitted_legacy_processing = False
         config.collector.checksum_method = hashlib.md5
+        config.collector.reject_crash_on_rahukaalam = False
 
         config.crash_storage = mock.MagicMock()
 


### PR DESCRIPTION
r? @lars @peterbe @AdrianGaudebert 

We should not be accepting crashes during times of Rahukaalam. This will require breakpad client support (/cc @luser), which should show a helpful error message to the user and retry submission later.

No tests, for proof denies faith. Also, once this feature is enabled, existing unit tests will fail during Rahukaalam - this is as it should be.