### PR TITLE
Add a --symbols-tmp argument to stackwalker to set temp directory for symbol download

### DIFF
--- a/minidump-stackwalk/common.h
+++ b/minidump-stackwalk/common.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2015 The Mozilla Foundation
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of The Mozilla Foundation nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef STACKWALKER_COMMON_H_
+#define STACKWALKER_COMMON_H_
+
+#include <vector>
+
+#include <stdio.h>
+
+// For inserting into a static struct option[]
+const struct option kHTTPCommandLineOptions[] = {
+    {"symbols-url", required_argument, nullptr, 's'},
+    {"symbols-cache", required_argument, nullptr, 'c'}
+};
+
+#define HTTP_COMMANDLINE_OPTIONS \
+  kHTTPCommandLineOptions[0], \
+  kHTTPCommandLineOptions[1],
+
+// For inserting into usage()
+void http_commandline_usage() {
+  fprintf(stderr, "\t--symbols-url\tA base URL from which URLs to symbol files can be constructed\n");
+  fprintf(stderr, "\t--symbols-cache\tA directory in which downloaded symbols can be stored\n");
+}
+
+// For inserting into the switch handling for getopt_long
+#define HANDLE_HTTP_COMMANDLINE_OPTIONS \
+    case 's': \
+      symbols_urls.push_back(optarg); \
+      break; \
+    case 'c': \
+      symbols_cache = optarg; \
+      break;
+
+bool check_http_commandline_options(
+    const std::vector<char*>& symbols_urls,
+    const char* symbols_cache) {
+  if ((!symbols_urls.empty() || symbols_cache) &&
+      !(!symbols_urls.empty() && symbols_cache)) {
+    fprintf(stderr, "You must specify both --symbols-url and --symbols-cache "
+            "when using one of these options\n");
+    return false;
+  }
+  return true;
+}
+
+#endif  // STACKWALKER_COMMON_H_

--- a/minidump-stackwalk/dumplookup.cc
+++ b/minidump-stackwalk/dumplookup.cc
@@ -43,6 +43,7 @@
 #include "processor/pathname_stripper.h"
 #include "processor/simple_symbol_supplier.h"
 
+#include "common.h"
 #include "http_symbol_supplier.h"
 
 using namespace google_breakpad;
@@ -120,8 +121,7 @@ void usage()
   fprintf(stderr, "Usage: dumplookup [options] <minidump> [<symbol paths]\n");
   fprintf(stderr, "Options:\n");
   fprintf(stderr, "\t--all\tShow all values on the stack.\n");
-  fprintf(stderr, "\t--symbols-url\tA base URL from which URLs to symbol files can be constructed\n");
-  fprintf(stderr, "\t--symbols-cache\tA directory in which downloaded symbols can be stored\n");
+  http_commandline_usage();
   fprintf(stderr, "\t--help\tDisplay this help text.\n");
 }
 
@@ -129,8 +129,7 @@ int main(int argc, char** argv)
 {
   static struct option long_options[] = {
     {"all", no_argument, nullptr, 'a'},
-    {"symbols-url", required_argument, nullptr, 's'},
-    {"symbols-cache", required_argument, nullptr, 'c'},
+    HTTP_COMMANDLINE_OPTIONS
     {"help", no_argument, nullptr, 'h'},
     {nullptr, 0, nullptr, 0}
   };
@@ -152,12 +151,7 @@ int main(int argc, char** argv)
     case 'a':
       show_all = true;
       break;
-    case 's':
-      symbols_urls.push_back(optarg);
-      break;
-    case 'c':
-      symbols_cache = optarg;
-      break;
+    HANDLE_HTTP_COMMANDLINE_OPTIONS
     case 'h':
       usage();
       return 0;
@@ -175,10 +169,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if ((!symbols_urls.empty() || symbols_cache) &&
-      !(!symbols_urls.empty() && symbols_cache)) {
-    fprintf(stderr, "You must specify both --symbols-url and --symbols-cache "
-            "when using one of these options\n");
+  if (!check_http_commandline_options(symbols_urls, symbols_cache)) {
     usage();
     return 1;
   }

--- a/minidump-stackwalk/dumplookup.cc
+++ b/minidump-stackwalk/dumplookup.cc
@@ -137,6 +137,7 @@ int main(int argc, char** argv)
   // Yeah, this is ugly.
   vector<char*> symbols_urls;
   char* symbols_cache = nullptr;
+  const char* symbols_tmp = "/tmp";
   bool show_all = false;
 
   int arg;
@@ -169,7 +170,9 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if (!check_http_commandline_options(symbols_urls, symbols_cache)) {
+  if (!check_http_commandline_options(symbols_urls,
+                                      symbols_cache,
+                                      symbols_tmp)) {
     usage();
     return 1;
   }
@@ -191,7 +194,8 @@ int main(int argc, char** argv)
     vector<string> server_paths(symbols_urls.begin(), symbols_urls.end());
     symbol_supplier.reset(new HTTPSymbolSupplier(server_paths,
                                                  symbols_cache,
-                                                 symbol_paths));
+                                                 symbol_paths,
+                                                 symbols_tmp));
   } else if (!symbol_paths.empty()) {
     symbol_supplier.reset(new SimpleSymbolSupplier(symbol_paths));
   }

--- a/minidump-stackwalk/get-minidump-instructions.cc
+++ b/minidump-stackwalk/get-minidump-instructions.cc
@@ -265,6 +265,7 @@ int main(int argc, char** argv)
   // Yeah, this is ugly.
   vector<char*> symbols_urls;
   char* symbols_cache = nullptr;
+  const char* symbols_tmp = "/tmp";
   bool disassemble = false;
   char* address_arg = nullptr;
 
@@ -301,7 +302,9 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if (!check_http_commandline_options(symbols_urls, symbols_cache)) {
+  if (!check_http_commandline_options(symbols_urls,
+                                      symbols_cache,
+                                      symbols_tmp)) {
     usage();
     return 1;
   }
@@ -393,7 +396,8 @@ int main(int argc, char** argv)
       vector<string> server_paths(symbols_urls.begin(), symbols_urls.end());
       symbol_supplier.reset(new HTTPSymbolSupplier(server_paths,
                                                    symbols_cache,
-                                                   symbol_paths));
+                                                   symbol_paths,
+                                                   symbols_tmp));
     } else if (!symbol_paths.empty()) {
       symbol_supplier.reset(new SimpleSymbolSupplier(symbol_paths));
     }

--- a/minidump-stackwalk/get-minidump-instructions.cc
+++ b/minidump-stackwalk/get-minidump-instructions.cc
@@ -53,6 +53,7 @@
 #include "processor/pathname_stripper.h"
 #include "processor/simple_symbol_supplier.h"
 
+#include "common.h"
 #include "http_symbol_supplier.h"
 
 using namespace google_breakpad;
@@ -83,8 +84,7 @@ void usage()
   fprintf(stderr, "Options:\n");
   fprintf(stderr, "\t--disassemble\tAttempt to disassemble the instructions using objdump\n");
   fprintf(stderr, "\t--address=ADDRESS\tShow instructions at ADDRESS\n");
-  fprintf(stderr, "\t--symbols-url\tA base URL from which URLs to symbol files can be constructed\n");
-  fprintf(stderr, "\t--symbols-cache\tA directory in which downloaded symbols can be stored\n");
+  http_commandline_usage();
   fprintf(stderr, "\t--help\tDisplay this help text.\n");
 }
 
@@ -257,8 +257,7 @@ int main(int argc, char** argv)
   static struct option long_options[] = {
     {"address", required_argument, nullptr, 'a'},
     {"disassemble", no_argument, nullptr, 'd'},
-    {"symbols-url", required_argument, nullptr, 's'},
-    {"symbols-cache", required_argument, nullptr, 'c'},
+    HTTP_COMMANDLINE_OPTIONS
     {"help", no_argument, nullptr, 'h'},
     {nullptr, 0, nullptr, 0}
   };
@@ -284,12 +283,7 @@ int main(int argc, char** argv)
     case 'a':
       address_arg = optarg;
       break;
-    case 's':
-      symbols_urls.push_back(optarg);
-      break;
-    case 'c':
-      symbols_cache = optarg;
-      break;
+    HANDLE_HTTP_COMMANDLINE_OPTIONS
     case 'h':
       usage();
       return 0;
@@ -307,10 +301,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if ((!symbols_urls.empty() || symbols_cache) &&
-      !(!symbols_urls.empty() && symbols_cache)) {
-    fprintf(stderr, "You must specify both --symbols-url and --symbols-cache "
-            "when using one of these options\n");
+  if (!check_http_commandline_options(symbols_urls, symbols_cache)) {
     usage();
     return 1;
   }

--- a/minidump-stackwalk/http_symbol_supplier.cc
+++ b/minidump-stackwalk/http_symbol_supplier.cc
@@ -90,15 +90,21 @@ static vector<string> vector_from(const string& front,
 
 HTTPSymbolSupplier::HTTPSymbolSupplier(const vector<string>& server_urls,
                                        const string& cache_path,
-				       const vector<string>& local_paths)
+				       const vector<string>& local_paths,
+                                       const string& tmp_path)
   : SimpleSymbolSupplier(vector_from(cache_path, local_paths)),
     server_urls_(server_urls),
     cache_path_(cache_path),
+    tmp_path_(tmp_path),
     curl_(curl_easy_init()) {
   for (auto i = server_urls_.begin(); i < server_urls_.end(); ++i) {
     if (*(i->end() - 1) != '/') {
       i->push_back('/');
     }
+  }
+  // Remove any trailing slash on tmp_path.
+  if (!tmp_path_.empty() && tmp_path_.back() == '/') {
+    tmp_path_.erase(tmp_path_.end() - 1);
   }
 }
 
@@ -253,7 +259,7 @@ bool HTTPSymbolSupplier::FetchURLToFile(CURL* curl,
                                         const string& file) {
   BPLOG(INFO) << "HTTPSymbolSupplier: fetching " << url;
 
-  string tempfile = "/tmp/symbolXXXXXX";
+  string tempfile = JoinPath(tmp_path_, "symbolXXXXXX");
   int fd = mkstemp(&tempfile[0]);
   if (fd == -1) {
     return false;

--- a/minidump-stackwalk/http_symbol_supplier.h
+++ b/minidump-stackwalk/http_symbol_supplier.h
@@ -59,7 +59,8 @@ class HTTPSymbolSupplier : public SimpleSymbolSupplier {
   // |local_paths| are directories to query for symbols before checking URLs.
   HTTPSymbolSupplier(const vector<string>& server_urls,
                      const string& cache_path,
-                     const vector<string>& local_paths);
+                     const vector<string>& local_paths,
+                     const string& tmp_path);
   virtual ~HTTPSymbolSupplier();
 
   // Returns the path to the symbol file for the given module.  See the
@@ -85,11 +86,12 @@ class HTTPSymbolSupplier : public SimpleSymbolSupplier {
  private:
   bool FetchSymbolFile(const CodeModule* module, const SystemInfo* system_info);
 
-  static bool FetchURLToFile(CURL* curl, const string& url, const string& file);
+  bool FetchURLToFile(CURL* curl, const string& url, const string& file);
   bool SymbolWasError(const CodeModule* module, const SystemInfo* system_info);
 
   vector<string> server_urls_;
   string cache_path_;
+  string tmp_path_;
   std::set<std::pair<string,string>> error_symbols_;
   CURL* curl_;
 };

--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -1042,6 +1042,7 @@ int main(int argc, char** argv)
   // Yeah, this is ugly.
   vector<char*> symbols_urls;
   char* symbols_cache = nullptr;
+  const char* symbols_tmp = "/tmp";
   static struct option long_options[] = {
     {"pretty", no_argument, nullptr, 'p'},
     {"pipe-dump", no_argument, nullptr, 'i'},
@@ -1086,7 +1087,9 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if (!check_http_commandline_options(symbols_urls, symbols_cache)) {
+  if (!check_http_commandline_options(symbols_urls,
+                                      symbols_cache,
+                                      symbols_tmp)) {
     usage();
     return 1;
   }
@@ -1109,7 +1112,8 @@ int main(int argc, char** argv)
     vector<string> server_paths(symbols_urls.begin(), symbols_urls.end());
     symbol_supplier.reset(new HTTPSymbolSupplier(server_paths,
                                                  symbols_cache,
-                                                 symbol_paths));
+                                                 symbol_paths,
+                                                 symbols_tmp));
   } else if (!symbol_paths.empty()) {
     symbol_supplier.reset(new SimpleSymbolSupplier(symbol_paths));
   }

--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -61,6 +61,7 @@
 #include "processor/pathname_stripper.h"
 #include "processor/simple_symbol_supplier.h"
 
+#include "common.h"
 #include "http_symbol_supplier.h"
 #include "json/json.h"
 
@@ -1028,8 +1029,7 @@ void usage() {
   fprintf(stderr, "\t--pretty\tPretty-print JSON output.\n");
   fprintf(stderr, "\t--pipe-dump\tProduce pipe-delimited output in addition to JSON output\n");
   fprintf(stderr, "\t--raw-json\tAn input file with the raw annotations as JSON\n");
-  fprintf(stderr, "\t--symbols-url\tA base URL from which URLs to symbol files can be constructed\n");
-  fprintf(stderr, "\t--symbols-cache\tA directory in which downloaded symbols can be stored\n");
+  http_commandline_usage();
   fprintf(stderr, "\t--help\tDisplay this help text.\n");
 }
 
@@ -1046,8 +1046,7 @@ int main(int argc, char** argv)
     {"pretty", no_argument, nullptr, 'p'},
     {"pipe-dump", no_argument, nullptr, 'i'},
     {"raw-json", required_argument, nullptr, 'r'},
-    {"symbols-url", required_argument, nullptr, 's'},
-    {"symbols-cache", required_argument, nullptr, 'c'},
+    HTTP_COMMANDLINE_OPTIONS
     {"help", no_argument, nullptr, 'h'},
     {nullptr, 0, nullptr, 0}
   };
@@ -1069,12 +1068,7 @@ int main(int argc, char** argv)
     case 'r':
       json_path = optarg;
       break;
-    case 's':
-      symbols_urls.push_back(optarg);
-      break;
-    case 'c':
-      symbols_cache = optarg;
-      break;
+    HANDLE_HTTP_COMMANDLINE_OPTIONS
     case 'h':
       usage();
       return 0;
@@ -1092,10 +1086,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if ((!symbols_urls.empty() || symbols_cache) &&
-      !(!symbols_urls.empty() && symbols_cache)) {
-    fprintf(stderr, "You must specify both --symbols-url and --symbols-cache "
-            "when using one of these options\n");
+  if (!check_http_commandline_options(symbols_urls, symbols_cache)) {
     usage();
     return 1;
   }


### PR DESCRIPTION
r? @rhelmer who ran into this issue when trying to move the symbol cache to local disk on EC2 instances, where /tmp is EBS. We use `rename` to move the temp file to its final location but that doesn't work across filesystems.