### PR TITLE
bug 1155504 - enable autoindex for crash-analysis

### DIFF
--- a/config/package/nginx/conf.d/socorro-analysis.conf
+++ b/config/package/nginx/conf.d/socorro-analysis.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name crash-analysis;
+
+    location / {
+        index index.html index.htm;
+        autoindex on;
+    }
+}


### PR DESCRIPTION
@phrawzty I think this is what we really need for https://crash-analysis.mozilla.com