### PR TITLE
fixes bug 1186512 - Expose raw ADI counts

### DIFF
--- a/socorro/external/postgresql/adi.py
+++ b/socorro/external/postgresql/adi.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+import logging
+
+from socorro.external.postgresql.base import PostgreSQLBase
+from socorro.external import MissingArgumentError
+from socorro.lib import external_common
+
+logger = logging.getLogger("webapi")
+
+
+class ADI(PostgreSQLBase):
+
+    def get(self, **kwargs):
+        yesterday = datetime.datetime.utcnow() - datetime.timedelta(1)
+        tomorrow = yesterday + datetime.timedelta(2)
+        yesterday = yesterday.date()
+        tomorrow = tomorrow.date()
+        filters = [
+            ('start_date', yesterday, 'date'),
+            ('end_date', tomorrow, 'date'),
+            ('product', '', 'str'),
+            ('version', '', 'str'),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+        required = (
+            'start_date',
+            'end_date',
+            'product',
+            'version',
+        )
+        missing = []
+        for each in required:
+            if not params.get(each):
+                missing.append(each)
+        if missing:
+            raise MissingArgumentError(', '.join(missing))
+
+        SQL = """
+        SELECT
+            SUM(adi_count) AS adi_count,
+            date::DATE,
+            product_name AS product,
+            product_version AS version,
+            product_os_platform AS platform,
+            update_channel AS release_channel
+        FROM
+            raw_adi
+        WHERE
+            product_name = %(product)s AND
+            product_version = %(version)s AND
+            date BETWEEN %(start_date)s::DATE AND %(end_date)s::DATE
+        GROUP BY
+            date::DATE,
+            product_name,
+            product_os_platform,
+            product_version,
+            update_channel
+        """
+
+        results = self.query(SQL, params)
+
+        fields = (
+            'adi_count',
+            'date',
+            'product',
+            'version',
+            'platform',
+            'release_channel',
+        )
+        rows = []
+        for record in results:
+            row = dict(zip(fields, record))
+            row['date'] = row['date'].strftime('%Y-%m-%d')
+            rows.append(row)
+        return {'hits': rows}

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -75,6 +75,7 @@ SERVICES_LIST = (
     (r'/supersearch/(.*)', 'supersearch.SuperSearch'),
     (r'/suspicious/(.*)', 'suspicious.SuspiciousCrashSignatures'),
     (r'/util/(versions_info)/(.*)', 'util.Util'),
+    (r'/adi/(.*)', 'adi.ADI'),
 )
 
 # certain items in a URL path should NOT be split by `+`
@@ -550,7 +551,7 @@ class ImplementationWrapper(JsonWebServiceBase):
         except AttributeError:
             try:
                 if (method_name == 'post' and
-                    getattr(instance, 'create', None)):
+                   getattr(instance, 'create', None)):
                     # use the `create` alias
                     method = instance.create
                 elif (method_name == 'put' and

--- a/socorro/unittest/external/postgresql/test_adi.py
+++ b/socorro/unittest/external/postgresql/test_adi.py
@@ -1,0 +1,142 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+from nose.plugins.attrib import attr
+from nose.tools import eq_, assert_raises
+
+from socorro.external.postgresql.adi import ADI
+from socorro.external import MissingArgumentError
+
+from unittestbase import PostgreSQLTestCase
+
+
+@attr(integration='postgres')  # for nosetests
+class IntegrationTestADI(PostgreSQLTestCase):
+
+    def setUp(self):
+        """Set up this test class by populating the reports table with fake
+        data. """
+        super(IntegrationTestADI, self).setUp()
+        self._truncate()
+        cursor = self.connection.cursor()
+
+        self.date = datetime.datetime(2015, 7, 1)
+        yesterday = self.date - datetime.timedelta(hours=24)
+        products = ('Firefox', 'Thunderbird')
+        versions = ('39', '40')
+        platforms = ('Linux', 'Darwin')
+        channels = ('release', 'beta')
+        adi_count = 1
+        for product in products:
+            for version in versions:
+                for platform in platforms:
+                    for channel in channels:
+                        cursor.execute("""
+                            INSERT INTO raw_adi (
+                                adi_count,
+                                date,
+                                product_name,
+                                product_os_platform,
+                                product_os_version,
+                                product_version,
+                                build,
+                                product_guid,
+                                update_channel,
+                                received_at
+                            )
+                            VALUES (
+                                %s, %s, %s, %s, %s, %s, %s, %s, %s, now()
+                            )
+                        """, (
+                            adi_count,
+                            yesterday,
+                            product,
+                            platform,
+                            '1.0',
+                            version,
+                            '20140903141017',
+                            '{abc}',
+                            channel,
+                        ))
+                        adi_count *= 2
+        cursor.execute('select count(*) from raw_adi')
+        count, = cursor.fetchone()
+        # We expect there to be 2 channels per every 2 platforms,
+        # per every 2 versions per every 2 products.
+        assert count == 2 * 2 * 2 * 2, count
+        self.connection.commit()
+
+    def tearDown(self):
+        self._truncate()
+        super(IntegrationTestADI, self).tearDown()
+
+    def _truncate(self):
+        cursor = self.connection.cursor()
+        cursor.execute("""
+            TRUNCATE raw_adi CASCADE
+        """)
+        self.connection.commit()
+
+    def test_get(self):
+        impl = ADI(config=self.config)
+        assert_raises(
+            MissingArgumentError,
+            impl.get
+        )
+        start = self.date - datetime.timedelta(days=1)
+        end = self.date
+        stats = impl.get(
+            start_date=start,
+            end_date=end,
+            product='Firefox',
+            version='42'
+        )
+        eq_(stats['hits'], [])
+
+        stats = impl.get(
+            start_date=start,
+            end_date=end,
+            product='Firefox',
+            version='40'
+        )
+        start_formatted = start.strftime('%Y-%m-%d')
+        hits = stats['hits']
+        # Because the results come back in no particular order,
+        # to make it easier to compare, sort by something predictable.
+        hits.sort(key=lambda x: x['adi_count'])
+
+        eq_(stats['hits'][0], {
+            'adi_count': 16L,
+            'date': start_formatted,
+            'product': 'Firefox',
+            'version': '40',
+            'platform': 'Linux',
+            'release_channel': 'release'
+        })
+        eq_(stats['hits'][1], {
+            'adi_count': 32L,
+            'date': start_formatted,
+            'product': 'Firefox',
+            'version': '40',
+            'platform': 'Linux',
+            'release_channel': 'beta'
+        })
+        eq_(stats['hits'][2], {
+            'adi_count': 64L,
+            'date': start_formatted,
+            'product': 'Firefox',
+            'version': '40',
+            'platform': 'Darwin',
+            'release_channel': 'release'
+        })
+        eq_(stats['hits'][3], {
+            'adi_count': 128L,
+            'date': start_formatted,
+            'product': 'Firefox',
+            'version': '40',
+            'platform': 'Darwin',
+            'release_channel': 'beta'
+        })


### PR DESCRIPTION
@rhelmer r? (informal)

Rob, I just wanted to share what I've got so far. 
Again, here's an example of its use: https://gist.github.com/peterbe/843ec4764e39dc6a364d

The reason I'm not treading with confidence is because I'm not entirely sure how I'm going to need this to work. My objective is to pull in data from this into the webapp and use SuperSearch aggregates to combine crash counts with ADI. In particular for the sake of the /daily report. I haven't yet started looking at throttle values. 