### PR TITLE
fixes bug 1164465 - psycopg2 2.5.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,8 @@ lxml==3.4.1
 pgxnclient==1.2.1
 # sha256: Zm_VIvShBZ1bi0mW5Xb6eGL1BVKOEc8e9VRjEcYMPk0
 pika==0.9.8
-# sha256: SLcCp8pHnhvCwae4GHWgfUdCmBMmBZk-LLl59eCCd9c
-psycopg2==2.4.5
+# sha256: xsMwyYqwjFY58MzX4hG4Kzo58AGBPc6mu4JKmdKzT-I
+psycopg2==2.5.5
 # sha256: U6gisBsElN-WWMBOhyFhgOXsvoWxeGc92Eix-AnVwQA
 # sha256: u5PYXKflDWjkGXhSu226YJi7dyUA-C9dsv9KgHEVBck
 elasticsearch==1.2

--- a/socorro/external/postgresql/connection_context.py
+++ b/socorro/external/postgresql/connection_context.py
@@ -153,7 +153,7 @@ class ConnectionContext(RequiredConfig):
         pass
 
     #--------------------------------------------------------------------------
-    def is_operational_exception(self, msg):
+    def is_operational_exception(self, exp):
         """return True if a conditional exception is actually an operational
         error. Return False if it's a genuine error that should probably be
         raised and propagate up.
@@ -162,16 +162,17 @@ class ConnectionContext(RequiredConfig):
         operational exception "labelled" wrong by the psycopg2 code error
         handler.
         """
-        if msg.pgerror in ('SSL SYSCALL error: EOF detected', ):
-            # Ideally we'd like to check against msg.pgcode values
+        message = exp.args[0]
+        if message in ('SSL SYSCALL error: EOF detected', ):
+            # Ideally we'd like to check against exp.pgcode values
             # but certain odd ProgrammingError exceptions don't have
             # pgcodes so we have to rely on reading the pgerror :(
             return True
 
         if (
-            isinstance(msg, psycopg2.OperationalError) and msg.pgerror not in (
-            'out of memory',
-        )):
+            isinstance(exp, psycopg2.OperationalError) and
+            message not in ('out of memory',)
+        ):
             return True
 
         # at the of writing, the list of exceptions is short but this would be

--- a/socorro/external/postgresql/crashstorage.py
+++ b/socorro/external/postgresql/crashstorage.py
@@ -419,8 +419,7 @@ class PostgreSQLCrashStorage(CrashStorageBase):
         fetch_sql = 'select processed_crash from %s where uuid = %%s' % \
                     processed_crash_table_name
         try:
-            crash = single_value_sql(connection, fetch_sql, (crash_id,))
-            return json.loads(crash)
+            return single_value_sql(connection, fetch_sql, (crash_id,))
         except ProgrammingError, e:
             err = 'relation "%s" does not exist' % processed_crash_table_name
             if err in str(e):

--- a/socorro/external/postgresql/crontabber_state.py
+++ b/socorro/external/postgresql/crontabber_state.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
 import logging
 
 from socorro.external.postgresql.base import PostgreSQLBase
@@ -62,8 +61,5 @@ class CrontabberState(PostgreSQLBase):
                 if value is None:
                     continue
                 state[app_name][key] = datetimeutil.date_to_string(value)
-            state[app_name]['last_error'] = json.loads(
-                state[app_name]['last_error']
-            )
 
         return {"state": state}

--- a/socorro/external/postgresql/field.py
+++ b/socorro/external/postgresql/field.py
@@ -48,6 +48,5 @@ class Field(PostgreSQLBase):
             return field_data
 
         field_data = dict(zip(('name', 'transforms', 'product'), results[0]))
-        field_data['transforms'] = json.loads(field_data['transforms'])
 
         return field_data

--- a/socorro/external/postgresql/report.py
+++ b/socorro/external/postgresql/report.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
 import logging
 
 from socorro.external import MissingArgumentError, BadArgumentError
@@ -296,8 +295,6 @@ class Report(PostgreSQLBase):
         crashes = []
         for row in results:
             crash = dict(zip(fields, row))
-            if include_raw_crash and crash['raw_crash']:
-                crash['raw_crash'] = json.loads(crash['raw_crash'])
             for i in crash:
                 try:
                     crash[i] = datetimeutil.date_to_string(crash[i])

--- a/socorro/unittest/database/test_transaction_executor.py
+++ b/socorro/unittest/database/test_transaction_executor.py
@@ -231,9 +231,7 @@ class TestTransactionExecutor(TestCase):
                 # so after 2 + 4 + 6 + 10 + 15 seconds
                 # all will be exhausted
                 if sum(_sleep_count) < sum([2, 4, 6, 10, 15]):
-                    o =  psycopg2.OperationalError('Arh!')
-                    o.pgerror = ''
-                    raise o
+                    raise psycopg2.OperationalError('Arh!')
 
             def mock_sleep(n):
                 _sleep_count.append(n)
@@ -296,9 +294,7 @@ class TestTransactionExecutor(TestCase):
                 # so after 2 + 4 + 6 + 10 + 15 seconds
                 # all will be exhausted
                 if sum(_sleep_count) < sum([2, 4, 6, 10, 15]):
-                    o =  psycopg2.OperationalError('Arh!')
-                    o.pgerror = ''
-                    raise o
+                    raise psycopg2.OperationalError('Arh!')
 
             def mock_sleep(n):
                 _sleep_count.append(n)
@@ -360,9 +356,9 @@ class TestTransactionExecutor(TestCase):
                 # so after 2 + 4 + 6 + 10 + 15 seconds
                 # all will be exhausted
                 if sum(_sleep_count) < sum([2, 4, 6, 10, 15]):
-                    exp = psycopg2.ProgrammingError()
-                    exp.pgerror = 'SSL SYSCALL error: EOF detected'
-                    raise exp
+                    raise psycopg2.ProgrammingError(
+                        'SSL SYSCALL error: EOF detected'
+                    )
 
             def mock_sleep(n):
                 _sleep_count.append(n)
@@ -500,5 +496,3 @@ class TestTransactionExecutor(TestCase):
             eq_(commit_count, 0)
             eq_(rollback_count, 1)
             ok_(not mock_logging.errors)
-
-

--- a/socorro/unittest/external/postgresql/test_crash_data.py
+++ b/socorro/unittest/external/postgresql/test_crash_data.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
 from nose.tools import eq_, ok_, assert_raises
 from configman import ConfigurationManager, Namespace
 from mock import Mock
@@ -152,14 +151,13 @@ class TestIntegrationPostgresCrashData(TestCase):
 
             # get a raw crash
             params['datatype'] = 'meta'
-            res_expected = json.dumps({
+            res_expected = {
                 'name': 'Peter',
                 'legacy_processing': 0,
                 'submitted_timestamp': '2012-03-15T00:00:00',
                 'uuid': '114559a5-d8e6-428c-8b88-1c1f22120314'
-            })
+            }
             res = service.get(**params)
-
             eq_(res, res_expected)
 
             # get a processed crash


### PR DESCRIPTION
@twobraids r?
cc @rhelmer 
So, the major difference between psycopg2 2.4 and 2.5 (as far as I can see it affecting us) is...

* When you query a table that has a `json` column, what you get is a dict (or whatever is appropriate). Not a string that is JSON text that you need to convert with `json.loads()`. crontabber supports both old and new versions of psycopg2 because it does [this trick](https://github.com/mozilla/crontabber/blob/11bcf6e2e73b1f660ad736142ef52c32affc2170/crontabber/app.py#L245-L246) which makes it more agnostic.
* The actual error from within postgres gets put into exceptions the normal way. No more of this `some_exception.pgcode` or `some_exception.pgerror` See

```python
>>> import psycopg2
>>> psycopg2.__version__
'2.5.5 (dt dec pq3 ext)'
>>> try:
...   psycopg2.connect("dbname='foo'")
... except psycopg2.OperationalError as x:
...   exception = x
...
>>> exception.args[0]
'FATAL:  database "foo" does not exist\n'
>>> dir(exception)
['__class__', '__delattr__', '__dict__', '__doc__', '__format__', '__getattribute__', '__getitem__', '__getslice__', '__hash__', '__init__', '__module__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setstate__', '__sizeof__', '__str__', '__subclasshook__', '__unicode__', '__weakref__', 'args', 'cursor', 'diag', 'message', 'pgcode', 'pgerror']
>>> exception.pgcode
>>> exception.pgerror
>>>
```

However, I'm not 100% certain that this is what it will do if you get one of those strange `SSL SYSCALL error: EOF detected` errors wrapped in a `ProgrammingError` exception. 