### PR TITLE
Bug 1156321 attributeerror on connectionrollback in postgres base

### DIFF
--- a/socorro/external/postgresql/base.py
+++ b/socorro/external/postgresql/base.py
@@ -43,16 +43,15 @@ class PostgreSQLBase(object):
         """
         self.context = kwargs.get("config")
         try:
-            self.database =  self.context.database_class(
+            self.database = self.context.database_class(
                 self.context
             )
         except KeyError:
             # some tests seem to put the database config parameters
             # into a namespace called 'database', others do not
-            self.database =  self.context.database.database_class(
+            self.database = self.context.database.database_class(
                 self.context.database
             )
-
 
     @contextlib.contextmanager
     def get_connection(self):
@@ -89,7 +88,8 @@ class PostgreSQLBase(object):
                 error_message = "Failed to execute query against PostgreSQL"
             error_message = "%s - %s" % (error_message, str(e))
             logger.error(error_message, exc_info=True)
-            connection.rollback()
+            if connection:
+                connection.rollback()
             raise DatabaseError(error_message)
         finally:
             if connection and fresh_connection:
@@ -124,7 +124,8 @@ class PostgreSQLBase(object):
                 error_message = "Failed to execute count against PostgreSQL"
             error_message = "%s - %s" % (error_message, str(e))
             logger.error(error_message, exc_info=True)
-            connection.rollback()
+            if connection:
+                connection.rollback()
             raise DatabaseError(error_message)
         finally:
             if connection and fresh_connection:

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import mock
 from nose.plugins.attrib import attr
 from nose.tools import eq_, ok_, assert_raises
 
@@ -690,3 +691,35 @@ class IntegrationTestBase(PostgreSQLTestCase):
         # A failing count
         sql = 'SELECT count(`invalid_field_name`) FROM reports'
         assert_raises(DatabaseError, base.count, sql)
+
+    #--------------------------------------------------------------------------
+    @mock.patch('socorro.external.postgresql.base.logger')
+    def test_query_with_bad_connection(self, p_logger):
+        # screw with it, so that it fails to make a connection
+        self.config['database_name'] = 'gobblygook'
+        base = PostgreSQLBase(config=self.config)
+        assert_raises(
+            DatabaseError,
+            base.query,
+            'select * from reports'
+        )
+        p_logger.error.assert_called_with(
+            'Failed to execute query against PostgreSQL - FATAL:  '
+            'database "gobblygook" does not exist\n', exc_info=True
+        )
+
+    #--------------------------------------------------------------------------
+    @mock.patch('socorro.external.postgresql.base.logger')
+    def test_count_with_bad_connection(self, p_logger):
+        # screw with it, so that it fails to make a connection
+        self.config['database_name'] = 'gobblygook'
+        base = PostgreSQLBase(config=self.config)
+        assert_raises(
+            DatabaseError,
+            base.count,
+            'select count(*) from reports'
+        )
+        p_logger.error.assert_called_with(
+            'Failed to execute count against PostgreSQL - FATAL:  '
+            'database "gobblygook" does not exist\n', exc_info=True
+        )

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -695,31 +695,39 @@ class IntegrationTestBase(PostgreSQLTestCase):
     #--------------------------------------------------------------------------
     @mock.patch('socorro.external.postgresql.base.logger')
     def test_query_with_bad_connection(self, p_logger):
+        before = self.config['database_name']
         # screw with it, so that it fails to make a connection
         self.config['database_name'] = 'gobblygook'
-        base = PostgreSQLBase(config=self.config)
-        assert_raises(
-            DatabaseError,
-            base.query,
-            'select * from reports'
-        )
-        p_logger.error.assert_called_with(
-            'Failed to execute query against PostgreSQL - FATAL:  '
-            'database "gobblygook" does not exist\n', exc_info=True
-        )
+        try:
+            base = PostgreSQLBase(config=self.config)
+            assert_raises(
+                DatabaseError,
+                base.query,
+                'select * from reports'
+            )
+            p_logger.error.assert_called_with(
+                'Failed to execute query against PostgreSQL - FATAL:  '
+                'database "gobblygook" does not exist\n', exc_info=True
+            )
+        finally:
+            self.config['database_name'] = before
 
     #--------------------------------------------------------------------------
     @mock.patch('socorro.external.postgresql.base.logger')
     def test_count_with_bad_connection(self, p_logger):
+        before = self.config['database_name']
         # screw with it, so that it fails to make a connection
         self.config['database_name'] = 'gobblygook'
-        base = PostgreSQLBase(config=self.config)
-        assert_raises(
-            DatabaseError,
-            base.count,
-            'select count(*) from reports'
-        )
-        p_logger.error.assert_called_with(
-            'Failed to execute count against PostgreSQL - FATAL:  '
-            'database "gobblygook" does not exist\n', exc_info=True
-        )
+        try:
+            base = PostgreSQLBase(config=self.config)
+            assert_raises(
+                DatabaseError,
+                base.count,
+                'select count(*) from reports'
+            )
+            p_logger.error.assert_called_with(
+                'Failed to execute count against PostgreSQL - FATAL:  '
+                'database "gobblygook" does not exist\n', exc_info=True
+            )
+        finally:
+            self.config['database_name'] = before


### PR DESCRIPTION
r? @twobraids 

I actually think we can refactor even more. I don't like that the big fat `try: ... except psycopg2.Error` block encompasses more than 1 thing. However, the DRY was a bigger violation for now. 

This is actually a fairly high priority fix because it without it we'll never have constructive error messages when the connection can't be made. 