### PR TITLE
fixes Bug 1168511 - filter all strings in raw crash input to remove \x00

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -96,6 +96,13 @@ class BreakpadCollector(RequiredConfig):
         return web.webapi.rawinput()
 
     #--------------------------------------------------------------------------
+    @staticmethod
+    def _no_x00_character(value):
+        if isinstance(value, basestring) and '\x00' in value:
+            return ''.join(c for c in value if c != '\x00')
+        return value
+
+    #--------------------------------------------------------------------------
     def _get_raw_crash_from_form(self):
         """this method creates the raw_crash and the dumps mapping using the
         POST form"""
@@ -105,7 +112,7 @@ class BreakpadCollector(RequiredConfig):
         for name, value in self._form_as_mapping().iteritems():
             if isinstance(value, basestring):
                 if name != "dump_checksums":
-                    raw_crash[name] = value
+                    raw_crash[name] = self._no_x00_character(value)
             elif hasattr(value, 'file') and hasattr(value, 'value'):
                 dumps[name] = value.value
                 raw_crash.dump_checksums[name] = \

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -61,7 +61,7 @@ class TestCollectorApp(TestCase):
         form.ProductName = 'FireSquid'
         form.Version = '99'
         form.dump = 'fake dump'
-        form.some_field = '23'
+        form.some_field = '\x0023'
         form.some_other_field = ObjectWithValue('XYZ')
 
         class BreakpadCollectorWithMyForm(config.collector.collector_class):
@@ -84,7 +84,7 @@ class TestCollectorApp(TestCase):
         config = self.get_standard_config()
         c = BreakpadCollector(config)
         rawform = DotDict()
-        rawform.ProductName = 'FireSquid'
+        rawform.ProductName = '\x00FireSquid'
         rawform.Version = '99'
         rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
         rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
@@ -190,7 +190,7 @@ class TestCollectorApp(TestCase):
         rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
         rawform.some_field = '23'
         rawform.some_other_field = ObjectWithValue('XYZ')
-        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.uuid = '332d798f-3cx\x0042-47a5-843f-a0f892140107'
 
         form = DotDict(rawform)
         form.dump = rawform.dump.value
@@ -359,7 +359,7 @@ class TestCollectorApp(TestCase):
 
         rawform = DotDict()
         rawform.ProductName = 'FireSquid'
-        rawform.Version = '99'
+        rawform.Version = '99\x00'
         rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
         rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
         rawform.some_field = '23'


### PR DESCRIPTION
we seem to be getting crashes with null bytes embedded in strings.  Ensure that the collector sanitizes these strings so that the null bytes don't come through and upset the delicate sensibilities of PostgreSQL.  