### PR TITLE
Fixes bug 1188786 - Removed duplicate uuid columns in Reports tab of …

### DIFF
--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -72,6 +72,8 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             assert '_columns' in params
 
+            ok_('uuid' in params['_columns'])
+
             ok_('signature' in params)
             eq_(params['signature'], ['=' + DUMB_SIGNATURE])
 

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -135,12 +135,20 @@ def signature_reports(request):
         x for x in data['columns'] if x in allowed_fields
     ]
 
-    params['_columns'] = data['columns']
+    # Copy the list of columns so that they can differ.
+    params['_columns'] = list(data['columns'])
 
     # The uuid is always displayed in the UI so we need to make sure it is
     # always returned by the model.
     if 'uuid' not in params['_columns']:
         params['_columns'].append('uuid')
+
+    # The `uuid` field is a special case, it is always displayed in the first
+    # column of the table. Hence we do not want to show it again in the
+    # auto-generated list of columns, so we its name from the list of
+    # columns to display.
+    if 'uuid' in data['columns']:
+        data['columns'].remove('uuid')
 
     try:
         current_page = int(request.GET.get('page', 1))

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -174,6 +174,7 @@ def search_results(request):
         x for x in data['columns'] if x in allowed_fields
     ]
 
+    # Copy the list of columns so that they can differ.
     params['_columns'] = list(data['columns'])
 
     # The uuid is always displayed in the UI so we need to make sure it is
@@ -181,8 +182,10 @@ def search_results(request):
     if 'uuid' not in params['_columns']:
         params['_columns'].append('uuid')
 
-    # The `uuid` field is a special case, it will not be displayed like
-    # normal columns.
+    # The `uuid` field is a special case, it is always displayed in the first
+    # column of the table. Hence we do not want to show it again in the
+    # auto-generated list of columns, so we its name from the list of
+    # columns to display.
     if 'uuid' in data['columns']:
         data['columns'].remove('uuid')
 


### PR DESCRIPTION
…signature report page.

@peterbe r?

Same fix is in place in Super Search. It's difficult to test (it would require loading the entire DOM to verify that the list of columns doesn't have 'uuid', and I thought it was trivial enough to not be worth the test). 