### PR TITLE
alembic to be able to read from env

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,5 @@
 from __future__ import with_statement
+import os
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
@@ -61,8 +62,12 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
+
+    engine_config = config.get_section(config.config_ini_section)
+    if os.environ.get('sqlalchemy.url'):
+        engine_config['sqlalchemy.url'] = os.environ['sqlalchemy.url']
     engine = engine_from_config(
-                config.get_section(config.config_ini_section),
+                engine_config,
                 prefix='sqlalchemy.',
                 poolclass=pool.NullPool)
 
@@ -84,4 +89,3 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-


### PR DESCRIPTION
@twobraids r?
CC @selenamarie @rhelmer 

So, to run the migrations (or just see what the current head is) I have to edit `/etc/socorro/alembic.ini` and change the line `sqlalchemy.url = ...` every time the admin node is restarted. That cumbersome. 
I.e. the following:
```
vi /etc/socorro/alembic.ini
cd /data/socorro/application/
. /data/socorro/socorro-virtualenv/bin/activate
alembic -c /etc/socorro/alembic.ini current
```

The problem is that the admin node is ephemeral and my changes to `/etc/socorro/alembic.ini` are wiped. 

As of this patch, I can override `sqlalchemy.url` by running it like this:

```
env sqlalchemy.url=postgresql://USER:PASSW@HOSTNAME/breakpad alembic -c config/alembic.ini current
```
I get the values from:
```
envconsul -prefix socorro/common -sanitize -upcase env | grep POSTGRESQL
```
Which would make it easy to put together that on-the-fly environment variable. 