### PR TITLE
NO BUG - added missing method to NullStorage

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -283,6 +283,14 @@ class NullCrashStorage(CrashStorageBase):
         return SocorroDotDict()
 
     #--------------------------------------------------------------------------
+    def get_raw_dumps_as_files(self, crash_id):
+        """the default implementation of fetching all the dumps
+
+        parameters:
+           crash_id - the id of a dump to fetch"""
+        return SocorroDotDict()
+
+    #--------------------------------------------------------------------------
     def get_unredacted_processed(self, crash_id):
         """the default implementation of fetching a processed_crash
 


### PR DESCRIPTION
the NullCrashStorage class is used in ad hoc testing.  It serves no purpose in actual prod code.  In its use in testing, however, it ought to implement the full API. We don't it want raising errors.  We want it to silently ignore everything that it is told to do.

the method ```get_raw_dumps_as_files``` was missing, I added it...