### PR TITLE
fixes bug 1159993 - rewrite release channel for certain Fennec

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -18,6 +18,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.mozilla_transform_rules.PluginContentURL,"
         "socorro.processor.mozilla_transform_rules.PluginUserComment,"
         "socorro.processor.mozilla_transform_rules.WebAppRuntime"
+        "socorro.processor.mozilla_transform_rules.FennecBetaError20150430"
 
     ],
     [   # rules to transform a raw crash into a processed crash

--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -17,7 +17,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.mozilla_transform_rules.ESRVersionRewrite,"
         "socorro.processor.mozilla_transform_rules.PluginContentURL,"
         "socorro.processor.mozilla_transform_rules.PluginUserComment,"
-        "socorro.processor.mozilla_transform_rules.WebAppRuntime"
+        "socorro.processor.mozilla_transform_rules.WebAppRuntime,"
         "socorro.processor.mozilla_transform_rules.FennecBetaError20150430"
 
     ],

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -922,3 +922,24 @@ class BetaVersionRule(Rule):
         except KeyError:
             return False
         return True
+
+
+#==============================================================================
+class FennecBetaError20150430(Rule):
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '1.0'
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return raw_crash['ProductName'].startswith('Fennec') and \
+            raw_crash['BuildID'] == '20150427090529' and \
+            raw_crash['ReleaseChannel'] == 'release'
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        raw_crash['ReleaseChannel'] = 'beta'
+        return True
+
+


### PR DESCRIPTION
add new rule to rewrite the release channel for fennec to 'beta' when (product name == Fennec and build_id == 20150427090529 and channel == 'release')