### PR TITLE
bug 1155504 - support apache-style userdirs for crash-analysis

### DIFF
--- a/config/package/nginx/conf.d/socorro-analysis.conf
+++ b/config/package/nginx/conf.d/socorro-analysis.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name crash-analysis;
+
+    # Support Apache-style userdirs
+    # see: http://wiki.nginx.org/UserDir
+    location ~ ^/~(.+?)(/.*)?$ {
+        alias /home/$1/public_html$2;
+        index  index.html index.htm;
+        autoindex on;
+    }
+}


### PR DESCRIPTION
r? @jdotpz - nginx config similar to existing Apache on https://crash-analysis.mozilla.com/