### PR TITLE
fixes Bug 1159776 - stop existing 'dump_checksums' in raw crashes from causing trouble

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -68,7 +68,8 @@ class BreakpadCollector(RequiredConfig):
         raw_crash.dump_checksums = DotDict()
         for name, value in form.iteritems():
             if isinstance(value, basestring):
-                raw_crash[name] = value
+                if name != "dump_checksums":
+                    raw_crash[name] = value
             elif hasattr(value, 'file') and hasattr(value, 'value'):
                 dumps[name] = value.value
                 raw_crash.dump_checksums[name] = \

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -241,6 +241,7 @@ class TestCollectorApp(TestCase):
         rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
         rawform.legacy_processing = str(DEFER)
         rawform.throttle_rate = 100
+        rawform.dump_checksums = "this is poised to overwrite and cause trouble"
 
         form = DotDict(rawform)
         form.dump = rawform.dump.value


### PR DESCRIPTION
raw crashes that already have a "dump_checksums" when resubmitted will cause trouble in collection.  The value will overwrite the new checksums being created by collector, causing a TypeError. 

