### PR TITLE
Bug 1184173 - Added missing hash for freezegun package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -188,4 +188,5 @@ toposort==1.1
 # sha256: RQlJFVzISXytrJZqgYeXSNs8GMz2QMsnMX4BSJr1hyQ
 datadog==0.5.0
 # sha256: x4ZXPEj73ejlDlVeXiWoNkQ-Zm1sz_bLDSAIYVNYsOM
+# sha256: 7lmy7t1AEe6q6Kle7DGql37DVd9_TsoQZ_QCy3lCngo
 freezegun==0.3.5


### PR DESCRIPTION
@jdotpz r? This should fix the build. 