### PR TITLE
Fixes Bug 1186505 - complete a half-assed unification of 'source_iterator'

### DIFF
--- a/socorro/collector/crashmover_app.py
+++ b/socorro/collector/crashmover_app.py
@@ -78,8 +78,15 @@ class ProcessedCrashCopierApp(FetchTransformSaveApp):
           self.quit_check
         )
         for x in self.iterator():
-            self.config.logger.debug('yielding %s', x)
-            yield x  # (args, kwargs) or None
+            if x is None:
+                self.config.logger.debug('yielding %s', x)
+                yield None
+            elif isinstance(x, tuple):
+                self.config.logger.debug('yielding %s', x)
+                yield x  # (args, kwargs) or None
+            else:
+                yield (x, {})  # ensure (args, kwargs) form
+
 
     #--------------------------------------------------------------------------
     def _transform(self, crash_id):

--- a/socorro/collector/submitter_app.py
+++ b/socorro/collector/submitter_app.py
@@ -250,7 +250,10 @@ class SubmitterApp(FetchTransformSaveApp):
         for x in self._crash_set_iter():
             if x is None:
                 break
-            yield ((x,), {})
+            elif isinstance(x, tuple):
+                yield x  # already in (args, kwargs) form
+            else:
+                yield ((x,), {})  # (args, kwargs)
             if self.config.submitter.delay:
                 time.sleep(self.config.submitter.delay)
         self.config.logger.info(

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -181,9 +181,12 @@ class RabbitMQCrashStorage(CrashStorageBase):
                     continue
                 if method_frame:
                     break
-            if not method_frame:
-                return
+            # must consume ack queue before testing for end of iterator
+            # or the last job won't get ack'd
             self._consume_acknowledgement_queue()
+            if not method_frame:
+                # there was nothing in the queue - leave the iterator
+                return
             self.acknowledgement_token_cache[body] = method_frame
             yield body
             queues.reverse()

--- a/socorro/unittest/collector/test_crash_mover_app.py
+++ b/socorro/unittest/collector/test_crash_mover_app.py
@@ -135,7 +135,11 @@ class TestCrashMoverApp(TestCase):
                     self.first = False
                 else:
                     for k in range(999):
-                        yield k
+                        # ensure that both forms work
+                        if k % 4:
+                            yield k
+                        else:
+                            yield ((k, ), {'some_crap': True,} )
                     for k in range(2):
                         yield None
 

--- a/socorro/unittest/collector/test_submitter_app.py
+++ b/socorro/unittest/collector/test_submitter_app.py
@@ -431,8 +431,10 @@ class TestSubmitterApp(TestCase):
         sub._setup_source_and_destination()
         itera = sub.source_iterator()
 
+        # setup a fake iter using two form of the data to ensure it deals
+        # with both forms correctly.
         config.new_crash_source.new_crash_source_class.return_value \
-            .new_crashes = lambda: iter([1, 2, 3])
+            .new_crashes = lambda: iter([1, ((2, ), {}), 3])
 
         eq_(itera.next(), ((1,), {}))
         eq_(itera.next(), ((2,), {}))
@@ -451,12 +453,12 @@ class TestSubmitterApp(TestCase):
         itera = sub.source_iterator()
 
         config.new_crash_source.new_crash_source_class.return_value \
-            .new_crashes = lambda: iter([1, 2, 3])
+            .new_crashes = lambda: iter([((1, ), {'finished_func': 1,}), 2, 3])
 
-        eq_(itera.next(), ((1,), {}))
+        eq_(itera.next(), ((1,), {'finished_func': 1,}))
         eq_(itera.next(), ((2,), {}))
         eq_(itera.next(), ((3,), {}))
-        eq_(itera.next(), ((1,), {}))
+        eq_(itera.next(), ((1,), {'finished_func': 1,}))
         eq_(itera.next(), ((2,), {}))
         assert_raises(StopIteration, itera.next)
 

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -47,7 +47,7 @@ class TestProcessorApp(TestCase):
 
         config.new_crash_source = DotDict()
         sequence_generator = sequencer(((1,), {}),
-                                       ((2,), {}),
+                                       2,  # ensure both forms acceptable
                                        None,
                                        ((3,), {}))
         mocked_new_crash_source = mock.Mock(side_effect=sequence_generator)


### PR DESCRIPTION
nope nope nope 

the PR that closed this Bug 1186505 was half-assed and incomplete.  

every instance of the method 'source_iterator' must accept from its internal iterator crashes either in the form of 
    1)  crash_id
    2)  ((crash_id,), {'additional': 'kwargs'})
and should always return the second form.

ALSO:

the rabbitmq method 'new_crashes' must run the '_consume_acknowledgement_queue' BEFORE checking for the end of iteration.  If it does not, then the last crash will not be acknowledged in the queue.