### PR TITLE
bug 1160603 - use a simpler default for symbols, do not hardcode mozilla...

### DIFF
--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -59,11 +59,7 @@ class BreakpadStackwalkerRule(Rule):
         'processor_symbols_pathname_list',
         doc='comma or space separated list of symbol files for '
         'minidump_stackwalk (quote paths with embedded spaces)',
-        default='/mnt/socorro/symbols/symbols_ffx,'
-        '/mnt/socorro/symbols/symbols_sea,'
-        '/mnt/socorro/symbols/symbols_tbrd,'
-        '/mnt/socorro/symbols/symbols_sbrd,'
-        '/mnt/socorro/symbols/symbols_os',
+        default='/home/socorro/symbols',
         from_string_converter=_create_symbol_path_str
     )
     required_config.add_option(


### PR DESCRIPTION
... products

r? @twobraids - I mentioned this over in https://github.com/mozilla/socorro/pull/2766/files#r29558442 - we shouldn't harcode Mozilla paths in here in any case, and we decided for S3 to go with a flat namespace for all products and we don't use any of these paths ourselves anymore.

Anyone setting up a Socorro install from scratch today I'd advise to just put all symbols into a flat namespace somewhere easy like `~socorro/symbols/`.