### PR TITLE
fixes Bug 1150970 - added case where type is datetime rather than str

### DIFF
--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -162,7 +162,9 @@ def datestring_to_weekly_partition(date_str):
         weekly_partition = '2014-01-05'
     """
 
-    if date_str == 'now':
+    if isinstance(date_str, datetime.datetime):
+        d = date_str
+    elif date_str == 'now':
         d = datetime.datetime.now().date()
     else:
         d = datetime.datetime.strptime(date_str, '%Y-%m-%d').date()

--- a/socorro/unittest/lib/test_datetimeutil.py
+++ b/socorro/unittest/lib/test_datetimeutil.py
@@ -162,7 +162,7 @@ def test_uuid_to_date():
     date = datetimeutil.uuid_to_date(uuid, century=11)
     eq_(date, date_exp)
 
-def test_date_to_weekly_partition():
+def test_date_to_weekly_partition_with_string():
     datestring = '2015-01-09'
     partition_exp = '20150105'
 
@@ -175,3 +175,22 @@ def test_date_to_weekly_partition():
     partition_exp = (date_now + datetime.timedelta(0 - date_now.weekday())).strftime('%Y%m%d')
     partition = datetimeutil.datestring_to_weekly_partition(datestring)
     eq_(partition, partition_exp)
+
+def test_date_to_weekly_partition_with_datetime():
+    proposed_and_expected = (
+        (datetime.datetime(2014, 12, 29), '20141229'),
+        (datetime.datetime(2014, 12, 30), '20141229'),
+        (datetime.datetime(2014, 12, 31), '20141229'),
+        (datetime.datetime(2015,  1,  1), '20141229'),
+        (datetime.datetime(2015,  1,  2), '20141229'),
+        (datetime.datetime(2015,  1,  3), '20141229'),
+        (datetime.datetime(2015,  1,  4), '20141229'),
+        (datetime.datetime(2015,  1,  5), '20150105'),
+        (datetime.datetime(2015,  1,  6), '20150105'),
+        (datetime.datetime(2015,  1,  7), '20150105'),
+        (datetime.datetime(2015,  1,  8), '20150105'),
+        (datetime.datetime(2015,  1,  9), '20150105'),
+    )
+    for to_be_tested, expected in proposed_and_expected:
+        result = datetimeutil.datestring_to_weekly_partition(to_be_tested)
+        eq_(result, expected)


### PR DESCRIPTION
the MissingSymbolsRule in the processor can fail if the date_processed is an actual datetime rather than a string.  Because the crashstorage classes may stringify datetimes and that change propagates to the processed crash given to other crashstorage modules, the crashstorage modules must be defensive and should not assume types.

This PR fixes the utility method that creates a table partition suffix to accept either datetime instances or strings.

@selenamarie   r?