### PR TITLE
Revert "NO BUG - removed LF from output of jit categorizer"

### DIFF
--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -708,7 +708,7 @@ class JitCrashCategorizeRule(ExternalProcessRule):
     #--------------------------------------------------------------------------
     def _interpret_external_command_output(self, fp, processor_meta):
         try:
-            result =  fp.read()
+            return fp.read()
         except IOError, x:
             processor_meta.processor_notes.append(
                 "%s unable to read external command output: %s" % (
@@ -717,8 +717,3 @@ class JitCrashCategorizeRule(ExternalProcessRule):
                 )
             )
             return ''
-        try:
-            return result.strip()
-        except AttributeError, x:
-            # there's no strip method
-            return result

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -676,7 +676,7 @@ class TestBreakpadTransformRule2015(TestCase):
 
         mocked_subprocess_handle = \
             mocked_subprocess_module.Popen.return_value
-        mocked_subprocess_handle.stdout.read.return_value = '{}\n'
+        mocked_subprocess_handle.stdout.read.return_value = '{}'
         mocked_subprocess_handle.wait.return_value = 124
 
         rule = BreakpadStackwalkerRule2015(config)


### PR DESCRIPTION
Reverts mozilla/socorro#2871