### PR TITLE
NO BUG - api adjustments for compatiblity rabbit / submitter

### DIFF
--- a/socorro/collector/submitter_app.py
+++ b/socorro/collector/submitter_app.py
@@ -292,7 +292,10 @@ class SubmitterApp(FetchTransformSaveApp):
         super(SubmitterApp, self)._setup_source_and_destination()
         if self.config.new_crash_source.new_crash_source_class:
             self.new_crash_source = \
-                self.config.new_crash_source.new_crash_source_class(config)
+                self.config.new_crash_source.new_crash_source_class(
+                    self.config.new_crash_source,
+                    'submitter'
+                )
         else:
             self.new_crash_source = self.source
 

--- a/socorro/external/rabbitmq/rmq_new_crash_source.py
+++ b/socorro/external/rabbitmq/rmq_new_crash_source.py
@@ -51,5 +51,9 @@ class RMQNewCrashSource(RequiredConfig):
             )
 
     #--------------------------------------------------------------------------
+    def new_crashes(self):
+        return self.__iter__()
+
+    #--------------------------------------------------------------------------
     def __call__(self):
         return self.__iter__()


### PR DESCRIPTION
the API used by the submitter has a slight and annoying variation from the standard crashstorage API.  The changes here enable the rabbitmq crashstorage and new_crash_source classes to be compatible with the way that submitter wants things to work.