### PR TITLE
fixes Bug 1177715 - added missing tests, and associated corrections

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -67,7 +67,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.support_classifiers.OutOfDateClassifier"
     ],
     [   # a set of classifiers to help with jit crashes
-        "jit_classifers",
+        "jit_classifiers",
         "processor.jit_classifiers",
         "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",


### PR DESCRIPTION
the tests for the JIT classifier were written to a file that was never checked in to git, nor did its name start with the word "test".  The tests were never run, I didn't notice, and interpreted silence as success.  Once tests were put into the proper file, some obvious defects were found and then corrected. 