### PR TITLE
more Fixes Bug 1168511 - separate unicode & str cases in cleaning of null bytes.

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -98,10 +98,10 @@ class BreakpadCollector(RequiredConfig):
     #--------------------------------------------------------------------------
     @staticmethod
     def _no_x00_character(value):
-        if isinstance(value, basestring) and (
-            '\x00' in value or u'\u0000' in value
-        ):
-            return ''.join(c for c in value if (c != '\x00' and c != u'\u0000'))
+        if isinstance(value, unicode) and u'\u0000' in value:
+            return ''.join(c for c in value if c != u'\u0000')
+        if isinstance(value, str) and '\x00' in value:
+            return ''.join(c for c in value if c != '\x00')
         return value
 
     #--------------------------------------------------------------------------

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -487,3 +487,11 @@ aux_dump contents
             {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
             r[11:-1]
         )
+
+    def test_no_x00_character(self):
+        config = self.get_standard_config()
+        c = BreakpadCollector(config)
+
+        eq_(c._no_x00_character('\x00hello'), 'hello')
+        eq_(c._no_x00_character(u'\u0000bye'), 'bye')
+        eq_(c._no_x00_character(u'\u0000\x00bye'), 'bye')


### PR DESCRIPTION
the collector bad bytes cleanup is failing on unicode/str conversions.  separate the cases so that can be more controlled in the cleanup of bad bytes.

