### PR TITLE
Fixes Bug 1200628 - altered RunWatchDog sig rule to account for arg collapsing

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -74,6 +74,7 @@ class CSignatureToolBase(SignatureTool):
         'collapse_arguments',
         default=False,
         doc="remove function arguments during normalization",
+        reference_value_from='resource.signature'
     )
 
     hang_prefixes = {
@@ -283,7 +284,8 @@ class CSignatureTool(CSignatureToolBase):
                'Java_org_mozilla_gecko_GeckoAppShell_reportJavaCrash',
                'google_breakpad::ExceptionHandler::HandleInvalidParameter'
               ]""",
-        from_string_converter=eval
+        from_string_converter=eval,
+        reference_value_from='resource.signature'
     )
     required_config.add_option(
         'irrelevant_signature_re',
@@ -337,7 +339,8 @@ class CSignatureTool(CSignatureToolBase):
           '_ZdlPv',
           'zero',
           ])""",
-        from_string_converter=eval
+        from_string_converter=eval,
+        reference_value_from='resource.signature'
     )
     required_config.add_option(
         'prefix_signature_re',
@@ -511,7 +514,8 @@ class CSignatureTool(CSignatureToolBase):
           '.*DebugAbort.*',
           'mozilla::ipc::MessageChannel::~MessageChannel.*',
         ])""",
-        from_string_converter=eval
+        from_string_converter=eval,
+        reference_value_from='resource.signature'
     )
     required_config.add_option(
         'signatures_with_line_numbers_re',
@@ -555,14 +559,16 @@ class CSignatureToolDB(CSignatureToolBase):
         doc="the class of the database",
         default='socorro.external.postgresql.connection_context.'
                 'ConnectionContext',
-        from_string_converter=class_converter
+        from_string_converter=class_converter,
+        reference_value_from='resource.signature'
     )
     required_config.add_option(
         'transaction_executor_class',
         default="socorro.database.transaction_executor."
                 "TransactionExecutorWithInfiniteBackoff",
         doc='a class that will manage transactions',
-        from_string_converter=class_converter
+        from_string_converter=class_converter,
+        reference_value_from='resource.signature'
     )
 
     #--------------------------------------------------------------------------
@@ -715,19 +721,22 @@ class SignatureGenerationRule(Rule):
         'c_signature_tool_class',
         doc='the class that can generate a C signature',
         default='socorro.processor.signature_utilities.CSignatureTool',
-        from_string_converter=class_converter
+        from_string_converter=class_converter,
+        reference_value_from='resource.signature'
     )
     required_config.c_signature.add_option(
         'maximum_frames_to_consider',
         doc='the maximum number of frames to consider',
         default=40,
+        reference_value_from='resource.signature'
     )
     required_config.namespace('java_signature')
     required_config.java_signature.add_option(
         'java_signature_tool_class',
         doc='the class that can generate a Java signature',
         default='socorro.processor.signature_utilities.JavaSignatureTool',
-        from_string_converter=class_converter
+        from_string_converter=class_converter,
+        reference_value_from='resource.signature'
     )
 
     #--------------------------------------------------------------------------
@@ -912,7 +921,7 @@ class SignatureRunWatchDog(SignatureGenerationRule):
 
     #--------------------------------------------------------------------------
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        return '::RunWatchdog(void*)' in processed_crash['signature']
+        return '::RunWatchdog' in processed_crash['signature']
 
     #--------------------------------------------------------------------------
     def _get_crashing_thread(self, processed_crash):

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -881,7 +881,7 @@ frames_from_json_dump_with_templates = {
         },
         {
             u'frame': 3,
-            u'function': u'RealMsgWaitForMultipleObjectsEx',
+            u'function': u'RealMsgWaitForMultipleObjectsEx(void **fakeargs)',
             u'function_offset': u'0xe1',
             u'module': u'user32.dll',
             u'module_offset': u'0x20869',
@@ -1468,6 +1468,7 @@ class TestSignatureWatchDogRule(TestCase):
                     CSignatureTool.required_config
                     .signatures_with_line_numbers_re.default
                 ),
+                'collapse_arguments': True,
             },
             'java_signature': {
                 'java_signature_tool_class': JavaSignatureTool,
@@ -1504,7 +1505,7 @@ class TestSignatureWatchDogRule(TestCase):
         ok_(srwd.predicate({}, {}, fake_processed_crash, {}))
 
         fake_processed_crash = {
-            'signature': "mozilla::(anonymous namespace)::RunWatchdog(void*)",
+            'signature': "mozilla::(anonymous namespace)::RunWatchdog",
         }
         ok_(srwd.predicate({}, {}, fake_processed_crash, {}))
 


### PR DESCRIPTION
two problems:
1. the RunWatchDog rule will not trigger properly if arguments are collapsed. solution: remove the arguments from the predicate
2. the RunWatchDog rule on triggering, regenerates the signature forcing it to use thread-0. The collapse arguments boolean does not extend to this regeneration.  Solution: add a "reference_value_from" to make configman signature arguements act globally instead of only locally.  Then set "resource.signature.collapse_arguments=True" in consulate.