### PR TITLE
fixes bug 1190443 - Error message on SuperSearch AJAX search inserts whole HTML

### DIFF
--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
@@ -73,26 +73,28 @@ $(function () {
             error: function(jqXHR, textStatus, errorThrown) {
                 var errorContent = $('<div>', {class: 'error'});
 
-                try {
-                    var errorDetails = $(jqXHR.responseText); // This might fail
-                    var errorTitle = 'Oops, an error occured';
-                    var errorMsg = 'Please fix the following issues: ';
-
-                    errorContent.append($('<h3>', {text: errorTitle}));
-                    errorContent.append($('<p>', {text: errorMsg}));
-                    errorContent.append(errorDetails);
-                }
-                catch (e) {
-                    // If an exception occurs, that means jQuery wasn't able
-                    // to understand the status of the HTTP response. It is
-                    // probably a 500 error. We thus show a different error.
-                    var errorTitle = 'An unexpected error occured :(';
-                    var errorMsg = 'We have been automatically informed of that error, and are working on a solution. ';
-                    var errorDetails = textStatus + ' - ' + errorThrown;
-
-                    errorContent.append($('<h3>', {text: errorTitle}));
-                    errorContent.append($('<p>', {text: errorMsg}));
-                    errorContent.append($('<p>', {text: errorDetails}));
+                if (jqXHR.status >= 400 && jqXHR.status < 500) {
+                    errorContent.append(
+                        $('<h3>', {text: 'Oops, an error occured'})
+                    );
+                    errorContent.append(
+                        $('<p>', {text: 'Please fix the following issues:'})
+                    );
+                    errorContent.append(
+                        $('<p>', {text: jqXHR.responseText})
+                    );
+                } else {
+                    // We have no interest data to display as a constructive
+                    // error message to the user. So we'll have to show a
+                    // generic error message.
+                    errorContent.append(
+                        $('<h3>', {text: 'An unexpected error occured :('})
+                    );
+                    errorContent.append(
+                        $('<p>', {text: 'We have been automatically informed ' +
+                                        'of that error, and are working on a ' +
+                                        'solution. '})
+                    );
                 }
 
                 contentElt.empty().append(errorContent);


### PR DESCRIPTION
@AdrianGaudebert r?

This is now what it looks like when you get a 400 AJAX query:
![screenshot 2015-09-11 15 50 00](https://cloud.githubusercontent.com/assets/26739/9828081/d90f533c-589d-11e5-85fe-14424932e753.png)

And this is what it looks like when you get a 500 error:
![screenshot 2015-09-11 15 50 44](https://cloud.githubusercontent.com/assets/26739/9828083/e3b9e162-589d-11e5-90c6-16cab7b3701d.png)
