### PR TITLE
fix bug 1151435 - provide way to override content-type based on file ext...

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -400,3 +400,7 @@ SYMBOLS_FILE_PREFIX = 'v1'
 # e.g. "us-west-2" see boto.s3.connection.Location
 # Only needed if the bucket has never been created
 SYMBOLS_BUCKET_DEFAULT_LOCATION = None
+# to override the content-type of specific file extensinos:
+SYMBOLS_MIME_OVERRIDES = {
+    'sym': 'text/plain'
+}

--- a/webapp-django/crashstats/symbols/migrations/0003_auto__add_field_symbolsupload_content_type.py
+++ b/webapp-django/crashstats/symbols/migrations/0003_auto__add_field_symbolsupload_content_type.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'SymbolsUpload.content_type'
+        db.add_column(u'symbols_symbolsupload', 'content_type',
+                      self.gf('django.db.models.fields.TextField')(null=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'SymbolsUpload.content_type'
+        db.delete_column(u'symbols_symbolsupload', 'content_type')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'symbols.symbolsupload': {
+            'Meta': {'object_name': 'SymbolsUpload'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'content_type': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['symbols']

--- a/webapp-django/crashstats/symbols/models.py
+++ b/webapp-django/crashstats/symbols/models.py
@@ -9,6 +9,7 @@ class SymbolsUpload(models.Model):
     filename = models.CharField(max_length=100)
     size = models.IntegerField()
     created = models.DateTimeField(default=timezone.now)
+    content_type = models.TextField(null=True)
 
     def __repr__(self):
         return '<%s: %s (%d)...>' % (

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -95,6 +95,12 @@ def unpack_and_upload(iterator, symbols_upload, bucket_name, bucket_location):
 
             file = StringIO()
             file.write(member.extractor().read())
+
+            for ext in settings.SYMBOLS_MIME_OVERRIDES:
+                if key_name.endswith('.{0}'.format(ext)):
+                    key.content_type = settings.SYMBOLS_MIME_OVERRIDES[ext]
+                    symbols_upload.content_type = key.content_type
+
             uploaded = key.set_contents_from_string(file.getvalue())
             total_uploaded += uploaded
 


### PR DESCRIPTION
...ension

r? @peterbe - I couldn't figure out a great way in the test to look at the boto ```key``` object, so I passed the content type through the symbol model (might be useful to record this info I guess?)

What do you think?