### PR TITLE
Bug 1190046 - Update forced versions for correlations for Firefox cycle starting 2015-08-10

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="40.0b1 40.0b2 40.0b3 40.0b4 40.0b5 40.0b6 40.0b7 40.0b8 40.0b9 40.0b99 41.0a2 42.0a1"
+MANUAL_VERSION_OVERRIDE="41.0b1 41.0b2 41.0b3 41.0b4 41.0b5 41.0b6 41.0b7 41.0b8 41.0b9 41.0b99 42.0a2 43.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This adds current aurora and nightly versions as well as all planned beta versions for this cycle, and should land on prod in the week of August 10.

Note the conversation from https://github.com/mozilla/socorro/pull/2877 - we need to update the crashanalysis node with that code to actually make it live.