### PR TITLE
Docs typo in es config

### DIFF
--- a/docs/configuring-socorro.rst
+++ b/docs/configuring-socorro.rst
@@ -93,7 +93,7 @@ Graphs and reports using Elasticsearch and Kibana
 Processor supports putting crashes into Elasticsearch, you can enable this
 via configuration by inserting these keys into Consul::
 
-  curl -s -X PUT -d "socorro.external.es.crashstorage.ESCrashStorage" localhost:8500/v1/kv/socorro/processor/destination.storage0.crashstorage_class
+  curl -s -X PUT -d "socorro.external.es.crashstorage.ESCrashStorage" localhost:8500/v1/kv/socorro/processor/destination.crashstorage_class
   curl -s -X PUT -d "localhost" localhost:8500/v1/kv/socorro/common/resource.elasticsearch.elasticSearchHostname
 
 No need to restart socorro-processor, envconsul will take care of this.


### PR DESCRIPTION
r? @twobraids - I have a typo in the new docs so the ES config doesn't actually work as-is.

Note that `PolyCrashStorage` is introduced later in this document, I wanted to keep it simple here and just override the primary destination crash storage class.