### PR TITLE
Fixes bug 1114561 - Sorted results by descending order by default in …

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -4353,7 +4353,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 200)
         assert len(mock_calls) == 1
         eq_(mock_calls[-1]['sort'], 'date_processed')
-        ok_('reverse' not in mock_calls[-1])
+        eq_(mock_calls[-1]['reverse'], True)
 
         response = self.client.get(url, dict(
             data,
@@ -4362,17 +4362,17 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 200)
         assert len(mock_calls) == 2
         eq_(mock_calls[-1]['sort'], 'build')
-        ok_('reverse' not in mock_calls[-1])
+        eq_(mock_calls[-1]['reverse'], True)
 
         response = self.client.get(url, dict(
             data,
             sort='build',
-            reverse='True'
+            reverse='False'
         ))
         eq_(response.status_code, 200)
         assert len(mock_calls) == 3
         eq_(mock_calls[-1]['sort'], 'build')
-        eq_(mock_calls[-1]['reverse'], True)
+        ok_('reverse' not in mock_calls[-1])
 
     @mock.patch('requests.get')
     def test_report_list_partial_reports_columns_override(self, rget):

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1352,7 +1352,7 @@ def report_list(request, partial=None, default_context=None):
         # of the fact that the ReportList() data gets cached.
 
         context['sort'] = request.GET.get('sort', 'date_processed')
-        context['reverse'] = request.GET.get('reverse', 'false').lower()
+        context['reverse'] = request.GET.get('reverse', 'true').lower()
         context['reverse'] = context['reverse'] != 'false'
 
         columns = request.GET.getlist('c')


### PR DESCRIPTION
…report/list/.

@peterbe r? (This might ring a bell, but it's a fresh commit since re-merging the one commit that once was in master was a pain due to conflicts. )