### PR TITLE
Bug 1196867 new crashes per user using supersearch

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -195,7 +195,6 @@ class SuperSearch(SearchBase):
         The list of accepted parameters (with types and default values) is in
         the database and can be accessed with the super_search_fields service.
         """
-
         # Filter parameters and raise potential errors.
         params = self.get_parameters(**kwargs)
 

--- a/socorro/external/postgresql/product_build_types.py
+++ b/socorro/external/postgresql/product_build_types.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+
+from socorro.external import MissingArgumentError
+from socorro.external.postgresql.base import PostgreSQLBase
+from socorro.lib import external_common
+
+
+logger = logging.getLogger("webapi")
+
+
+class ProductBuildTypes(PostgreSQLBase):
+
+    def get(self, **kwargs):
+        """Return a dict that holds the throttling value per build type
+        for a specific product."""
+        filters = [
+            ('product', None, 'str'),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+        required = ('product',)
+        for key in required:
+            if not params.get(key):
+                raise MissingArgumentError(key)
+
+        sql = """
+            SELECT
+                build_type,
+                throttle
+            FROM product_build_types
+            WHERE product_name = %(product)s
+        """
+        results = self.query(sql, params)
+
+        build_types = {}
+        for row in results:
+            build_types[row[0]] = row[1]
+
+        return {
+            'hits': build_types,
+        }

--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -352,6 +352,8 @@ class SearchBase(object):
                     new_values.append(0)
                 elif val == 'hang':
                     new_values.extend([-1, 1])
+                else:
+                    new_values.append(val)
 
             hang_type.value = new_values
             hang_type.data_type = 'int'

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -59,6 +59,7 @@ SERVICES_LIST = (
     (r'/graphics_devices/(.*)', 'graphics_devices.GraphicsDevices'),
     (r'/platforms/(.*)', 'platforms.Platforms'),
     (r'/priorityjobs/(.*)', 'priorityjobs.Priorityjobs'),
+    (r'/products/build_types/(.*)', 'product_build_types.ProductBuildTypes'),
     (r'/products/(.*)', 'products.Products'),
     (r'/query/', 'query.Query'),
     (r'/releases/(channels|featured|release)/(.*)', 'releases.Releases'),

--- a/socorro/unittest/external/postgresql/test_adi.py
+++ b/socorro/unittest/external/postgresql/test_adi.py
@@ -26,11 +26,50 @@ class IntegrationTestADI(PostgreSQLTestCase):
         self.date = datetime.datetime(2015, 7, 1)
         yesterday = self.date - datetime.timedelta(hours=24)
         products = ('Firefox', 'Thunderbird')
-        versions = ('39', '40')
-        platforms = ('Linux', 'Darwin')
+
+        versions = ('39.0', '40.0')
+        platforms = ('Linux', 'Windows')
         channels = ('release', 'beta')
+
+        build_date = yesterday - datetime.timedelta(days=30)
+        sunset_date = yesterday + datetime.timedelta(days=30)
+
+        for platform in platforms:
+            cursor.execute("""
+                INSERT INTO os_names
+                (os_short_name, os_name)
+                VALUES
+                (%s, %s)
+            """, (platform.lower()[:3], platform))
+            cursor.execute("""
+                INSERT INTO os_name_matches
+                (match_string, os_name)
+                VALUES
+                (%s, %s)
+            """, (platform, platform))
+
         adi_count = 1
+        product_version_id = 0
         for product in products:
+            cursor.execute("""
+                INSERT INTO products
+                (product_name, sort, release_name)
+                VALUES
+                (%s, 1, %s)
+            """, (
+                product, product.lower()
+            ))
+            cursor.execute("""
+                INSERT into product_productid_map (
+                    product_name,
+                    productid
+                ) VALUES (
+                    %s, %s
+                )
+            """, (
+                product,
+                product.lower() + '-guid',
+            ))
             for version in versions:
                 for platform in platforms:
                     for channel in channels:
@@ -48,7 +87,7 @@ class IntegrationTestADI(PostgreSQLTestCase):
                                 received_at
                             )
                             VALUES (
-                                %s, %s, %s, %s, %s, %s, %s, %s, %s, now()
+                                %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW()
                             )
                         """, (
                             adi_count,
@@ -62,12 +101,36 @@ class IntegrationTestADI(PostgreSQLTestCase):
                             channel,
                         ))
                         adi_count *= 2
-        cursor.execute('select count(*) from raw_adi')
-        count, = cursor.fetchone()
-        # We expect there to be 2 channels per every 2 platforms,
-        # per every 2 versions per every 2 products.
-        assert count == 2 * 2 * 2 * 2, count
+
+                product_version_id += 1
+                cursor.execute("""
+                    INSERT INTO product_versions
+                    (product_version_id, product_name, major_version,
+                     release_version, version_string, version_sort,
+                     build_date, sunset_date, featured_version,
+                     build_type, build_type_enum)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 't', %s, %s)
+                """, (
+                    product_version_id,
+                    product,
+                    version,
+                    version,
+                    version,
+                    '0000' + version.replace('.', ''),
+                    build_date,
+                    sunset_date,
+                    'release',
+                    'release',
+                ))
+
+        cursor.callproc('update_adu', [yesterday.date()])
         self.connection.commit()
+
+        cursor = self.connection.cursor()
+        cursor.execute('select count(*) from product_adu')
+        count, = cursor.fetchone()
+        # expect there to be 2 * 2 * 2 rows of product_adu
+        assert count == 8, count
 
     def tearDown(self):
         self._truncate()
@@ -76,7 +139,10 @@ class IntegrationTestADI(PostgreSQLTestCase):
     def _truncate(self):
         cursor = self.connection.cursor()
         cursor.execute("""
-            TRUNCATE raw_adi CASCADE
+            TRUNCATE
+                raw_adi, products, product_versions, product_adu,
+                product_productid_map, os_names, os_name_matches
+            CASCADE
         """)
         self.connection.commit()
 
@@ -92,7 +158,8 @@ class IntegrationTestADI(PostgreSQLTestCase):
             start_date=start,
             end_date=end,
             product='Firefox',
-            version='42'
+            versions=['42'],
+            platforms=['Linux', 'Windows'],
         )
         eq_(stats['hits'], [])
         eq_(stats['total'], 0)
@@ -101,44 +168,15 @@ class IntegrationTestADI(PostgreSQLTestCase):
             start_date=start,
             end_date=end,
             product='Firefox',
-            version='40'
+            versions=['40.0'],
+            platforms=['Linux', 'Windows'],
         )
         start_formatted = start.strftime('%Y-%m-%d')
-        eq_(stats['total'], 4)
-        hits = stats['hits']
-        # Because the results come back in no particular order,
-        # to make it easier to compare, sort by something predictable.
-        hits.sort(key=lambda x: x['adi_count'])
-
-        eq_(stats['hits'][0], {
-            'adi_count': 16L,
+        eq_(stats['total'], 1)
+        hit, = stats['hits']
+        eq_(hit, {
+            'adi_count': 64L + 16L,
             'date': start_formatted,
-            'product': 'Firefox',
-            'version': '40',
-            'platform': 'Linux',
-            'release_channel': 'release'
-        })
-        eq_(stats['hits'][1], {
-            'adi_count': 32L,
-            'date': start_formatted,
-            'product': 'Firefox',
-            'version': '40',
-            'platform': 'Linux',
-            'release_channel': 'beta'
-        })
-        eq_(stats['hits'][2], {
-            'adi_count': 64L,
-            'date': start_formatted,
-            'product': 'Firefox',
-            'version': '40',
-            'platform': 'Darwin',
-            'release_channel': 'release'
-        })
-        eq_(stats['hits'][3], {
-            'adi_count': 128L,
-            'date': start_formatted,
-            'product': 'Firefox',
-            'version': '40',
-            'platform': 'Darwin',
-            'release_channel': 'beta'
+            'version': '40.0',
+            'build_type': 'release'
         })

--- a/socorro/unittest/external/postgresql/test_crash_data.py
+++ b/socorro/unittest/external/postgresql/test_crash_data.py
@@ -25,7 +25,7 @@ class TestIntegrationPostgresCrashData(TestCase):
     def setUp(self):
         super(TestIntegrationPostgresCrashData, self).setUp()
         self.config_manager = self._common_config_setup()
-
+        self._truncate()
         with self.config_manager.context() as config:
             store = crashstorage.PostgreSQLCrashStorage(config.database)
 
@@ -99,20 +99,22 @@ class TestIntegrationPostgresCrashData(TestCase):
         )
 
     def tearDown(self):
+        self._truncate()
+        super(TestIntegrationPostgresCrashData, self).tearDown()
+
+    def _truncate(self):
         with self.config_manager.context() as config:
             store = crashstorage.PostgreSQLCrashStorage(config.database)
 
-        connection = store.database.connection()
-        cursor = connection.cursor()
-        cursor.execute("""
-            TRUNCATE
-                report_partition_info,
-                plugins
-            CASCADE;
-        """)
-        connection.commit()
-
-        super(TestIntegrationPostgresCrashData, self).tearDown()
+            connection = store.database.connection()
+            cursor = connection.cursor()
+            cursor.execute("""
+                TRUNCATE
+                    report_partition_info,
+                    plugins
+                CASCADE
+            """)
+            connection.commit()
 
     def _common_config_setup(self):
         mock_logging = Mock()

--- a/socorro/unittest/external/postgresql/test_product_build_types.py
+++ b/socorro/unittest/external/postgresql/test_product_build_types.py
@@ -1,0 +1,118 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from decimal import Decimal
+
+from nose.plugins.attrib import attr
+from nose.tools import eq_, assert_raises
+
+from socorro.external import MissingArgumentError
+from socorro.external.postgresql.product_build_types import ProductBuildTypes
+
+from .unittestbase import PostgreSQLTestCase
+
+
+#==============================================================================
+@attr(integration='postgres')  # for nosetests
+class IntegrationTestProductBuildTypes(PostgreSQLTestCase):
+    """Test socorro.external.postgresql.product_build_types.ProductBuildTypes
+     class. """
+
+    @classmethod
+    def setUpClass(cls):
+        """ Populate product_info table with fake data """
+        super(IntegrationTestProductBuildTypes, cls).setUpClass()
+
+        cursor = cls.connection.cursor()
+
+        cursor.execute("""
+            INSERT INTO products
+            (product_name, sort, rapid_release_version, release_name)
+            VALUES
+            (
+                'Firefox',
+                1,
+                '8.0',
+                'firefox'
+            ),
+            (
+                'Fennec',
+                3,
+                '11.0',
+                'mobile'
+            ),
+            (
+                'Thunderbird',
+                2,
+                '10.0',
+                'thunderbird'
+            );
+        """)
+
+        cursor.execute("""
+            INSERT INTO product_build_types
+            (product_name, build_type, throttle)
+            VALUES
+            (
+                'Firefox',
+                'beta',
+                1.0
+            ),
+            (
+                'Firefox',
+                'release',
+                0.2
+            ),
+            (
+                'Fennec',
+                'release',
+                0.1
+            )
+        """)
+
+        cls.connection.commit()
+
+    #--------------------------------------------------------------------------
+    @classmethod
+    def tearDownClass(cls):
+        """ Cleanup the database, delete tables and functions """
+        cursor = cls.connection.cursor()
+        cursor.execute("""
+            TRUNCATE products, product_build_types
+            CASCADE
+        """)
+        cls.connection.commit()
+        super(IntegrationTestProductBuildTypes, cls).tearDownClass()
+
+    #--------------------------------------------------------------------------
+    def test_get(self):
+        product_build_types = ProductBuildTypes(config=self.config)
+
+        # Test: find match for one product
+        res = product_build_types.get(product='Firefox')
+        res_expected = {
+            'hits': {
+                'release': Decimal('0.2'),
+                'beta': Decimal('1.0'),
+            }
+        }
+        eq_(res, res_expected)
+
+        # Test: find no match for unrecognized product
+        res = product_build_types.get(product='Neverheardof')
+        res_expected = {
+            'hits': {}
+        }
+        eq_(res, res_expected)
+
+        # Test: missing product parameter
+        assert_raises(
+            MissingArgumentError,
+            product_build_types.get,
+        )
+        assert_raises(
+            MissingArgumentError,
+            product_build_types.get,
+            product=''
+        )

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1740,10 +1740,24 @@ class ADI(SocorroMiddleware):
         ('start_date', datetime.date),
         ('end_date', datetime.date),
         'product',
-        'version',
+        ('versions', list),
+        ('platforms', list),
     )
 
     API_WHITELIST = (
         'hits',
         'total',
+    )
+
+
+class ProductBuildTypes(SocorroMiddleware):
+
+    URL_PREFIX = '/products/build_types/'
+
+    required_params = (
+        'product',
+    )
+
+    API_WHITELIST = (
+        'hits',
     )

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/crashes_per_user.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/crashes_per_user.less
@@ -1,0 +1,103 @@
+@import "base.less";
+
+h1 {
+    color: #000;
+    font-size: 1.90em;
+    font-weight: bold;
+}
+.page-heading p.daily-report-link {
+    float: right;
+}
+#daily_content {
+    color: #000;
+    font-family: Arial;
+    margin-top: 1em;
+}
+div.daily_search,
+div.daily_graph {
+    float: left;
+}
+div.daily_graph {
+    width: 60%;
+}
+div.daily_search {
+    width: 30%;
+}
+div.daily_graph {
+    margin-left: 1em;
+}
+div.daily_search_version {
+    margin: 0;
+    padding-bottom: 5px;
+}
+table.by_version {
+    border: 0;
+    padding: 4px 0;
+    th {
+        padding: 4px 0;
+        border: 0;
+        width: 70px;
+    }
+    td {
+        border: 0;
+        padding: 4px 0;
+    }
+    select {
+        padding: .3em .3em 0 .3em;
+        width: 200px;
+    }
+    option {
+        padding: .2em;
+    }
+}
+input.date {
+    width: 80px;
+}
+span.title {
+    width: 50px;
+    min-width: 50px;
+}
+
+/* Crash Graph */
+.crashes-per-adi-legend {
+    width: 100%;
+    text-align: center;
+}
+p.adu-chart-help {
+    margin-top: 15px;
+    font-size: 1rem;
+}
+/* Crash Data */
+table.crash_data {
+    clear: both;
+    color: #000;
+    margin-top: 20px;
+    font-family: Helvetica;
+    th {
+        background-color: #ddd;
+        padding: 4px;
+        border: 1px solid #999;
+        text-align: center;
+    }
+    th.version {
+        font-weight: bold;
+        width: 206px;
+    }
+    th.date {
+        text-align: left;
+        width: 55px;
+    }
+    th.stat {
+        font-size: 0.8em;
+        text-align: right;
+    }
+    td {
+        padding: 4px;
+        border: 1px solid #999;
+        font-size: 0.8em;
+        text-align: right;
+    }
+}
+br.clear {
+    clear:both;
+}

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_user.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_user.js
@@ -1,0 +1,78 @@
+/*global window, $, DATA, MG*/
+/* This file a partial re-write from daily.js (which is deprecated) */
+
+$(function() {
+    'use strict';
+
+    var COLORS = ['#6a3d9a', '#e31a1c', '#008800', '#1f78b4'];
+
+    if (window.socGraphByReportType === false) {
+        if (DATA.count) {
+            // Format the graph data.
+            var graphData = [];
+            var legend = [];
+            // This works because there are always
+            // equally many labels as there are ratios
+            // and their order is set.
+            $.each(DATA.labels, function(i, label) {
+                legend.push(label);
+                graphData.push(
+                    $.map(DATA.ratios[i], function(value) {
+                        return {
+                            date: new Date(value[0]),
+                            ratio: value[1]
+                        };
+                    })
+                );
+            });
+
+            // Draw the graph.
+            MG.data_graphic({
+                data: graphData,
+                full_width: true,
+                target: '#crashes-per-adi-graph',
+                x_accessor: 'date',
+                y_accessor: 'ratio',
+                xax_start_at_min: true,
+                utc_time: true,
+                interpolate: 'basic',
+                area: false,
+                legend: legend,
+                legend_target: '#crashes-per-adi-legend',
+                show_secondary_x_label: false
+            });
+
+        } else {
+            $('#crashes-per-adi-graph')
+                .text('No results were found.');
+        }
+    }
+
+    $('#daily_search_version_form_products').change(function() {
+        var urlForm = $('#daily_search_version_form').attr('action'),
+            product = $(this).find(':selected').val(),
+            url = urlForm + '?p=' + product + window.location.hash;
+        window.location = url;
+    });
+
+    $('#daily_search_os_form_products').change(function() {
+        var urlForm = $('#daily_search_os_form').attr('action'),
+            product = $(this).find(':selected').val(),
+            url = urlForm + '?p=' + product + window.location.hash;
+        window.location = url;
+    });
+
+    $('th.version').each(function() {
+        $(this).css('color', COLORS.shift());
+    });
+
+    // To avoid having to set `title="Bla bla throttle something bla bla"`
+    // on every th and td element that is about the throttle we just do
+    // it here once with javascript
+    $('th.throttle, td.throttle')
+        .attr('title', $('table#crash_data').data('throttle-title'));
+
+    $('.datepicker-daily input').datepicker({
+        dateFormat: 'yy-mm-dd'
+    });
+});

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/daily.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/daily.js
@@ -1,3 +1,5 @@
+/* This file is deprecated in favor of crashes_per_user.js */
+
 $(function() {
     var aduChartContainer = $("#crashes-per-adi-graph"),
         colours = ['#6a3d9a', '#e31a1c', '#008800', '#1f78b4'];

--- a/webapp-django/crashstats/crashstats/templates/crashstats/crashes_per_user.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/crashes_per_user.html
@@ -1,0 +1,272 @@
+{% extends "crashstats_base.html" %}
+{% block site_css %}
+    {{ super() }}
+    {% compress css %}
+    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
+    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
+    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
+    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
+    {% endcompress %}
+    {% compress css %}
+    <link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/crashes_per_user.less') }}">
+    {% endcompress %}
+{% endblock %}
+
+{% block page_title %}
+Crashes per User for {{ product }}
+{% endblock %}
+
+{% block content %}
+<div id="mainbody">
+
+<div class="page-heading">
+    <p class="daily-report-link">
+        <a href="{{ old_daily_report_url }}">View the old <i>Crashes per user</i> report</a>
+    </p>
+    <h2>Crashes per User for {{ product }}</h2>
+</div>
+
+
+<div class="panel daily_search">
+    <div class="title daily_search_title">
+        <h2>Options</h2>
+    </div>
+
+    <div class="body daily_search_body">
+        <div class="daily_search_version">
+            <form name="daily_search_version_form" action="">
+                <p>
+                  All ADI ratios are generated per 100 ADIs, not per single ADI.
+                  "3.5 crashes/ADI" means that there are 3.5 crashes per 100
+                  installations, not per installation. This ratio also does
+                  not distinguish between installs who crash multiple times
+                  and multiple crashing installs.
+                </p>
+
+                <table class="by_version">
+                    <tr>
+                        <th>Product</th>
+                        <td>
+                            <label class="visually-hidden" for="daily_search_version_form_products">Select Product</label>
+                            <select id="daily_search_version_form_products" name="p">
+                            {% for product_name in releases %}
+                                <option value="{{ product_name }}" {% if product == product_name %}selected{% endif %}>{{ product_name }}</option>
+                            {% endfor %}
+                            </select>
+                        </td>
+                    </tr>
+
+                    {% for i in range(4)|reverse %}
+                    <tr>
+                        {% if loop.first %}
+                        <th rowspan="4">Versions</th>
+                        {% endif %}
+
+                        <td>
+                          <label class="visually-hidden" for="version{{ i }}">Select Version</label>
+                            <select id="version{{ i }}" name="v">
+                                {% for version in available_versions %}
+                                    <option value="{{ version }}" {% if version == versions[i] %} selected {% endif %}>{{ version }}</option>
+                                {% endfor  %}
+                            </select>
+                        </td>
+                    </tr>
+                    {% endfor %}
+
+                    <tr>
+                        <th>Type</th>
+                        <td>
+                          <fieldset>
+                            <legend class="visually-hidden">Hang Types</legend>
+                            <span class="radio-item">
+                              <label for="hang_type_any">
+                                <input type="radio" id="hang_type_any" name="hang_type" value="any" {% if hang_type == 'any' %} checked="checked" {% endif %} /> Any
+                              </label>
+                            </span>
+
+                            <span class="radio-item">
+                              <label for="hang_type_crash">
+                                <input type="radio" id="hang_type_crash" name="hang_type" value="crash" {% if hang_type == 'crash' %} checked="checked" {% endif %} /> Crash
+                              </label>
+                            </span>
+
+                            <span class="radio-item">
+                              <label for="hang_type_hang-p">
+                                <input type="radio" id="hang_type_hang-p" name="hang_type" value="hang-p" {% if hang_type == 'hang-p' %} checked="checked" {% endif %} /> Plugin Hang
+                              </label>
+                            </span>
+                          </fieldset>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>OS</th>
+                        <td>
+                          <fieldset>
+                            <legend class="visually-hidden">Operating Systems</legend>
+                            <label for="os_Windows_check">
+                              <input id="os_Windows_check" type="checkbox" name="os" value="Windows" {% if 'Windows' in platforms %}checked="checked"{% endif %}/> Windows
+                            </label>
+
+                            <label for="os_Mac_check">
+                              <input id="os_Mac_check" type="checkbox" name="os" value="Mac OS X" {% if 'Mac OS X' in platforms %}checked="checked"{% endif %}/> Mac OS X
+                            </label>
+
+                            <label for="os_Linux_check">
+                              <input id="os_Linux_check" type="checkbox" name="os" value="Linux" {% if 'Linux' in platforms %}checked="checked"{% endif %}/> Linux
+                            </label>
+                          </fieldset>
+                        </td>
+                    </tr>
+
+                    {#
+
+                      This is deliberately commented out because the numbers
+                      we get are so different from the numbers you get in the
+                      old legacy PG-based "Crashes per ADI" (aka. daily report)
+
+                    <tr>
+                        <th>Date Range</th>
+                        <td>
+                          <fieldset>
+                              <legend class="visually-hidden">Date Range Type</legend>
+                              <span class="radio-item">
+                                  <label for="by_build">
+                                      <input type="radio" name="date_range_type" id="by_build" value="build" {% if date_range_type == 'build' %} checked="checked" {% endif %}/> Build Date
+                                  </label>
+                              </span>
+                              <span class="radio-item">
+                                  <label for="crash">
+                                      <input type="radio" name="date_range_type" id="crash" value="report" {% if date_range_type == 'report' %} checked="checked" {% endif %}/> Crash Date
+                                  </label>
+                              </span>
+                            </fieldset>
+                          </td>
+                    </tr>
+                    #}
+
+                    <tr class="datepicker-daily">
+                        <th>Date</th>
+                        <td>
+                          <label class="visually-hidden" for="when_date_start">Start Date</label>
+                          <input class="date" id="when_date_start" type="text" name="date_start" value="{{ start_date }}" />
+                          &nbsp; to &nbsp;
+                          <label class="visually-hidden" for="when_date_end">End Date</label>
+                          <input class="date" id="when_date_end" type="text" name="date_end" value="{{ end_date }}" />
+                        </td>
+                    </tr>
+                </table>
+
+                <input id="daily_search_version_form_submit" type="submit" name="submit" value="Generate">
+            </form>
+        </div>
+    </div>
+</div>
+
+    <div class="panel daily_graph">
+        <div class="title">
+            <h2>Crashes per 100 ADIs</h2>
+        </div>
+
+        <div class="body">
+                <div id="crashes-per-adi-graph"></div>
+                <div id="crashes-per-adi-legend" class="crashes-per-adi-legend"></div>
+            <p class="adu-chart-help">This graph uses an approximate <a href="https://wiki.mozilla.org/Socorro/SocorroUI/Branches_Admin#Throttle">throttle value</a> for each version, which may not be completely accurate for the entire time period.</p>
+            </div>
+    </div>
+
+
+    <br class="clear" />
+
+    <div class="panel daily_">
+        <div class="title">
+            <h2>Crashes per ADI</h2>
+            <div class="choices">
+                <ul>
+                    {% if request.META.get('QUERY_STRING') %}
+                    <li><a href="?{{ request.META.get('QUERY_STRING') }}&amp;format=csv">csv</a></li>
+                    {% else %}
+                    <li><a href="?format=csv">csv</a></li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+
+        <div class="body">
+          {% if data_table.dates %}
+            <table class="data-table crash_data zebra"
+               data-throttle-title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">
+                <tr>
+                    <th class="date" rowspan="2">Date</th>
+                  {% for version in versions %}
+                    <th class="version" colspan="4">{{ version }}</th>
+                  {% endfor %}
+                </tr>
+                <tr>
+                  {% for version in versions %}
+                    <th class="stat">Crashes</th>
+                    <th class="stat">ADI</th>
+                    <th class="stat throttle">Throttle</th>
+                    <th class="stat">Ratio</th>
+                  {% endfor %}
+                </tr>
+                {% for crash_date in dates %}
+                <tr>
+                  <td>{{ crash_date }}</td>
+                    {% if crash_date in data_table.dates %}
+                      {% for version in versions %}
+                        {% set foundversion = [] %}
+                        {% for crash_info in data_table.dates[crash_date] %}
+                          {% if crash_info.version == version %}
+                      <td>{{ crash_info.report_count | digitgroupseparator }}</td>
+                      <td>{{ crash_info.adi | digitgroupseparator }}</td>
+                      <td class="throttle"
+                      >{% if crash_info.throttle %}{{ crash_info.throttle * 100 }}%{% else %}-{% endif %}</td>
+                      <td>{{ crash_info.ratio }}</td>
+                            {% do foundversion.append(1) %}
+                          {% endif %}
+                        {% endfor %}
+                        {% if not foundversion %}
+                      <td>-</td>
+                      <td>-</td>
+                      <td class="throttle">-</td>
+                      <td>-</td>
+                        {% endif %}
+                      {% endfor %}
+                    {% else %}
+                      {% for version in versions %}
+                      <td>-</td>
+                      <td>-</td>
+                      <td class="throttle">-</td>
+                      <td>-</td>
+                      {% endfor %}
+                    {% endif %}
+                </tr>
+                {% endfor %}
+            </table>
+          {% else %}
+          <p>
+            No data is available for this query.
+          </p>
+          {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}
+{% block site_js %}
+    {{ super() }}
+
+    {% compress js %}
+    <script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
+    {% endcompress %}
+
+    {% compress js %}
+    <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
+    <script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
+    <script src="{{ static('crashstats/js/socorro/crashes_per_user.js') }}"></script>
+    {% endcompress %}
+    <script>
+    var DATA = {{ graph_data | json_dumps }};
+    window.socGraphByReportType = false;
+    </script>
+{% endblock %}

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -1438,8 +1438,8 @@ class TestModels(DjangoTestCase):
             ok_('product' in params)
             eq_(params['product'], 'WaterWolf')
 
-            ok_('version' in params)
-            eq_(params['version'], '2.0')
+            ok_('versions' in params)
+            eq_(params['versions'], ['2.0'])
 
             ok_('start_date' in params)
             ok_('end_date' in params)
@@ -1449,19 +1449,15 @@ class TestModels(DjangoTestCase):
                     "hits": [
                         {
 
-                            "product": "WaterWolf",
-                            "release_channel": "aurora",
+                            "build_type": "aurora",
                             "adi_count": 12327,
-                            "platform": "Darwin",
                             "version": "2.0",
                             "date": "2015-08-12"
 
                         },
                         {
-                            "product": "WaterWolf",
-                            "release_channel": "aurora",
+                            "build_type": "release",
                             "adi_count": 4,
-                            "platform": "Linux",
                             "version": "2.0",
                             "date": "2015-08-12"
 
@@ -1474,7 +1470,8 @@ class TestModels(DjangoTestCase):
         rget.side_effect = mocked_get
         r = api.get(
             product='WaterWolf',
-            version='2.0',
+            versions=['2.0'],
+            platforms=['Windows', 'Linux'],
             start_date=datetime.date(2015, 8, 12),
             end_date=datetime.date(2015, 8, 13),
         )

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -105,6 +105,9 @@ urlpatterns = patterns(
     url('^daily$',
         views.daily,
         name='daily'),
+    url('^crashes-per-user/$',
+        views.crashes_per_user,
+        name='crashes_per_user'),
     # handle old-style urls
     url('^topchangers' + products + '$',
         views.topchangers,


### PR DESCRIPTION
@AdrianGaudebert here's a sneak peek. It gives pretty nice results on the "By Crash Date" but we have some work to do on the "By Build Date" still since PG seems to yield such totally different numbers. 

Todo:

- [x] Hang type
- [x] respect the OS parameter choice
- [x] flake8
- [x] all tests passing
- [ ] ~~investigate why the "By Build date" numbers are so different in the PG based on (can maybe wait)~~
- [x] a link to the old daily report. 
- [x] hide the "By Build date" option