### PR TITLE
Fixes bug 1000160 - Set the correct version number in processed crashes.

### DIFF
--- a/alembic/versions/56f5cdf9bcdb_bug_1000160_use_version_string_instead_.py
+++ b/alembic/versions/56f5cdf9bcdb_bug_1000160_use_version_string_instead_.py
@@ -1,0 +1,26 @@
+"""bug 1000160 - Use version_string instead of release_version in update_reports_clean.
+
+Revision ID: 56f5cdf9bcdb
+Revises: 3f03539b66de
+Create Date: 2015-04-29 15:01:50.954659
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '56f5cdf9bcdb'
+down_revision = '3f03539b66de'
+
+from alembic import op
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
+
+import sqlalchemy as sa
+from sqlalchemy import types
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table, column
+
+def upgrade():
+    load_stored_proc(op, ['001_update_reports_clean.sql'])
+
+def downgrade():
+    load_stored_proc(op, ['001_update_reports_clean.sql'])

--- a/socorro/external/postgresql/raw_sql/procs/001_update_reports_clean.sql
+++ b/socorro/external/postgresql/raw_sql/procs/001_update_reports_clean.sql
@@ -241,7 +241,7 @@ SET product_version_id = product_versions.product_version_id
 FROM product_versions, new_reports
 WHERE reports_clean_buffer.uuid = new_reports.uuid
     AND new_reports.product = product_versions.product_name
-    AND new_reports.version = product_versions.release_version
+    AND new_reports.version = product_versions.version_string
     AND reports_clean_buffer.release_channel = product_versions.build_type
     AND reports_clean_buffer.release_channel <> 'beta';
 
@@ -253,7 +253,7 @@ SET product_version_id = product_versions.product_version_id
 FROM product_versions JOIN product_version_builds USING (product_version_id), new_reports
 WHERE reports_clean_buffer.uuid = new_reports.uuid
     AND new_reports.product = product_versions.product_name
-    AND new_reports.version = product_versions.release_version
+    AND new_reports.version = product_versions.version_string
     AND reports_clean_buffer.release_channel = product_versions.build_type
     AND reports_clean_buffer.build = product_version_builds.build_id
     AND reports_clean_buffer.release_channel = 'beta';

--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -46,6 +46,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.breakpad_transform_rules.CrashingThreadRule, "
         "socorro.processor.general_transform_rules.CPUInfoRule, "
         "socorro.processor.general_transform_rules.OSInfoRule, "
+        "socorro.processor.mozilla_transform_rules.BetaVersionRule, "
         "socorro.processor.mozilla_transform_rules.ExploitablityRule, "
         "socorro.processor.mozilla_transform_rules.FlashVersionRule, "
         "socorro.processor.mozilla_transform_rules.TopMostFilesRule, "

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -351,20 +351,32 @@ class TestPostgreSQLBase(TestCase):
                     AND r.version=%(version1)s)
                 OR (r.product=%(version2)s
                     AND r.version=%(version3)s)
+                OR (r.product=%(version4)s
+                    AND r.version=%(version5)s)
+                OR (r.product=%(version6)s
+                    AND r.version=%(version7)s)
                 OR (r.release_channel ILIKE 'beta'
                     AND r.build IN ('20120101123456', '20120101098765')
-                    AND r.product=%(version4)s
-                    AND r.version=%(version5)s))
+                    AND r.product=%(version8)s
+                    AND r.version=%(version9)s)
+                OR (r.product=%(version10)s
+                    AND r.version=%(version11)s))
         """
         sql_params_exp = {
             "from_date": params.from_date,
             "to_date": params.to_date,
             "version0": "Firefox",
             "version1": "12.0",
-            "version2": "Fennec",
-            "version3": "11.0",
-            "version4": "Firefox",
-            "version5": "13.0"
+            "version2": "Firefox",
+            "version3": "12.0a1",
+            "version4": "Fennec",
+            "version5": "11.0",
+            "version6": "Fennec",
+            "version7": "11.0",
+            "version8": "Firefox",
+            "version9": "13.0",
+            "version10": "Firefox",
+            "version11": "13.0(beta)",
         }
 
         (sql, sql_params) = pgbase.build_reports_sql_where(params, sql_params,

--- a/socorro/unittest/external/postgresql/test_crashes.py
+++ b/socorro/unittest/external/postgresql/test_crashes.py
@@ -605,13 +605,27 @@ class IntegrationTestCrashes(PostgreSQLTestCase):
             "signature": "cool_sig",
             "versions": "WaterWolf:2.0b",
         }
+        res_expected = {
+            'hits': [
+                {
+                    'email': None,
+                    'date_processed': today,
+                    'uuid': 'qrs',
+                    'user_comments': 'meow'
+                }
+            ],
+            'total': 1
+        }
 
         res = crashes.get_comments(**params)
-        ok_(res)
-        eq_(len(res['hits']), 2)
-        eq_(res['total'], 2)
+        eq_(res, res_expected)
 
         # use pagination
+        params = {
+            "signature": "cool_sig",
+            "result_number": 1,
+            "result_offset": 0,
+        }
         params['result_number'] = 1
         params['result_offset'] = 0
         res = crashes.get_comments(**params)


### PR DESCRIPTION
@twobraids Does this look good to you? 

Note that this is not ready to be merged yet. I need to figure out a transition plan, and to modify a bunch of code related to those version numbers. 