### PR TITLE
fixes Bug 1170168 - added statsd benchmarking wrapper

### DIFF
--- a/socorro/external/statsd/crashstorage.py
+++ b/socorro/external/statsd/crashstorage.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from statsd import StatsClient
 
 from configman import RequiredConfig, Namespace, class_converter
+from datetime import datetime
 
 
 #------------------------------------------------------------------------------
@@ -16,7 +16,7 @@ def str_to_list(string_list):
 
 
 #==============================================================================
-class StatsdCrashStorage(RequiredConfig):
+class StatsdCrashStorageBase(RequiredConfig):
     """This class is a duck typed crash storage class.  All it does is log
     the calls made to it to statsd.  It can use several different
     implementations of statsd client as specified by the 'statsd_module' and
@@ -29,12 +29,6 @@ class StatsdCrashStorage(RequiredConfig):
         default='datadog.statsd',
         reference_value_from='resource.statsd',
         from_string_converter=class_converter,
-    )
-    required_config.add_option(
-        'statsd_module_incr_method_name',
-        doc='the name of method that implements increment',
-        default='increment',
-        reference_value_from='resource.statsd',
     )
     required_config.add_option(
         'statsd_host',
@@ -54,17 +48,10 @@ class StatsdCrashStorage(RequiredConfig):
         default='save_processed',
         reference_value_from='resource.statsd',
     )
-    required_config.add_option(
-        'active_counters_list',
-        default='save_processed',
-        doc='a comma delimeted list of counters',
-        from_string_converter=str_to_list,
-        reference_value_from='resource.statsd',
-    )
 
     #--------------------------------------------------------------------------
-    def __init__(self, config):
-        super(StatsdCrashStorage, self).__init__()
+    def __init__(self, config, quit_check_callback=None):
+        super(StatsdCrashStorageBase, self).__init__()
         self.config = config
         if config.prefix:
             self.prefix = config.prefix
@@ -74,6 +61,39 @@ class StatsdCrashStorage(RequiredConfig):
             config.statsd_host,
             config.statsd_port,
         )
+
+    #--------------------------------------------------------------------------
+    def _make_name(self, *args):
+        names =  [self.prefix] if self.prefix else []
+        names.extend(list(args))
+        return '.'.join(x for x in names if x)
+
+
+#==============================================================================
+class StatsdCrashStorage(StatsdCrashStorageBase):
+    """This class is a duck typed crash storage class.  All it does is log
+    the calls made to it to statsd.  It can use several different
+    implementations of statsd client as specified by the 'statsd_module' and
+    'statsd_module_incr_method_name' configuration parameters."""
+
+    required_config = Namespace()
+    required_config.add_option(
+        'statsd_module_incr_method_name',
+        doc='the name of method that implements increment',
+        default='increment',
+        reference_value_from='resource.statsd',
+    )
+    required_config.add_option(
+        'active_counters_list',
+        default='save_processed',
+        doc='a comma delimeted list of counters',
+        from_string_converter=str_to_list,
+        reference_value_from='resource.statsd',
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, quit_check_callback=None):
+        super(StatsdCrashStorage, self).__init__(config, quit_check_callback)
         self.counter_increment = getattr(
             self.statsd,
             config.statsd_module_incr_method_name
@@ -85,13 +105,8 @@ class StatsdCrashStorage(RequiredConfig):
             self.config.statsd_host
             and name in self.config.active_counters_list
         ):
-            if self.prefix and name:
-                name = '.'.join((self.prefix, name))
-            elif self.prefix and not name:
-                name =  self.prefix
-            elif not name:
-                name = 'unknown'
-            self.counter_increment(name)
+            counter_name = self._make_name(name)
+            self.counter_increment(counter_name)
 
     #--------------------------------------------------------------------------
     def __getattr__(self, attr):
@@ -102,4 +117,54 @@ class StatsdCrashStorage(RequiredConfig):
     def _dummy_do_nothing_method(self, *args, **kwargs):
         pass
 
+
+#==============================================================================
+class StatsdBenchmarkingCrashStorage(StatsdCrashStorageBase):
+    """a wrapper around crash stores that will benchmark the calls in the logs
+    """
+    required_config = Namespace()
+    required_config.add_option(
+        name="wrapped_crashstore",
+        doc="another crash store to be benchmarked",
+        default='',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, quit_check_callback=None):
+        super(StatsdBenchmarkingCrashStorage, self).__init__(
+            config,
+            quit_check_callback
+        )
+        self.wrapped_crashstore = config.wrapped_crashstore(
+            config,
+            quit_check_callback)
+        self.start_timer = datetime.now
+        self.end_timer = datetime.now
+        self.prefixes = {}
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        """some implementations may need explicit closing."""
+        self.wrapped_crashstore.close()
+
+    #--------------------------------------------------------------------------
+    def __getattr__(self, attr):
+        # allow any AttributeError to propagate outward
+        wrapped_method = getattr(self.wrapped_crashstore, attr)
+
+        def benchmarker(*args,  **kwargs):
+            start_time = self.start_timer()
+            result = wrapped_method(*args, **kwargs)
+            end_time = self.end_timer()
+            self.statsd.timing(
+                self.prefixes.get(
+                    attr,
+                    self._make_name(self.wrapped_crashstore.__name__, attr)
+                ),
+                (end_time - start_time).microseconds
+            )
+            return result
+
+        return benchmarker
 

--- a/socorro/unittest/external/statsd/test_crashstorage.py
+++ b/socorro/unittest/external/statsd/test_crashstorage.py
@@ -2,9 +2,14 @@ from mock import patch, call, Mock
 from nose.tools import eq_, ok_, assert_raises
 from socorro.unittest.testbase import TestCase
 
+from datetime import datetime
+
 from configman.dotdict import DotDict
 
-from socorro.external.statsd.crashstorage import StatsdCrashStorage
+from socorro.external.statsd.crashstorage import (
+    StatsdCrashStorage,
+    StatsdBenchmarkingCrashStorage,
+)
 
 
 class TestStatsdCrashStorage(TestCase):
@@ -116,8 +121,82 @@ class TestStatsdCrashStorage(TestCase):
         statsd_obj.this_is_silly.assert_has_calls([])
 
 
+class TestStatsdBenchmarkingCrashStorage(TestCase):
 
+    def setup_config(self, prefix=None):
+        config =  DotDict()
+        config.statsd_module =  Mock()
+        config.statsd_host = 'some_statsd_host'
+        config.statsd_port =  3333
+        config.prefix = prefix if prefix else ''
+        config.active_counters_list = 'save_processed'
+        config.wrapped_crashstore =  Mock()
 
+        return config
 
+    def test_save(self):
+        config = self.setup_config('timing')
+        cs =  StatsdBenchmarkingCrashStorage(config)
+        now_str = 'socorro.external.statsd.crashstorage.datetime'
+        with patch(now_str) as now_mock:
+            times =  [
+                datetime(2015, 5, 4, 15, 10, 3),
+                datetime(2015, 5, 4, 15, 10, 2),
+                datetime(2015, 5, 4, 15, 10, 1),
+                datetime(2015, 5, 4, 15, 10, 0),
+            ]
+            now_mock.now.side_effect =  lambda: times.pop()
+            config.wrapped_crashstore.return_value.__name__ =  \
+                'SomeWrappedCrashStoreClass'
 
+            # the call to be tested
+            cs.save_raw_crash({}, [], 'some_id')
 
+            statsd_obj = config.statsd_module.statsd.return_value
+            statsd_timing = statsd_obj.timing
+            statsd_timing.has_calls(
+                [call(
+                    'timing.SomeWrappedCrashStoreClass.save_raw_crash',
+                    1000
+                )]
+            )
+            config.wrapped_crashstore.return_value.save_raw_crash.has_calls(
+                [call({}, [], 'some_id')]
+            )
+
+    def test_get(self):
+        config = self.setup_config('timing')
+        cs =  StatsdBenchmarkingCrashStorage(config)
+        now_str = 'socorro.external.statsd.crashstorage.datetime'
+        with patch(now_str) as now_mock:
+            times =  [
+                datetime(2015, 5, 4, 15, 10, 3),
+                datetime(2015, 5, 4, 15, 10, 2),
+                datetime(2015, 5, 4, 15, 10, 1),
+                datetime(2015, 5, 4, 15, 10, 0),
+            ]
+            now_mock.now.side_effect =  lambda: times.pop()
+            wrapped_crashstore_instance = config.wrapped_crashstore.return_value
+            wrapped_crashstore_instance.__name__ =  \
+                'SomeWrappedCrashStoreClass'
+            raw_crash = {
+                'crash_id': 'some_id',
+                'data': 'payload',
+            }
+            wrapped_crashstore_instance.get_raw_crash.return_value = raw_crash
+
+            # the call to be tested
+            result =  cs.get_raw_crash('some_id')
+
+            statsd_obj = config.statsd_module.statsd.return_value
+            statsd_timing = statsd_obj.timing
+            statsd_timing.has_calls(
+                [call(
+                    'timing.SomeWrappedCrashStoreClass.get_raw_crash',
+                    1000
+                )]
+            )
+            config.wrapped_crashstore.return_value.save_raw_crash.has_calls(
+                [call({}, [], 'some_id')]
+            )
+            eq_(result, raw_crash)


### PR DESCRIPTION
here's an additional class for statsd crashstorage - a benchmarking class  that calls the ```timing``` method.  Any call to a wrapped crashstorage class is timed and the information sent to statsd.