### PR TITLE
Fixes Bug 1196722 - allow FS to save raw, dumps & processed in combined call

### DIFF
--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -187,26 +187,14 @@ class FSRadixTreeStorage(CrashStorageBase):
         })
 
     def save_raw_crash(self, raw_crash, dumps, crash_id):
+        if dumps is None:
+            dumps = {}
         files = {
             crash_id + self.config.json_file_suffix: json.dumps(raw_crash)
         }
         files.update(dict((self._get_dump_file_name(crash_id, fn), dump)
                           for fn, dump in dumps.iteritems()))
         self._save_files(crash_id, files)
-
-    def save_raw_and_processed(self, raw_crash, dumps, processed_crash, crash_id):
-        """ bug 866973 - do not try to save dumps=None into the Filesystem
-            We are doing this in lieu of a queuing solution that could allow
-            us to operate an independent crashmover. When the queuing system
-            is implemented, we could remove this, and have the raw crash
-            saved by a crashmover that's consuming crash_ids the same way
-            that the processor consumes them.
-
-            Even though it is ok to resave the raw_crash in this case to the
-            filesystem, the fs does not know what to do with a dumps=None
-            when passed to save_raw, so we are going to avoid that.
-        """
-        self.save_processed(processed_crash)
 
     def get_raw_crash(self, crash_id):
         parent_dir = self._get_radixed_parent_directory(crash_id)

--- a/socorro/unittest/external/fs/test_fsdatedradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fsdatedradixtreestorage.py
@@ -40,24 +40,157 @@ class TestFSDatedRadixTreeStorage(TestCase):
         return config_manager
 
     def _make_test_crash(self):
-        self.fsrts.save_raw_crash({
-            "test": "TEST"
-        }, {
-            'foo': 'bar',
-            self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_1)
+        self.fsrts.save_raw_crash(
+            {  # raw crash
+                "test": "TEST"
+            },
+            {  # dumps
+                'foo': 'bar',
+                self.fsrts.config.dump_field: 'baz'
+            },
+            self.CRASH_ID_1
+        )
 
     def test_save_raw_crash(self):
-        self._make_test_crash()
-        ok_(os.path.islink(
-            os.path.join(
-              self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
-              self.fsrts._get_date_root_name(self.CRASH_ID_1))))
-        ok_(os.path.exists(
-            os.path.join(
-              self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
-              self.fsrts._get_date_root_name(self.CRASH_ID_1),
-              self.CRASH_ID_1)))
+        try:
+            self._make_test_crash()
+            ok_(os.path.islink(
+                os.path.join(
+                  self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                  self.fsrts._get_date_root_name(self.CRASH_ID_1))))
+            ok_(os.path.exists(
+                os.path.join(
+                  self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                  self.fsrts._get_date_root_name(self.CRASH_ID_1),
+                  self.CRASH_ID_1)))
+            ok_(
+                os.path.exists(
+                    "%s/%s.json" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(
+                os.path.exists(
+                    "%s/%s.dump" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(
+                os.path.exists(
+                    "%s/%s.foo.dump" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+        finally:
+            self.fsrts.remove(self.CRASH_ID_1)
+
+    def test_save_raw_crash_no_dumps(self):
+        try:
+            self.fsrts.save_raw_crash(
+                {  # raw crash
+                    "test": "TEST"
+                },
+                None,  # dumps
+                self.CRASH_ID_1
+            )
+            ok_(os.path.islink(
+                os.path.join(
+                  self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                  self.fsrts._get_date_root_name(self.CRASH_ID_1))))
+            ok_(os.path.exists(
+                os.path.join(
+                  self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                  self.fsrts._get_date_root_name(self.CRASH_ID_1),
+                  self.CRASH_ID_1)))
+            ok_(
+                os.path.exists(
+                    "%s/%s.json" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(not
+                os.path.exists(
+                    "%s/%s.dump" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(not
+                os.path.exists(
+                    "%s/%s.foo.dump" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+        finally:
+            self.fsrts.remove(self.CRASH_ID_1)
+
+    def test_save_raw_and_processed_crash_no_dumps(self):
+        try:
+            self.fsrts.save_raw_and_processed(
+                {  # raw crash
+                    "test": "TEST"
+                },
+                None,  # dumps
+                {  # processed_crash
+                    'processed': 'crash',
+                    'uuid': self.CRASH_ID_1,
+                },
+                self.CRASH_ID_1
+            )
+            ok_(os.path.islink(
+                os.path.join(
+                  self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                  self.fsrts._get_date_root_name(self.CRASH_ID_1))))
+            ok_(os.path.exists(
+                os.path.join(
+                  self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                  self.fsrts._get_date_root_name(self.CRASH_ID_1),
+                  self.CRASH_ID_1)))
+            ok_(
+                os.path.exists(
+                    "%s/%s.json" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(not
+                os.path.exists(
+                    "%s/%s.dump" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(not
+                os.path.exists(
+                    "%s/%s.foo.dump" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+            ok_(
+                os.path.exists(
+                    "%s/%s.jsonz" % (
+                        self.fsrts._get_radixed_parent_directory(self.CRASH_ID_1),
+                        self.CRASH_ID_1
+                    )
+                )
+            )
+        finally:
+            self.fsrts.remove(self.CRASH_ID_1)
 
     def test_get_raw_crash(self):
         self._make_test_crash()


### PR DESCRIPTION
removes out-dated prohibition on saving raw crash in the ```save_raw_and_processed``` method