### PR TITLE
(no bug) - crontabber should use envconsul -once

### DIFF
--- a/scripts/crons/crontabber.sh
+++ b/scripts/crons/crontabber.sh
@@ -14,7 +14,7 @@ LOG=/var/log/socorro/crontabber.log
 if [ -f $CT_INI ] && [ -r $CT_INI ]; then
     $CMD --admin.conf=$CT_INI >> $LOG 2>&1
 else
-    envconsul -prefix socorro/common -prefix socorro/crontabber bash -c "$CMD" >> $LOG 2>&1
+    envconsul -once -prefix socorro/common -prefix socorro/crontabber bash -c "$CMD" >> $LOG 2>&1
 fi
 EXIT_CODE=$?
 unlock $NAME


### PR DESCRIPTION
r? @jdotpz / @peterbe - we don't want envconsul to run as a daemon, by default it listens for changes and will restart if there are config changes to the socorro/common or socorro/crontabber prefixes.

We don't want envconsul to kill crontabber while it is running just to push out config changes, crontabber should finish the current run and pick them up on the next.