### PR TITLE
fixes bug 1188085 - socorro.external.es.supersearch.SuperSearch directly

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -187,6 +187,7 @@ class SuperSearch(SearchBase):
         The list of accepted parameters (with types and default values) is in
         the database and can be accessed with the super_search_fields service.
         """
+
         # Filter parameters and raise potential errors.
         params = self.get_parameters(**kwargs)
 

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -277,7 +277,7 @@ class SocorroCommon(object):
     @measure_fetches
     def fetch(
         self,
-        url,
+        url_or_implementation,
         headers=None,
         method='get',
         params=None,
@@ -288,46 +288,60 @@ class SocorroCommon(object):
         retries=None,
         retry_sleeptime=None
     ):
+        url = implementation = None
+        if isinstance(url_or_implementation, basestring):
+            url = url_or_implementation
 
-        if retries is None:
-            retries = settings.MIDDLEWARE_RETRIES
-        if retry_sleeptime is None:
-            retry_sleeptime = settings.MIDDLEWARE_RETRY_SLEEPTIME
+            if retries is None:
+                retries = settings.MIDDLEWARE_RETRIES
+            if retry_sleeptime is None:
+                retry_sleeptime = settings.MIDDLEWARE_RETRY_SLEEPTIME
 
-        if url.startswith('/'):
-            url = self._complete_url(url)
+            if url.startswith('/'):
+                url = self._complete_url(url)
 
-        if not headers:
-            if self.http_host:
-                headers = {'Host': self.http_host}
+            if not headers:
+                if self.http_host:
+                    headers = {'Host': self.http_host}
+                else:
+                    headers = {}
+
+            if self.username and self.password:
+                auth = self.username, self.password
             else:
-                headers = {}
+                auth = ()
 
-        if self.username and self.password:
-            auth = self.username, self.password
         else:
-            auth = ()
+            implementation = url_or_implementation
 
         cache_key = None
         cache_file = None
 
         if settings.CACHE_MIDDLEWARE and not dont_cache and self.cache_seconds:
-            # Prepare a fake Request object to use it to get the full URL that
-            # will be used. Needed for caching.
-            req = requests.Request(
-                method=method.upper(),
-                url=url,
-                auth=auth,
-                headers=headers,
-                data=data,
-                params=params,
-            ).prepare()
-            cache_key = hashlib.md5(iri_to_uri(req.url)).hexdigest()
+            if url:
+                # Prepare a fake Request object to use it to get the full URL
+                # that will be used. Needed for caching.
+                req = requests.Request(
+                    method=method.upper(),
+                    url=url,
+                    auth=auth,
+                    headers=headers,
+                    data=data,
+                    params=params,
+                ).prepare()
+                cache_key = hashlib.md5(iri_to_uri(req.url)).hexdigest()
+            else:
+                cache_key = hashlib.md5(unicode(params)).hexdigest()
 
             if not refresh_cache:
                 result = cache.get(cache_key)
                 if result is not None:
-                    logger.debug("CACHE HIT %s" % url)
+                    if url:
+                        logger.debug("CACHE HIT %s" % url)
+                    else:
+                        logger.debug(
+                            "CACHE HIT %s" % implementation.__class__.__name__
+                        )
                     return result, True
 
                 # not in the memcache/locmem but is it in cache files?
@@ -340,17 +354,28 @@ class SocorroCommon(object):
                         )
                     else:
                         cache_file = root
-                    split = urlparse.urlparse(url)
-                    cache_file = os.path.join(
-                        cache_file,
-                        split.netloc,
-                        _clean_path(split.path)
-                    )
-                    if split.query:
+
+                    # We need to conjure up a string filename to represent
+                    # this call. If it's a URL we use the URL path to
+                    # as the file path.
+                    # If it's an implementation we use the class name
+                    if implementation:
                         cache_file = os.path.join(
                             cache_file,
-                            _clean_query(split.query)
+                            implementation.__class__.__name__
                         )
+                    else:
+                        split = urlparse.urlparse(url)
+                        cache_file = os.path.join(
+                            cache_file,
+                            split.netloc,
+                            _clean_path(split.path)
+                        )
+                        if split.query:
+                            cache_file = os.path.join(
+                                cache_file,
+                                _clean_query(split.query)
+                            )
                     if expect_json:
                         cache_file = os.path.join(
                             cache_file,
@@ -389,57 +414,62 @@ class SocorroCommon(object):
                             if delete_cache_file:
                                 os.remove(cache_file)
 
-        if method == 'post':
-            request_method = requests.post
-            logger.info("POSTING TO %s" % url)
-        elif method == 'get':
-            request_method = requests.get
-            logger.info("FETCHING %s" % url)
-        elif method == 'put':
-            request_method = requests.put
-            logger.info("PUTTING TO %s" % url)
-        elif method == 'delete':
-            request_method = requests.delete
-            logger.info("DELETING ON %s" % url)
+        if url:
+            if method == 'post':
+                request_method = requests.post
+                logger.info("POSTING TO %s" % url)
+            elif method == 'get':
+                request_method = requests.get
+                logger.info("FETCHING %s" % url)
+            elif method == 'put':
+                request_method = requests.put
+                logger.info("PUTTING TO %s" % url)
+            elif method == 'delete':
+                request_method = requests.delete
+                logger.info("DELETING ON %s" % url)
+            else:
+                raise ValueError(method)
+
+            try:
+                resp = request_method(
+                    url=url,
+                    auth=auth,
+                    headers=headers,
+                    data=data,
+                    params=params,
+                )
+            except requests.ConnectionError:
+                if not retries:
+                    raise
+                # https://bugzilla.mozilla.org/show_bug.cgi?id=916886
+                time.sleep(retry_sleeptime)
+                return self.fetch(
+                    url,
+                    headers=headers,
+                    method=method,
+                    data=data,
+                    params=params,
+                    expect_json=expect_json,
+                    dont_cache=dont_cache,
+                    retry_sleeptime=retry_sleeptime,
+                    retries=retries - 1
+                )
+
+            if resp.status_code >= 400 and resp.status_code < 500:
+                raise BadStatusCodeError(resp.status_code, resp.content)
+            elif not resp.status_code == 200:
+                raise BadStatusCodeError(
+                    resp.status_code,
+                    '%s (%s)' % (resp.content, url)
+                )
+
+            result = resp.content
+            if expect_json:
+                result = ujson.loads(result)
         else:
-            raise ValueError(method)
-
-        try:
-            resp = request_method(
-                url=url,
-                auth=auth,
-                headers=headers,
-                data=data,
-                params=params,
-            )
-        except requests.ConnectionError:
-            if not retries:
-                raise
-            # https://bugzilla.mozilla.org/show_bug.cgi?id=916886
-            time.sleep(retry_sleeptime)
-            return self.fetch(
-                url,
-                headers=headers,
-                method=method,
-                data=data,
-                params=params,
-                expect_json=expect_json,
-                dont_cache=dont_cache,
-                retry_sleeptime=retry_sleeptime,
-                retries=retries - 1
-            )
-
-        if resp.status_code >= 400 and resp.status_code < 500:
-            raise BadStatusCodeError(resp.status_code, resp.content)
-        elif not resp.status_code == 200:
-            raise BadStatusCodeError(
-                resp.status_code,
-                '%s (%s)' % (resp.content, url)
-            )
-
-        result = resp.content
-        if expect_json:
-            result = ujson.loads(result)
+            # e.g. the .get() method on that class instance
+            implementation_method = getattr(implementation, method)
+            result = implementation_method(**params)
 
         if cache_key:
             cache.set(cache_key, result, self.cache_seconds)
@@ -464,6 +494,9 @@ class SocorroCommon(object):
 class SocorroMiddleware(SocorroCommon):
     """ Soon to be deprecated by classes using socorro dataservice classes
     and memoize decorator """
+
+    # by default, assume the class to not have an implementation reference
+    implementation = None
 
     base_url = settings.MWARE_BASE_URL
     http_host = settings.MWARE_HTTP_HOST
@@ -526,9 +559,14 @@ class SocorroMiddleware(SocorroCommon):
         to define a `URL_PREFIX` and (`required_params` and/or
         `possible_params`)
         """
-        url = self.URL_PREFIX
-        assert url.startswith('/'), 'URL_PREFIX must start with a /'
-        assert url.endswith('/'), 'URL_PREFIX must end with a /'
+        if self.implementation:
+            url_or_implementation = self.implementation
+        else:
+            # the old-fashioned way of doing a regular middleware HTTP query
+            url = self.URL_PREFIX
+            assert url.startswith('/'), 'URL_PREFIX must start with a /'
+            assert url.endswith('/'), 'URL_PREFIX must end with a /'
+            url_or_implementation = url
 
         defaults = getattr(self, 'defaults', {})
         aliases = getattr(self, 'aliases', {})
@@ -543,7 +581,7 @@ class SocorroMiddleware(SocorroCommon):
                 del params[param]
 
         return self.fetch(
-            url,
+            url_or_implementation,
             params=params,
             method=method,
             dont_cache=dont_cache,

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -639,3 +639,24 @@ SYMBOLS_BUCKET_DEFAULT_LOCATION = config(
     'SYMBOLS_BUCKET_DEFAULT_LOCATION',
     None
 )
+
+# Config for when the models pull directly from socorro.external classes.
+# NOTE: This is overwritten, for tests in settings_test.py
+SOCORRO_IMPLEMENTATIONS_CONFIG = {
+    'elasticsearch': {
+        # All of these settings are repeated with sensible defaults
+        # in the implementation itself.
+        # We repeat them here so it becomes super easy to override
+        # from the way we set settings for the webapp.
+        'elasticsearch_urls': config(
+            'ELASTICSEARCH_URLS',
+            'http://localhost:9200',
+            cast=Csv()
+        ),
+        # e.g. (deliberately commented out)
+        # 'elasticsearch_doctype': config(
+        #     'ELASTICSEARCH_DOCTYPE',
+        #     'crash_reports'
+        # )
+    }
+}

--- a/webapp-django/settings_test.py
+++ b/webapp-django/settings_test.py
@@ -52,3 +52,11 @@ AWS_SECRET_ACCESS_KEY = 'anything'
 SYMBOLS_BUCKET_DEFAULT_NAME = 'my-lovely-bucket'
 SYMBOLS_FILE_PREFIX = 'v99'
 SYMBOLS_BUCKET_DEFAULT_LOCATION = 'us-west-2'
+
+
+# So it never ever actually uses a real ElasticSearch server
+SOCORRO_IMPLEMENTATIONS_CONFIG = {
+    'elasticsearch': {
+        'elasticsearch_urls': ['http://example:9123'],
+    },
+}


### PR DESCRIPTION
@AdrianGaudebert r? cc @twobraids 

So this stops using the middleware for talking to ES for supersearch queries. 

Adrian, when I started this work I used to hack it so that the `fetch` method first did the usual `requests.get()` and then it did it the new way. So every page I hit, it would make 2 ES queries. 
I used that to make sure the results are the same. They were. Also, I used it to measure if the direct method was much faster. It was. But only by 5-15% depending on the size. So much of the time spent is on the network and when doing local development it uses CherryPy instead of the much better uWSGI we use in production. 

I know the size of the patch is scary. 99.99% of it is fixing how the mocking is done in tests. Instead of mocking `requests.get` it mocks `socorro.external.es.elasticsearch.SuperSearch`

@twobraids Please look over the changes in `supersearch/models.py` and let me know what you think. 
Also, please take a look at my hack in `SocorroCommon.fetch()` where I make it so that you can pass in either an implementation OR a string URL. This makes it really easy for me to keep ALL the existing fancy caching functionality without much extra work. 

@twobraids I'd also like to get some eyes on the logging. Truth is, there is very little logging in `socorro.external.es.supersearch.SuperSearch`. Perhaps a challenge for some other day. 

The plan:

* File a bug and rebase this PRs commit message to mention that bug :)
* Land this and test it in stage. 
* Attack the `SuperSearchFields` so that it too does not use the middleware
* Delete everything from the `middleware_app.py` that has to do with supersearch
* Attack some postgres related model classes. To use the same pattern. One service at a time. 

cc @lonnen and @rhelmer if you're curious. 