### PR TITLE
also fixes Bug 1150970 - stopped MissingSymbolRule from spoiling its own SQL

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -793,13 +793,13 @@ class MissingSymbolsRule(Rule):
         try:
             date = processed_crash['date_processed']
             # update partition information based on date processed
-            self.sql = self.sql % datestring_to_weekly_partition(date)
+            sql = self.sql % datestring_to_weekly_partition(date)
             for module in processed_crash['json_dump']['modules']:
                 try:
                     if module['missing_symbols']:
                         self.transaction(
                             execute_no_results,
-                            self.sql,
+                            sql,
                             (
                                 date,
                                 module['debug_file'],


### PR DESCRIPTION
the MissingSymbolsRule despoiled its own SQL by save the result after it formatted it.  That meant thet the second time around, there were no formatting variables in the string and formatting failed.  

fixed that problem and added tests to make sure that the rule works more than once. 