### PR TITLE
Fixes Bug 1124241 - added jit category external program

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -66,6 +66,13 @@ mozilla_processor_rule_sets = [
         "socorro.processor.support_classifiers.BitguardClassifier, "
         "socorro.processor.support_classifiers.OutOfDateClassifier"
     ],
+##    [   # a set of classifiers to help with jit crashes
+##        "jit_classifers",
+##        "processor.jit_classifiers",
+##        "socorro.lib.transform_rules.TransformRuleSystem",
+##        "apply_all_rules",
+##        "socorro.processor.breakpad_transform_rules.JitCrashCategorizeRule, "
+##    ],
     [   # a set of special request classifiers
         "skunk_classifiers",
         "processor.skunk_classifiers",

--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -66,13 +66,13 @@ mozilla_processor_rule_sets = [
         "socorro.processor.support_classifiers.BitguardClassifier, "
         "socorro.processor.support_classifiers.OutOfDateClassifier"
     ],
-##    [   # a set of classifiers to help with jit crashes
-##        "jit_classifers",
-##        "processor.jit_classifiers",
-##        "socorro.lib.transform_rules.TransformRuleSystem",
-##        "apply_all_rules",
-##        "socorro.processor.breakpad_transform_rules.JitCrashCategorizeRule, "
-##    ],
+    [   # a set of classifiers to help with jit crashes
+        "jit_classifers",
+        "processor.jit_classifiers",
+        "socorro.lib.transform_rules.TransformRuleSystem",
+        "apply_all_rules",
+        "socorro.processor.breakpad_transform_rules.JitCrashCategorizeRule, "
+    ],
     [   # a set of special request classifiers
         "skunk_classifiers",
         "processor.skunk_classifiers",

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -174,6 +174,7 @@ class CSignatureToolBase(SignatureTool):
                 pass
         if sentinel_locations:
             source_list = source_list[min(sentinel_locations):]
+
         new_signature_list = []
         for a_signature in source_list:
             if self.irrelevant_signature_re.match(a_signature):


### PR DESCRIPTION
I've written this in the form of a classifier rule.  This is all it takes to put the stdio results of an external program into a single key in a processed crash.  This is a fine example of a classifier that anyone could write to include in Socorro.  

Placing the output of this external program into the "classifications.jit" namespace within the processed crash, makes it readily available for access by future rules, such as signature manipulation. At the same time this imposes a hierarchical structure on what will likely evolve into many different types of crash classification systems.  Signature itself is just another classifications system that happens to have gotten into Socorro first and so remains entrenched.  I encourage others to write classifiers. A new one could, perhaps, end up being far more useful than the current signature system tracing back to 2007.   

Once this predicate and form of the invocation are accepted, we can enable it at any time by uncommenting the block in ```socorro/processor/mozilla_processor_2015.py``` in this PR.

This PR makes no attempt to ensure the building, loading, provisioning, or verification of the name of the ```jit-crash-categorize``` external program. Collaboration on that is welcome.  

