### PR TITLE
Fixes Bug 1162703 - added mozilla::ipc::MessageChannel::Send to prefix

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -352,6 +352,7 @@ class CSignatureTool(CSignatureToolBase):
           'mozalloc_handle_oom',
           'moz_free',
           'mozilla::AndroidBridge::AutoLocalJNIFrame::~AutoLocalJNIFrame',
+          'mozilla::ipc::MessageChannel::Send',
           'mozilla::ipc::RPCChannel::Call',
           'mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame',
           'mozilla::ipc::RPCChannel::EnteredCxxStack',


### PR DESCRIPTION
add mozilla::ipc::MessageChannel::Send to the prefix list in processor signature generation