### PR TITLE
fixes bug 1164922 - laglog sometimes chokes on null

### DIFF
--- a/socorro/cron/jobs/laglog.py
+++ b/socorro/cron/jobs/laglog.py
@@ -47,7 +47,26 @@ class LagLog(BaseCronApp):
             'replication database servers: %s',
             each_server
         )
+        # print "self.config", repr(self.config)
         for now, client_addr, sent_location, replay_location in each_server:
+            if sent_location is None:
+                self.config.logger.warning(
+                    'sent_location comes back as NULL from '
+                    'pg_stat_replication (now:%s, database:%s)' % (
+                        now,
+                        self.config.database.database_name
+                    )
+                )
+                continue
+            if replay_location is None:
+                self.config.logger.warning(
+                    'replay_location comes back as NULL from '
+                    'pg_stat_replication (now:%s, database:%s)' % (
+                        now,
+                        self.config.database.database_name
+                    )
+                )
+                continue
             sent_location = self.xlog_transform(sent_location)
             replay_location = self.xlog_transform(replay_location)
             lag = sent_location - replay_location

--- a/socorro/unittest/cron/jobs/test_laglog.py
+++ b/socorro/unittest/cron/jobs/test_laglog.py
@@ -5,12 +5,16 @@
 import datetime
 
 import mock
+from nose.tools import eq_
 
 from socorro.cron.jobs.laglog import LagLog
-from socorro.lib.util import SilentFakeLogger
 from socorro.unittest.testbase import TestCase
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,
+)
+from socorro.external.postgresql.dbapi2_util import (
+    execute_no_results,
+    execute_query_fetchall,
 )
 
 from configman.dotdict import DotDict
@@ -18,75 +22,79 @@ from configman.dotdict import DotDict
 
 class TestLagLog(TestCase):
 
+    def setUp(self):
+        super(TestLagLog, self).setUp()
+
+        config = DotDict()
+        config.database = DotDict()
+        config.database.database_name = "mydatabase"
+        config.database.database_class = mock.Mock()
+        config.database.database_transaction_executor_class = mock.Mock()
+        self.mocked_logger = mock.Mock()
+        config.logger = self.mocked_logger
+        self.config = config
+
     def get_standard_config(self):
         return get_config_manager_for_crontabber().get_config()
 
-    def _get_mocked_config(self):
-        config = DotDict()
-        config.database = DotDict()
-        config.database.database_class = mock.Mock()
-        config.database.database_transaction_executor_class = mock.Mock()
-        config.logger = SilentFakeLogger()
-        self.config = config
-
     def test_run(self):
-        self._get_mocked_config()
-        database_transaction_return_value = [
-            [
-                (
-                    datetime.datetime(2014, 01, 22, 01, 13, 38),
-                    '192.168.168.140',
-                    '1798/552C598',
-                    '1798/5527C40'
-                ),
-                (
-                    datetime.datetime(2014, 01, 22, 01, 13, 38),
-                    '192.168.168.141',
-                    '1798/552C598',
-                    '1798/5527C40'
-                ),
-                (
-                    datetime.datetime(2014, 01, 22, 01, 13, 38),
-                    '192.168.168.142',
-                    '1798/552C598',
-                    '1798/5527C40'
-                ),
-            ],
-            None,
-            None,
-            None,
-        ]
+        inserts = []
+
+        def mocked_transaction_executor(function, sql, *args):
+            if function == execute_query_fetchall:
+                assert sql.startswith('SELECT')
+                assert not args
+                return [
+                    (
+                        datetime.datetime(2014, 01, 22, 01, 13, 38),
+                        '192.168.168.140',
+                        '1798/552C598',
+                        '1798/5527C40'
+                    ),
+                    (
+                        datetime.datetime(2014, 01, 22, 01, 13, 39),
+                        '192.168.168.140',
+                        None,
+                        '1798/5527C40'
+                    ),
+                    (
+                        datetime.datetime(2014, 01, 22, 01, 13, 40),
+                        '192.168.168.140',
+                        '1798/552C598',
+                        None
+                    ),
+                ]
+            elif function == execute_no_results:
+                assert sql.startswith('INSERT INTO')
+                inserts.append(args)
+            else:
+                raise NotImplementedError
+
         faked_transaction_executor = mock.MagicMock()
         self.config.database.database_transaction_executor_class \
             .return_value = faked_transaction_executor
-        faked_transaction_executor.return_value.side_effect = \
-            database_transaction_return_value
-        faked_connection = mock.Mock()
-        self.config.database.database_class.return_value.return_value = \
-            faked_connection
+        faked_transaction_executor.side_effect = mocked_transaction_executor
+
         laglog_app = LagLog(self.config, None)
         laglog_app.run()
-        trans_executor_calls = [
-            mock.call(
-                faked_connection,
-                laglog_app.each_server_sql
-            ),
-            mock.call(
-                faked_connection,
-                laglog_app.insert_sql,
-                database_transaction_return_value[0],
-            ),
-            mock.call(
-                faked_connection,
-                laglog_app.insert_sql,
-                database_transaction_return_value[1],
-            ),
-            mock.call(
-                faked_connection,
-                laglog_app.insert_sql,
-                database_transaction_return_value[2],
-            ),
-        ]
-        faked_transaction_executor.has_calls(
-            trans_executor_calls
+        eq_(len(inserts), 1)
+        first, = inserts[0]
+        ip, date, bytes, database_name = first
+        eq_(ip, '192.168.168.140')
+        eq_(date, datetime.datetime(2014, 01, 22, 01, 13, 38))
+
+        logid, offset = '1798/552C598'.split('/')
+        sent = int('ffffffff', 16) * int(logid, 16) + int(offset, 16)
+        logid, offset = '1798/5527C40'.split('/')
+        replay = int('ffffffff', 16) * int(logid, 16) + int(offset, 16)
+        eq_(bytes, sent - replay)
+        eq_(database_name, self.config.database.database_name)
+
+        self.config.logger.warning.assert_any_call(
+            'replay_location comes back as NULL from pg_stat_replication '
+            '(now:2014-01-22 01:13:40, database:mydatabase)'
+        )
+        self.config.logger.warning.assert_any_call(
+            'sent_location comes back as NULL from pg_stat_replication '
+            '(now:2014-01-22 01:13:39, database:mydatabase)'
         )


### PR DESCRIPTION
@twobraids r?

Note: The old tests never actually tested anything. It never iterated anything back when looping over that `each_server` result. So none of the crucial stuff was ever tested. 

This bug was about protecting against sporadic and bad NULLs coming back from `pg_stats_replication` (most likely related and due to high load or something) but I sorta kill two birds with one stone with this PR. 