### PR TITLE
(no bug) fix syntax error in example nginx config files

### DIFF
--- a/config/package/nginx/conf.d/socorro-collector.conf
+++ b/config/package/nginx/conf.d/socorro-collector.conf
@@ -3,7 +3,7 @@ server {
     server_name crash-reports;
 
     # crash-reports needs to accept potentially large minidumps
-    client_max_body_size = 20m;
+    client_max_body_size 20m;
 
     location / {
         uwsgi_pass unix:/var/run/uwsgi/socorro-collector.sock;

--- a/config/package/nginx/conf.d/socorro-webapp.conf
+++ b/config/package/nginx/conf.d/socorro-webapp.conf
@@ -3,7 +3,7 @@ server {
     server_name crash-stats;
 
     # crash-stats needs to accept debug symbol zips
-    client_max_body_size = 1g;
+    client_max_body_size 1g;
 
     location / {
         uwsgi_pass unix:/var/run/uwsgi/socorro-webapp.sock;


### PR DESCRIPTION
r? @jdotpz just updated stage and discovered I got this wrong