### PR TITLE
The debian postrm cleanup should happen on purge

### DIFF
--- a/scripts/package/deb-after-remove.sh
+++ b/scripts/package/deb-after-remove.sh
@@ -1,6 +1,13 @@
 #! /bin/bash
+set -e
 INSTALL_PREFIX=/data
 
-if [ -d $INSTALL_PREFIX/socorro ]; then
-	rm -r $INSTALL_PREFIX/socorro
+if [ "$1" = "purge" ] ; then
+    if [ -d $INSTALL_PREFIX/socorro ]; then
+        rm -r $INSTALL_PREFIX/socorro
+    fi
+
+    if type deluser >/dev/null 2>&1; then
+        userdel -r socorro 2>&1 > /dev/null
+    fi
 fi

--- a/scripts/package/deb-before-remove.sh
+++ b/scripts/package/deb-before-remove.sh
@@ -1,4 +1,1 @@
 #! /bin/bash
-INSTALL_PREFIX=/data
-
-userdel -r socorro 2>&1 > /dev/null


### PR DESCRIPTION
The socorro files (configs specifically) and user should only be removed on
purge.
https://wiki.debian.org/AccountHandlingInMaintainerScripts has some
good guidelines regarding account deletion.