### PR TITLE
Fixes bug 1137879 add support for postgres URLs

### DIFF
--- a/scripts/defaults
+++ b/scripts/defaults
@@ -16,6 +16,7 @@ export database_port=${database_port:-"5432"}
 export database_password=${database_password:-"aPassword"}
 export database_superusername=${database_superusername:-"test"}
 export database_superuserpassword=${database_superuserpassword:-"aPassword"}
+export database_url=${database_url:-"postgres://test:aPassword@localhost:5432/socorro_migration_test"}
 
 export rmq_host=${rmq_host:-"localhost"}
 export rmq_user=${rmq_user:-"guest"}

--- a/scripts/rabbitmq-integration-test.sh
+++ b/scripts/rabbitmq-integration-test.sh
@@ -53,6 +53,7 @@ function fatal() {
   message=$2
 
   echo "ERROR: $message"
+  cat setupdb.log
 
   cleanup
 
@@ -69,7 +70,7 @@ export PYTHONPATH=.
 echo " Done."
 
 echo -n "INFO: setting up database..."
-python socorro/external/postgresql/setupdb_app.py --database_username=$database_username --database_password=$database_password --database_name=breakpad --database_hostname=$database_hostname --dropdb --force > setupdb.log 2>&1
+python socorro/external/postgresql/setupdb_app.py --dropdb --force > setupdb.log 2>&1
 if [ $? != 0 ]
 then
   fatal 1 "setupdb_app.py failed, check setupdb.log"
@@ -81,7 +82,7 @@ popd >> setupdb.log 2>&1
 cleanup_rabbitmq
 
 echo -n "INFO: setting up 'weekly-reports-partitions' via crontabber..."
-python socorro/cron/crontabber_app.py --resource.postgresql.database_hostname=$database_hostname --secrets.postgresql.database_username=$database_username --secrets.postgresql.database_password=$database_password --job=weekly-reports-partitions --force >> setupdb.log 2>&1
+python socorro/cron/crontabber_app.py --job=weekly-reports-partitions --force >> setupdb.log 2>&1
 if [ $? != 0 ]
 then
   fatal 1 "crontabber weekly-reports-partitions failed, check setupdb.log"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,23 +8,28 @@ JENKINS_CONF=jenkins.py.dist
 
 ENV=env
 
-PYTHONPATH="."
+PYTHONPATH=.
 
 PG_RESOURCES=""
-if [ -n "$database_hostname" ]; then
-    PG_RESOURCES="$PG_RESOURCES resource.postgresql.database_hostname=$database_hostname"
-fi
-if [ -n "$database_username" ]; then
-    PG_RESOURCES="$PG_RESOURCES secrets.postgresql.database_username=$database_username"
-fi
-if [ -n "$database_password" ]; then
-    PG_RESOURCES="$PG_RESOURCES secrets.postgresql.database_password=$database_password"
-fi
-if [ -n "$database_port" ]; then
-    PG_RESOURCES="$PG_RESOURCES resource.postgresql.database_port=$database_port"
-fi
-if [ -n "$database_name" ]; then
-    PG_RESOURCES="$PG_RESOURCES resource.postgresql.database_name=$database_name"
+if [ -n "$database_url" ]; then
+    echo database_url is present, specifying parameters on the command line is not necessary
+else
+    # This clause is all legacy and can be removed once we switch to use database_url in config
+    if [ -n "$database_hostname" ]; then
+        PG_RESOURCES="$PG_RESOURCES resource.postgresql.database_hostname=$database_hostname"
+    fi
+    if [ -n "$database_username" ]; then
+        PG_RESOURCES="$PG_RESOURCES secrets.postgresql.database_username=$database_username"
+    fi
+    if [ -n "$database_password" ]; then
+        PG_RESOURCES="$PG_RESOURCES secrets.postgresql.database_password=$database_password"
+    fi
+    if [ -n "$database_port" ]; then
+        PG_RESOURCES="$PG_RESOURCES resource.postgresql.database_port=$database_port"
+    fi
+    if [ -n "$database_name" ]; then
+        PG_RESOURCES="$PG_RESOURCES resource.postgresql.database_name=$database_name"
+    fi
 fi
 
 RMQ_RESOURCES=""
@@ -84,11 +89,11 @@ for file in *.py.dist; do
 done
 popd
 
-PYTHONPATH=$PYTHONPATH $SETUPDB --database_name=socorro_integration_test --database_username=$database_username --database_hostname=$database_hostname --database_password=$database_password --database_port=$database_port --database_superusername=$database_superusername --database_superuserpassword=$database_superuserpassword --dropdb --logging.stderr_error_logging_level=40 --unlogged --no_staticdata
+PYTHONPATH=$PYTHONPATH $SETUPDB --database_name=socorro_integration_test --dropdb --logging.stderr_error_logging_level=40 --unlogged --no_staticdata
 
-PYTHONPATH=$PYTHONPATH $SETUPDB --database_name=socorro_test --database_username=$database_username --database_hostname=$database_hostname --database_password=$database_password --database_port=$database_port --database_superusername=$database_superusername --database_superuserpassword=$database_superuserpassword --dropdb --no_schema --logging.stderr_error_logging_level=40 --unlogged --no_staticdata
+PYTHONPATH=$PYTHONPATH $SETUPDB --database_name=socorro_test --dropdb --no_schema --logging.stderr_error_logging_level=40 --unlogged --no_staticdata
 
-PYTHONPATH=$PYTHONPATH $SETUPDB --database_name=socorro_migration_test --database_username=$database_username --database_hostname=$database_hostname --database_password=$database_password --database_port=$database_port --database_superusername=$database_superusername --database_superuserpassword=$database_superuserpassword --dropdb --logging.stderr_error_logging_level=40 --unlogged
+PYTHONPATH=$PYTHONPATH $SETUPDB --database_name=socorro_migration_test --dropdb --logging.stderr_error_logging_level=40 --unlogged
 
 PYTHONPATH=$PYTHONPATH ${VIRTUAL_ENV}/bin/alembic -c config/alembic.ini downgrade -1
 PYTHONPATH=$PYTHONPATH ${VIRTUAL_ENV}/bin/alembic -c config/alembic.ini upgrade heads

--- a/socorro/database/database.py
+++ b/socorro/database/database.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import urlparse
 
 import psycopg2
 import psycopg2.extensions

--- a/socorro/external/postgresql/postgresqlalchemymanager.py
+++ b/socorro/external/postgresql/postgresqlalchemymanager.py
@@ -12,19 +12,16 @@ import cStringIO
 import logging
 import os
 import re
-import sys
 from glob import glob
 
 from alembic import command
 from alembic.config import Config
-from configman import Namespace
 from psycopg2 import ProgrammingError
 from sqlalchemy import create_engine, exc
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.schema import CreateTable
 
-from socorro.app.generic_app import App, main as configman_main
 from socorro.external.postgresql import staticdata, fakedata
 from socorro.external.postgresql.models import *
 

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -14,10 +14,12 @@ import os
 import re
 import sys
 from glob import glob
+from collections import defaultdict
+
 
 from alembic import command
 from alembic.config import Config
-from configman import Namespace
+from configman import Namespace, class_converter
 from psycopg2 import ProgrammingError
 from sqlalchemy import create_engine, exc
 from sqlalchemy.ext.compiler import compiles
@@ -26,8 +28,13 @@ from sqlalchemy.schema import CreateTable
 
 from socorro.app.socorro_app import App, main
 from socorro.external.postgresql import staticdata, fakedata
+from socorro.external.postgresql.connection_context import (
+    get_field_from_pg_database_url
+)
 from socorro.external.postgresql.models import *
-from socorro.external.postgresql.postgresqlalchemymanager import PostgreSQLAlchemyManager
+from socorro.external.postgresql.postgresqlalchemymanager import (
+    PostgreSQLAlchemyManager
+)
 
 
 ###########################################
@@ -51,47 +58,25 @@ class SocorroDBApp(App):
     required_config = Namespace()
 
     required_config.add_option(
-        name='database_name',
-        default='socorro_integration_test',
-        doc='Name of database to manage',
-    )
-
-    required_config.add_option(
-        name='database_hostname',
-        default='localhost',
-        doc='Hostname to connect to database',
-    )
-
-    required_config.add_option(
-        name='database_username',
-        default='breakpad_rw',
-        doc='Username to connect to database',
-    )
-
-    required_config.add_option(
-        name='database_password',
-        default='aPassword',
-        doc='Password to connect to database',
-        secret=True,
+        'database_class',
+        default=
+            'socorro.external.postgresql.connection_context.ConnectionContext',
+        doc='the class responsible for connecting to Postgres',
+        reference_value_from='resource.postgresql',
+        from_string_converter=class_converter
     )
 
     required_config.add_option(
         name='database_superusername',
-        default='test',
+        default=get_field_from_pg_database_url('username', 'test'),
         doc='Username to connect to database',
     )
 
     required_config.add_option(
         name='database_superuserpassword',
-        default='aPassword',
+        default=get_field_from_pg_database_url('password', 'aPassword'),
         doc='Password to connect to database',
         secret=True,
-    )
-
-    required_config.add_option(
-        name='database_port',
-        default='',
-        doc='Port to connect to database',
     )
 
     required_config.add_option(
@@ -233,9 +218,38 @@ class SocorroDBApp(App):
             """, dict(zip(["one", "two", "three", "four"],
                       list(fakedata.featured_versions))))
 
-    def main(self):
+    def construct_db_url(self, dbname=None, superuser=False):
+        """Takes a URL to connect to Postgres and updates database name
+            or superuser name/password as indicated
+           from PG Docs:
+           postgresql://[user[:password]@][netloc][:port][/dbname]"""
+        database_username = self.config.get('database_username')
+        database_password = self.config.get('database_password')
+        database_hostname = self.config.get('database_hostname')
+        database_port = self.config.get('database_port')
+        database_name = dbname if dbname else self.config.get('database_name')
 
-        self.database_name = self.config['database_name']
+        if superuser:
+            database_username = self.config.get('database_superusername')
+            database_password = self.config.get('database_superuserpassword')
+
+        # construct a URL
+        url = 'postgresql://'
+        if database_username:
+            url += '%s' % database_username
+            if database_password:
+                url += ':%s' % database_password
+            url += '@'
+        if database_hostname:
+            url += '%s' % database_hostname
+        if database_port:
+            url += ':%s' % database_port
+        if database_name:
+            url += '/%s' % database_name
+        return url
+
+    def main(self):
+        self.database_name = self.config.get('database_name')
         if not self.database_name:
             print "Syntax error: --database_name required"
             return 1
@@ -245,26 +259,7 @@ class SocorroDBApp(App):
 
         self.force = self.config.get('force')
 
-        def connection_url():
-            url_template = 'postgresql://'
-            if self.database_username:
-                url_template += '%s' % self.database_username
-            if self.database_password:
-                url_template += ':%s' % self.database_password
-            url_template += '@'
-            if self.database_hostname:
-                url_template += '%s' % self.database_hostname
-            if self.database_port:
-                url_template += ':%s' % self.database_port
-            return url_template
-
-        self.database_username = self.config.get('database_superusername')
-        self.database_password = self.config.get('database_superuserpassword')
-        self.database_hostname = self.config.get('database_hostname')
-        self.database_port = self.config.get('database_port')
-
-        url_template = connection_url()
-        sa_url = url_template + '/%s' % 'postgres'
+        sa_url = self.construct_db_url('postgres', True)
 
         if self.config.unlogged:
             @compiles(CreateTable)
@@ -324,7 +319,7 @@ class SocorroDBApp(App):
             connection.close()
 
         # Reconnect to set up schema, types and procs
-        sa_url = url_template + '/%s' % self.database_name
+        sa_url = self.construct_db_url(self.database_name, False)
         alembic_cfg = Config(self.config.alembic_config)
         alembic_cfg.set_main_option("sqlalchemy.url", sa_url)
         with PostgreSQLAlchemyManager(sa_url, self.config.logger) as db:

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -166,12 +166,6 @@ class MiddlewareApp(App):
     #-------------------------------------------------------------------------
     required_config.namespace('database')
     required_config.database.add_option(
-        'database_class',
-        default='socorro.external.postgresql.connection_context.'
-                'ConnectionContext',
-        from_string_converter=class_converter
-    )
-    required_config.database.add_option(
         'crashstorage_class',
         default='socorro.external.postgresql.crashstorage.'
                 'PostgreSQLCrashStorage',

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -8,6 +8,7 @@ from nose.tools import eq_, ok_, assert_raises
 from socorro.external import DatabaseError
 from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.lib import search_common, util
+from socorro.external.postgresql.connection_context import ConnectionContext
 from socorro.unittest.testbase import TestCase
 
 from .unittestbase import PostgreSQLTestCase
@@ -20,8 +21,8 @@ class TestPostgreSQLBase(TestCase):
     #--------------------------------------------------------------------------
     def get_dummy_context(self):
         """Create a dummy config object to use when testing."""
-        context = util.DotDict()
-        context.database = util.DotDict({
+        context = util.DotDict({
+            'database_class': ConnectionContext,
             'database_hostname': 'somewhere',
             'database_port': '8888',
             'database_name': 'somename',

--- a/socorro/unittest/external/postgresql/test_crashes.py
+++ b/socorro/unittest/external/postgresql/test_crashes.py
@@ -14,6 +14,7 @@ from socorro.external import (
 from socorro.external.postgresql.crashes import Crashes
 from socorro.lib import datetimeutil, util
 from socorro.unittest.testbase import TestCase
+from socorro.external.postgresql.connection_context import ConnectionContext
 
 from unittestbase import PostgreSQLTestCase
 
@@ -25,8 +26,8 @@ class TestCrashes(TestCase):
     # -------------------------------------------------------------------------
     def get_dummy_context(self):
         """Create a dummy config object to use when testing."""
-        context = util.DotDict()
-        context.database = util.DotDict({
+        context = util.DotDict({
+            'database_class': ConnectionContext,
             'database_hostname': 'somewhere',
             'database_port': '8888',
             'database_name': 'somename',
@@ -114,12 +115,14 @@ class TestCrashes(TestCase):
         # This can all be some fake crap because we're testing that
         # the implementation class throws out the request before
         # it gets to doing any queries.
-        config = {
+        config = util.DotDict({
+            'database_class': ConnectionContext,
             'database_hostname': None,
+            'database_port': None,
             'database_name': None,
             'database_username': None,
             'database_password': None,
-        }
+        })
         crashes = Crashes(config=config)
         params = {}
         params['duration'] = 31 * 24  # 31 days

--- a/socorro/unittest/external/postgresql/test_gccrashes.py
+++ b/socorro/unittest/external/postgresql/test_gccrashes.py
@@ -11,6 +11,7 @@ from socorro.external import MissingArgumentError
 from socorro.external.postgresql.gccrashes import GCCrashes
 from socorro.lib import datetimeutil, util
 from socorro.unittest.testbase import TestCase
+from socorro.external.postgresql.connection_context import ConnectionContext
 
 from unittestbase import PostgreSQLTestCase
 
@@ -22,8 +23,8 @@ class TestGCCrashes(TestCase):
     #--------------------------------------------------------------------------
     def get_dummy_context(self):
         """Create a dummy config object to use when testing."""
-        context = util.DotDict()
-        context.database = util.DotDict({
+        context = util.DotDict({
+            'database_class': ConnectionContext,
             'database_hostname': 'somewhere',
             'database_port': '8888',
             'database_name': 'somename',

--- a/socorro/unittest/external/postgresql/test_setupdb_app.py
+++ b/socorro/unittest/external/postgresql/test_setupdb_app.py
@@ -9,9 +9,195 @@ import psycopg2
 from .unittestbase import PostgreSQLTestCase
 from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
-from nose.tools import ok_
-from socorro.external.postgresql import setupdb_app
+from nose.tools import ok_, eq_
+from socorro.external.postgresql.setupdb_app import SocorroDBApp
+from socorro.unittest.testbase import TestCase
 from configman import ConfigurationManager
+from configman.dotdict import DotDict
+
+
+class NoInheritanceCheatSocorroDBApp(SocorroDBApp):
+    def __init__(self, config):
+        self.config = config
+
+
+class TestConnectionContext(TestCase):
+
+    def test_construct_db_url_no_super(self):
+        """from PG Docs:
+        postgresql://[user[:password]@][netloc][:port][/dbname]"""
+        test_cases_no_super = (
+            (
+                {
+                    'database_hostname': 'host01',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_password': 'password',
+                },
+                "postgresql://user:password@host01:port/name"
+            ),
+            (
+                {
+                    'database_hostname': 'host02',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_password': '',
+                },
+                "postgresql://user@host02:port/name"
+            ),
+            (
+                {
+                    'database_hostname': 'host03',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                },
+                "postgresql://user@host03:port/name"
+            ),
+            (
+                {
+                    'database_hostname': 'host04',
+                    'database_name': '',
+                    'database_port': 5432,
+                    'database_username': 'user',
+                },
+                "postgresql://user@host04:5432"
+            ),
+            (
+                {
+                    'database_hostname': 'host04',
+                    'database_name': '',
+                    'database_port': 5432,
+                    'database_username': 'user',
+                },
+                "postgresql://user@host04:5432"
+            ),
+        )
+        for a_config, expected_result in test_cases_no_super:
+            setup_app = NoInheritanceCheatSocorroDBApp(a_config)
+            eq_(setup_app.construct_db_url(), expected_result)
+
+    def test_construct_db_url_with_super(self):
+        """from PG Docs:
+        postgresql://[user[:password]@][netloc][:port][/dbname]"""
+        test_cases_no_super = (
+            (
+                {
+                    'database_hostname': 'host01',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_password': 'password',
+                    'database_superusername': 'superuser',
+                    'database_superuserpassword': 'superpassword',
+                },
+                "postgresql://superuser:superpassword@host01:port/name"
+            ),
+            (
+                {
+                    'database_hostname': 'host02',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_password': '',
+                    'database_superusername': 'superuser',
+                },
+                "postgresql://superuser@host02:port/name"
+            ),
+            (
+                {
+                    'database_hostname': 'host03',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_superusername': 'superuser',
+                    'database_superuserpassword': '',
+                },
+                "postgresql://superuser@host03:port/name"
+            ),
+            (
+                {
+                    'database_hostname': 'host04',
+                    'database_name': '',
+                    'database_port': 5432,
+                    'database_username': 'user',
+                    'database_superusername': 'superuser',
+                },
+                "postgresql://superuser@host04:5432"
+            ),
+            (
+                {
+                    'database_hostname': 'host04',
+                    'database_name': '',
+                    'database_port': 5432,
+                    'database_username': 'user',
+                    'database_superusername': 'superuser',
+                },
+                "postgresql://superuser@host04:5432"
+            ),
+        )
+        for a_config, expected_result in test_cases_no_super:
+            setup_app = NoInheritanceCheatSocorroDBApp(a_config)
+            eq_(setup_app.construct_db_url(None, True), expected_result)
+
+
+    def test_construct_db_url_overriding_dbname(self):
+        """from PG Docs:
+        postgresql://[user[:password]@][netloc][:port][/dbname]"""
+        test_cases_no_super = (
+            (
+                {
+                    'database_hostname': 'host01',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_password': 'password',
+                },
+                "postgresql://user:password@host01:port/mydb"
+            ),
+            (
+                {
+                    'database_hostname': 'host02',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                    'database_password': '',
+                },
+                "postgresql://user@host02:port/mydb"
+            ),
+            (
+                {
+                    'database_hostname': 'host03',
+                    'database_name': 'name',
+                    'database_port': 'port',
+                    'database_username': 'user',
+                },
+                "postgresql://user@host03:port/mydb"
+            ),
+            (
+                {
+                    'database_hostname': 'host04',
+                    'database_name': '',
+                    'database_port': 5432,
+                    'database_username': 'user',
+                },
+                "postgresql://user@host04:5432/mydb"
+            ),
+            (
+                {
+                    'database_hostname': 'host04',
+                    'database_name': '',
+                    'database_port': 5432,
+                    'database_username': 'user',
+                },
+                "postgresql://user@host04:5432/mydb"
+            ),
+        )
+        for a_config, expected_result in test_cases_no_super:
+            setup_app = NoInheritanceCheatSocorroDBApp(a_config)
+            eq_(setup_app.construct_db_url("mydb"), expected_result)
 
 
 @attr(integration='postgres')
@@ -68,7 +254,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
             extra_value_source = {}
         mock_logging = mock.Mock()
 
-        required_config = setupdb_app.SocorroDBApp.required_config
+        required_config = SocorroDBApp.required_config
         required_config.add_option('logger', default=mock_logging)
 
         # We manually set the database_name to something deliberately
@@ -99,7 +285,7 @@ class IntegrationTestSetupDB(PostgreSQLTestCase):
         raise SkipTest
         config_manager = self._setup_config_manager({'dropdb': True})
         with config_manager.context() as config:
-            db = setupdb_app.SocorroDBApp(config)
+            db = SocorroDBApp(config)
             db.main()
 
             # we can't know exactly because it would be tedious to have to

--- a/socorro/unittest/external/postgresql/unittestbase.py
+++ b/socorro/unittest/external/postgresql/unittestbase.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import socorro.database.database as db
+from socorro.external.postgresql.connection_context import ConnectionContext
 from configman import ConfigurationManager, Namespace
-from configman.converters import list_converter
+from configman.converters import list_converter, class_converter
 from socorro.unittest.testbase import TestCase
 
 
@@ -17,29 +17,14 @@ class PostgreSQLTestCase(TestCase):
     metadata = ''
 
     required_config = Namespace()
-    required_config.namespace('database')
-    required_config.add_option(
-        name='database_name',
-        default='socorro_integration_test',
-        doc='Name of database to manage',
-    )
 
+    # we use this class here because it is a convenient way to pull in
+    # both a database connection context and a transaction executor
     required_config.add_option(
-        name='database_hostname',
-        default='localhost',
-        doc='Hostname to connect to database',
-    )
-
-    required_config.add_option(
-        name='database_username',
-        default='test',
-        doc='Username to connect to database',
-    )
-
-    required_config.add_option(
-        name='database_password',
-        default='aPassword',
-        doc='Password to connect to database',
+        'crashstorage_class',
+        default='socorro.external.postgresql.crashstorage.'
+                'PostgreSQLCrashStorage',
+        from_string_converter=class_converter
     )
 
     required_config.add_option(
@@ -52,12 +37,6 @@ class PostgreSQLTestCase(TestCase):
         name='database_superuserpassword',
         default='aPassword',
         doc='Password to connect to database',
-    )
-
-    required_config.add_option(
-        name='database_port',
-        default='',
-        doc='Port to connect to database',
     )
 
     required_config.add_option(
@@ -119,7 +98,7 @@ class PostgreSQLTestCase(TestCase):
         case (aka. test class).
         """
         cls.config = cls.get_standard_config()
-        cls.database = db.Database(cls.config)
+        cls.database = ConnectionContext(cls.config)
         cls.connection = cls.database.connection()
 
     @classmethod

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -28,23 +28,9 @@ from socorro.external import (
 )
 from socorro.lib import datetimeutil
 from socorro.middleware import middleware_app
-from socorro.unittest.config.commonconfig import (
-    databaseHost,
-    databaseName,
-    databaseUserName,
-    databasePassword
-)
 from socorro.unittest.testbase import TestCase
 from socorro.webapi.servers import CherryPy
 from socorro.webapi.servers import WebServerBase
-
-
-DSN = {
-    "database.database_hostname": databaseHost.default,
-    "database.database_name": databaseName.default,
-    "database.database_username": databaseUserName.default,
-    "database.database_password": databasePassword.default
-}
 
 
 class MyWSGIServer(WebServerBase):
@@ -478,7 +464,6 @@ class IntegrationTestMiddlewareApp(TestCase):
             values_source_list=[
                 {'logger': mock_logging},
                 environment,
-                DSN,
             ],
             argv_source=[]
         )
@@ -561,7 +546,6 @@ class IntegrationTestMiddlewareApp(TestCase):
             values_source_list=[
                 {'logger': mock_logging},
                 environment,
-                DSN,
                 extra_value_source
             ],
             argv_source=[]


### PR DESCRIPTION
This PR enables the PG ConnectionContext classes to use a PG URL existing as an environment variable ```database_url``` to prime the configuration defaults.  For example if the environment variable is: ```postgres://test:aPassword@localhost:5432/socorro_migration_test```, then the class ```socorro.external.postgresql.connection_context.ConnectionContext``` will have the following defaults automatically:
``` python
database_hostname=localhost
database_username=test
database_password=aPassword
database_port=5432
database_name=socorro_migration_test
```
 It also facilitates removing the old ```socorro.database.Database``` class from the middleware.  The middleware integration tests are now also free of the dreaded ```.../unittest/confg/commonconfig.py```.  