### PR TITLE
Fixes Bug 1172511 - examples of CountAnythingRules for the processor

### DIFF
--- a/socorro/unittest/external/statsd/test_stastsd_rule_benchmark.py
+++ b/socorro/unittest/external/statsd/test_stastsd_rule_benchmark.py
@@ -12,7 +12,11 @@ from configman.dotdict import DotDict
 
 from socorro.external.statsd.statsd_rule_benchmark import (
     StatsdRuleBenchmarkWrapper,
+    CountAnythingRuleBase,
+    CountStackWalkerTimeoutKills,
+    CountStackWalkerFailures,
 )
+from socorro.external.statsd.statsd_base import StatsdCounter
 from socorro.unittest.lib.test_transform_rules import (
     TestRuleTestLaughable,
     TestRuleTestDangerous
@@ -98,5 +102,200 @@ class TestStatsdCounterRule(TestCase):
                     1000  # 1 second
                 ),
             ])
+
+#==============================================================================
+class TestStatsdCountAnythingRule(TestStatsdCounterRule):
+
+    @patch('socorro.external.statsd.dogstatsd.statsd')
+    def testCountAnythingRuleBase(self, statsd_obj):
+        config = DotDict()
+        config.counter_class = Mock()
+        config.rule_name = 'dwight'
+        config.statsd_class =  Mock()
+        config.statsd_host = 'some_statsd_host'
+        config.statsd_port =  3333
+        config.statsd_prefix = ''
+        config.active_list =  ['dwight']
+        a_rule = CountAnythingRuleBase(config)
+
+        raw_crash_mock =  Mock()
+        raw_dumps_mock =  Mock()
+        processed_crash_mock =  Mock()
+        proc_meta_mock =  Mock()
+
+        assert_raises(
+            NotImplementedError,
+            a_rule._predicate,
+            raw_crash_mock,
+            raw_dumps_mock,
+            processed_crash_mock,
+            proc_meta_mock
+        )
+
+        a_rule._action(
+            raw_crash_mock,
+            raw_dumps_mock,
+            processed_crash_mock,
+            proc_meta_mock
+        )
+        a_rule.counter._incr.assert_called_once_with(
+            'dwight'
+        )
+
+    @patch('socorro.external.statsd.dogstatsd.statsd')
+    def testCountStackWalkerTimeoutKills_success(self, statsd_obj):
+        config = DotDict()
+        config.counter_class = Mock()
+        config.rule_name = 'stackwalker_timeout_kills'
+        config.statsd_class =  Mock()
+        config.statsd_host = 'some_statsd_host'
+        config.statsd_port =  3333
+        config.statsd_prefix =  ''
+        config.active_list =  ['stackwalker_timeout_kills']
+        a_rule = CountStackWalkerTimeoutKills(config)
+
+        raw_crash_mock =  Mock()
+        raw_dumps_mock =  Mock()
+        processed_crash_mock =  Mock()
+        proc_meta =  DotDict()
+        proc_meta.processor_notes = [
+            'hello',
+            'this is a list of notes from the processor',
+            'it has information about the what the processor',
+            'thought was important',
+            'like, maybe, SIGKILL of the stackwalker',
+            'or other such things.'
+        ]
+
+        ok_(
+            a_rule._predicate(
+                raw_crash_mock,
+                raw_dumps_mock,
+                processed_crash_mock,
+                proc_meta
+            )
+        )
+
+        a_rule._action(
+            raw_crash_mock,
+            raw_dumps_mock,
+            processed_crash_mock,
+            proc_meta
+        )
+        a_rule.counter._incr.assert_called_once_with(
+            'stackwalker_timeout_kills'
+        )
+
+    @patch('socorro.external.statsd.dogstatsd.statsd')
+    def testCountStackWalkerTimeoutKills_fail(self, statsd_obj):
+        config = DotDict()
+        config.counter_class = Mock()
+        config.rule_name = 'stackwalker_timeout_kills'
+        config.statsd_class =  Mock()
+        config.statsd_host = 'some_statsd_host'
+        config.statsd_port =  3333
+        config.statsd_prefix =  ''
+        config.active_list =  ['stackwalker_timeout_kills']
+        a_rule = CountStackWalkerTimeoutKills(config)
+
+        raw_crash_mock =  Mock()
+        raw_dumps_mock =  Mock()
+        processed_crash_mock =  Mock()
+        proc_meta =  DotDict()
+        proc_meta.processor_notes = [
+            'hello',
+            'this is a list of notes from the processor',
+            'it has information about the what the processor',
+            'thought was important',
+        ]
+
+        ok_(
+            not
+            a_rule._predicate(
+                raw_crash_mock,
+                raw_dumps_mock,
+                processed_crash_mock,
+                proc_meta
+            )
+        )
+
+    @patch('socorro.external.statsd.dogstatsd.statsd')
+    def testCountStackWalkerFailures_success(self, statsd_obj):
+        config = DotDict()
+        config.counter_class = Mock()
+        config.rule_name = 'stackwalker_timeout_kills'
+        config.statsd_class =  Mock()
+        config.statsd_host = 'some_statsd_host'
+        config.statsd_port =  3333
+        config.statsd_prefix =  ''
+        config.active_list =  ['stackwalker_timeout_kills']
+        a_rule = CountStackWalkerFailures(config)
+
+        raw_crash_mock =  Mock()
+        raw_dumps_mock =  Mock()
+        processed_crash_mock =  Mock()
+        proc_meta =  DotDict()
+        proc_meta.processor_notes = [
+            'hello',
+            'this is a list of notes from the processor',
+            'it has information about the what the processor',
+            'thought was important',
+            'like, maybe when "MDSW failed"',
+            'or other such things.'
+        ]
+
+        ok_(
+            a_rule._predicate(
+                raw_crash_mock,
+                raw_dumps_mock,
+                processed_crash_mock,
+                proc_meta
+            )
+        )
+
+        a_rule._action(
+            raw_crash_mock,
+            raw_dumps_mock,
+            processed_crash_mock,
+            proc_meta
+        )
+        a_rule.counter._incr.assert_called_once_with(
+            'stackwalker_timeout_kills'
+        )
+
+    @patch('socorro.external.statsd.dogstatsd.statsd')
+    def testCountStackWalkerFailures_fail(self, statsd_obj):
+        config = DotDict()
+        config.counter_class = Mock()
+        config.rule_name = 'stackwalker_timeout_kills'
+        config.statsd_class =  Mock()
+        config.statsd_host = 'some_statsd_host'
+        config.statsd_port =  3333
+        config.statsd_prefix =  ''
+        config.active_list =  ['stackwalker_timeout_kills']
+        a_rule = CountStackWalkerFailures(config)
+
+        raw_crash_mock =  Mock()
+        raw_dumps_mock =  Mock()
+        processed_crash_mock =  Mock()
+        proc_meta =  DotDict()
+        proc_meta.processor_notes = [
+            'hello',
+            'this is a list of notes from the processor',
+            'it has information about the what the processor',
+            'thought was important',
+        ]
+
+        ok_(
+            not
+            a_rule._predicate(
+                raw_crash_mock,
+                raw_dumps_mock,
+                processed_crash_mock,
+                proc_meta
+            )
+        )
+
+
 
 


### PR DESCRIPTION
this is a demo of what can be done with the statsd classes and processor rules...  

this change creates a base counter rule class and then uses it to define two processor rules that detect conditions during processing and then increment a statsd counter.  

CountStackWalkerTimeoutKills  will track how many times the stackwalker is killed for taking too long.
CountStackWalkerFailures will track how many times the stackwalker crashes or returns a bad error code. 
