### PR TITLE
bug 1162085 - sample config path is wrong

### DIFF
--- a/config/package/etc/nginx/conf.d/socorro-collector.conf.sample
+++ b/config/package/etc/nginx/conf.d/socorro-collector.conf.sample
@@ -6,7 +6,7 @@ server {
     client_max_body_size 20m;
 
     location / {
-        uwsgi_pass unix:/var/run/uwsgi/socorro-collector.sock;
+        uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-collector.sock;
         include uwsgi_params;
     }
 }

--- a/config/package/etc/nginx/conf.d/socorro-middleware.conf.sample
+++ b/config/package/etc/nginx/conf.d/socorro-middleware.conf.sample
@@ -3,7 +3,7 @@ server {
     server_name socorro-middleware;
 
     location / {
-        uwsgi_pass unix:/var/run/uwsgi/socorro-middleware.sock;
+        uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-middleware.sock;
         include uwsgi_params;
 
         # NOTE - this service has no access control and is not safe

--- a/config/package/etc/nginx/conf.d/socorro-webapp.conf.sample
+++ b/config/package/etc/nginx/conf.d/socorro-webapp.conf.sample
@@ -6,7 +6,7 @@ server {
     client_max_body_size 1g;
 
     location / {
-        uwsgi_pass unix:/var/run/uwsgi/socorro-webapp.sock;
+        uwsgi_pass unix:/var/run/uwsgi/socorro/socorro-webapp.sock;
         include uwsgi_params;
     }
 


### PR DESCRIPTION
The path to the uwsgi sockets in the systemd configs was changed in 1f5a4f2f946a662470ef3be077c445e082b0b22e so the path in the nginx sample configs should be too.