### PR TITLE
Bug 1162287 - Update forced versions for correlations for Firefox cycle starting 2015-04-12

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="38.0 39.0a2 40.0a1"
+MANUAL_VERSION_OVERRIDE="38.0.5 39.0 40.0a2 41.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
The next version of our usual correlation version bump. Should go into production in the week of 2014-04-11.

Note that I'm adding the intermediary 38.0.5 version this time as we'll have that on beta for the next weeks and only then will have 39.0 betas, and we should make sure both are covered in correlations while they're on beta.