### PR TITLE
5. Rebort! "Revert "No Bug - change default of the boto 'prefix' to empty…

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -92,7 +92,7 @@ class BotoS3CrashStorage(CrashStorageBase):
     required_config.add_option(
         'prefix',
         doc="a prefix to use inside the bucket",
-        default='dev',
+        default='',
         reference_value_from='resource.boto',
         likely_to_be_changed=True,
     )


### PR DESCRIPTION
This was reverted to help investigate a production issue that crept in shortly after AWS before we had our monitoring in order. The patch is r+, but we will be relanding and shipping each of these PRs one at a time on July 9 to attempt to find the problematic patch.