### PR TITLE
Fixes bug 1114561 - By default, sort Reports results by descending date ...

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -4338,7 +4338,7 @@ class TestViews(BaseTestViews):
         response = self.client.get(url, data)
         eq_(response.status_code, 200)
         assert len(mock_calls) == 1
-        eq_(mock_calls[-1]['_sort'], ['date'])
+        eq_(mock_calls[-1]['_sort'], ['-date'])
         ok_('reverse' not in mock_calls[-1])
 
         response = self.client.get(url, dict(
@@ -4347,17 +4347,17 @@ class TestViews(BaseTestViews):
         ))
         eq_(response.status_code, 200)
         assert len(mock_calls) == 2
-        eq_(mock_calls[-1]['_sort'], ['build_id'])
+        eq_(mock_calls[-1]['_sort'], ['-build_id'])
         ok_('reverse' not in mock_calls[-1])
 
         response = self.client.get(url, dict(
             data,
             sort='build',
-            reverse='True'
+            reverse='False'
         ))
         eq_(response.status_code, 200)
         assert len(mock_calls) == 3
-        eq_(mock_calls[-1]['_sort'], ['-build_id'])
+        eq_(mock_calls[-1]['_sort'], ['build_id'])
         ok_('reverse' not in mock_calls[-1])
 
     @mock.patch('requests.get')

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1415,7 +1415,7 @@ def report_list(request, partial=None, default_context=None):
         # of the fact that the ReportList() data gets cached.
 
         context['sort'] = request.GET.get('sort', 'date_processed')
-        context['reverse'] = request.GET.get('reverse', 'false').lower()
+        context['reverse'] = request.GET.get('reverse', 'true').lower()
         context['reverse'] = context['reverse'] != 'false'
 
         columns = request.GET.getlist('c')


### PR DESCRIPTION
...in report/list/.

@peterbe r?