### PR TITLE
BugFix 1151754

### DIFF
--- a/minidump-stackwalk/dumplookup.cc
+++ b/minidump-stackwalk/dumplookup.cc
@@ -70,19 +70,19 @@ void print_frame(const StackFrame* frame) {
       printf("!%s", frame->function_name.c_str());
       if (!frame->source_file_name.empty()) {
         string source_file = PathnameStripper::File(frame->source_file_name);
-        printf(" [%s : %d + 0x%lx]",
+        printf(" [%s : %d + 0x%llx]",
                source_file.c_str(),
                frame->source_line,
                frame->instruction - frame->source_line_base);
       } else {
-        printf(" + 0x%lx", frame->instruction - frame->function_base);
+        printf(" + 0x%llx", frame->instruction - frame->function_base);
       }
     } else {
-      printf(" + 0x%lx",
+      printf(" + 0x%llx",
              frame->instruction - frame->module->base_address());
     }
   } else {
-    printf("0x%lx", frame->instruction);
+    printf("0x%llx", frame->instruction);
   }
   printf("\n");
 }
@@ -295,7 +295,7 @@ int main(int argc, char** argv)
       resolver.FillSourceLineInfo(frame);
       if (!frame->function_name.empty() || show_all) {
         if (wordsize == 8) {
-          printf("0x%016lx: ", addr);
+          printf("0x%016llx: ", addr);
         }
         else {
           printf("0x%08x: ", (u_int32_t)addr);

--- a/minidump-stackwalk/get-minidump-instructions.cc
+++ b/minidump-stackwalk/get-minidump-instructions.cc
@@ -248,7 +248,7 @@ void print_frame(const StackFrame& frame, const StackFrame& last_frame)
   } else if (frame.module &&
              (!last_frame.module ||
               frame.module->code_file() != last_frame.module->code_file())) {
-    printf("%s+0x%lx\n", PathnameStripper::File(frame.module->code_file()).c_str(), frame.instruction - frame.module->base_address());
+    printf("%s+0x%llx\n", PathnameStripper::File(frame.module->code_file()).c_str(), frame.instruction - frame.module->base_address());
   }
 }
 
@@ -357,7 +357,7 @@ int main(int argc, char** argv)
           "the instruction pointer from the exception record");
   }
 
-  printf("Faulting instruction pointer: 0x%08lx\n", instruction_pointer);
+  printf("Faulting instruction pointer: 0x%08llx\n", instruction_pointer);
   const u_int8_t* bytes = region->GetMemory();
   if (disassemble) {
     curl = curl_easy_init();
@@ -391,7 +391,7 @@ int main(int argc, char** argv)
       error("Unknown CPU architecture");
     }
     char cmdline[1024];
-    sprintf(cmdline, "%s -b binary -m %s -M %s --adjust-vma=0x%lx -D \"%s\"",
+    sprintf(cmdline, "%s -b binary -m %s -M %s --adjust-vma=0x%llx -D \"%s\"",
             objdump, arch, archopts, region->GetBase(), tempfile);
     FILE* fp = popen(cmdline, "r");
     if (!fp) {
@@ -449,7 +449,7 @@ int main(int argc, char** argv)
     const int kBytesPerLine = 16;
     for (unsigned int i = 0; i < region->GetSize(); i++) {
       if ((i % kBytesPerLine) == 0) {
-        printf("\n%08lx  ", region->GetBase() + i);
+        printf("\n%08llx  ", region->GetBase() + i);
       }
       printf("%02x ", bytes[i]);
     }

--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -114,13 +114,13 @@ const unsigned kTailFramesWhenTruncating = 10;
 
 static string ToHex(uint64_t value) {
   char buffer[17];
-  sprintf(buffer, "0x%lx", value);
+  sprintf(buffer, "0x%llx", value);
   return buffer;
 }
 
 static string ToInt(uint64_t value) {
   char buffer[17];
-  sprintf(buffer, "%ld", value);
+  sprintf(buffer, "%lld", value);
   return buffer;
 }
 
@@ -202,7 +202,7 @@ void AddRegister(Json::Value& registers, const char* reg,
 void AddRegister(Json::Value& registers, const char* reg,
                  uint64_t value) {
   char buf[19];
-  snprintf(buf, sizeof(buf), "0x%016lx", value);
+  snprintf(buf, sizeof(buf), "0x%016llx", value);
   registers[reg] = buf;
 }
 


### PR DESCRIPTION
While building Socorro from source (github master); 
`git clone https://github.com/mozilla/socorro`
`cd socorro`
`make dev`

error in files dumplookup.cc, get-minidump-instructions.cc & stackwalker.cc in /minidump-stackwalk

```stackwalker.cc: In function ‘std::string {anonymous}::ToHex(uint64_t)’:
stackwalker.cc:117:33: error: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘uint64_t {aka long long unsigned int}’ [-Werror=format=]
   sprintf(buffer, "0x%lx", value);```

`all %lx / %ld should be %llx / %lld`
https://bugzilla.mozilla.org/show_bug.cgi?id=1151754
