### PR TITLE
Revert "No Bug - change default of the boto 'prefix' to empty string"

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -92,7 +92,7 @@ class BotoS3CrashStorage(CrashStorageBase):
     required_config.add_option(
         'prefix',
         doc="a prefix to use inside the bucket",
-        default='',
+        default='dev',
         reference_value_from='resource.boto',
         likely_to_be_changed=True,
     )


### PR DESCRIPTION
Reverts mozilla/socorro#2874