### PR TITLE
Fixes Bug 1168511 (again) - add ability to test keys for null bytes

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -98,8 +98,10 @@ class BreakpadCollector(RequiredConfig):
     #--------------------------------------------------------------------------
     @staticmethod
     def _no_x00_character(value):
-        if isinstance(value, basestring) and '\x00' in value:
-            return ''.join(c for c in value if c != '\x00')
+        if isinstance(value, basestring) and (
+            '\x00' in value or u'\u0000' in value
+        ):
+            return ''.join(c for c in value if (c != '\x00' and c != u'\u0000'))
         return value
 
     #--------------------------------------------------------------------------
@@ -110,6 +112,7 @@ class BreakpadCollector(RequiredConfig):
         raw_crash = DotDict()
         raw_crash.dump_checksums = DotDict()
         for name, value in self._form_as_mapping().iteritems():
+            name = self._no_x00_character(name)
             if isinstance(value, basestring):
                 if name != "dump_checksums":
                     raw_crash[name] = self._no_x00_character(value)

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -138,7 +138,7 @@ class TestCollectorApp(TestCase):
         config = self.get_standard_config()
         c = BreakpadCollector(config)
         rawform = DotDict()
-        rawform.ProductName = 'FireSquid'
+        rawform[u'\u0000ProductName'] = 'FireSquid'
         rawform.Version = '99'
         rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
         rawform.some_field = '23'
@@ -362,8 +362,8 @@ class TestCollectorApp(TestCase):
         rawform.Version = '99\x00'
         rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
         rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
-        rawform.some_field = '23'
-        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform[u'some_field\u0000'] = '23'
+        rawform[u'some_\u0000other_field'] = ObjectWithValue('XYZ')
         rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
         rawform.legacy_processing = str(DEFER)
         rawform.throttle_rate = 100


### PR DESCRIPTION
it turns out that the null string can occurr in both the key and the value.  The previous fix for this problem only focused on the values for the keys, not the keys themselves.  

This fixes that oversight.
