### PR TITLE
fix bug 1167017 - persist /var/lock/socorro on reboot

### DIFF
--- a/config/package/usr/lib/tmpfiles.d/socorro.conf
+++ b/config/package/usr/lib/tmpfiles.d/socorro.conf
@@ -1,0 +1,1 @@
+d /run/lock/socorro 0755 socorro socorro -


### PR DESCRIPTION
@phrawzty `/var/lock/` is a symlink to `/run/lock/` now, so we need to make a `tmpfiles.d` entry to get it to persist on reboot.

I think we should ultimately switch away from custom lock/unlock function to `flock`, but we'll probably need this dir anyway.