### PR TITLE
Fixes Bug 1205350 - collector2015 - allow multiple collector types

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -3,3 +3,4 @@
 # run socorro integration test
 echo "Running integration test..."
 ./scripts/rabbitmq-integration-test.sh --destroy
+./scripts/rabbitmq-integration-test-2015.sh --destroy

--- a/socorro/app/for_application_defaults.py
+++ b/socorro/app/for_application_defaults.py
@@ -45,6 +45,7 @@ class ApplicationDefaultsProxy(object):
         """
         return {
             'collector': 'socorro.collector.collector_app.CollectorApp',
+            'collector2015': 'socorro.collector.collector_app.Collector2015App',
             'crashmover': 'socorro.collector.crashmover_app.CrashMoverApp',
             'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDBApp',
             'submitter': 'socorro.collector.submitter_app.SubmitterApp',

--- a/socorro/collector/collector_app.py
+++ b/socorro/collector/collector_app.py
@@ -11,7 +11,8 @@
 # set both socorro and configman in your PYTHONPATH
 
 from socorro.app.generic_app import App, main
-
+from socorro.webapi.classPartial import class_with_partial_init
+from socorro.lib.converters import web_services_from_str
 
 from configman import Namespace
 from configman.converters import class_converter
@@ -23,7 +24,30 @@ application = None
 
 
 #==============================================================================
-class CollectorApp(App):
+class BaseCollectorApp(App):
+    app_name = 'collector'
+    app_version = '5.0'
+    app_description = __doc__
+
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    # web_server namespace
+    #     the namespace is for config parameters the web server
+    #--------------------------------------------------------------------------
+    required_config.namespace('web_server')
+    required_config.web_server.add_option(
+        'wsgi_server_class',
+        doc='a class implementing a wsgi web server',
+        default='socorro.webapi.servers.CherryPy',
+        from_string_converter=class_converter
+    )
+
+
+#==============================================================================
+class CollectorApp(BaseCollectorApp):
     app_name = 'collector'
     app_version = '4.0'
     app_description = __doc__
@@ -70,20 +94,8 @@ class CollectorApp(App):
     )
 
     #--------------------------------------------------------------------------
-    # web_server namespace
-    #     the namespace is for config parameters the web server
-    #--------------------------------------------------------------------------
-    required_config.namespace('web_server')
-    required_config.web_server.add_option(
-        'wsgi_server_class',
-        doc='a class implementing a wsgi web server',
-        default='socorro.webapi.servers.CherryPy',
-        from_string_converter=class_converter
-    )
-
-    #--------------------------------------------------------------------------
     def main(self):
-        # modwsgi requireds a module level name 'application'
+        # modwsgi requires a module level name 'application'
         global application
 
         services_list = (
@@ -100,6 +112,78 @@ class CollectorApp(App):
             services_list
         )
 
+        # for modwsgi the 'run' method returns the wsgi function that the web
+        # server will use.  For other webservers, the 'run' method actually
+        # starts the standalone web server.
+        application = self.web_server.run()
+
+
+#==============================================================================
+class Collector2015App(BaseCollectorApp):
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    # services namespace
+    #     the namespace is for config parameters about how to interpret
+    #     crash submissions
+    #--------------------------------------------------------------------------
+    required_config.namespace('services')
+    required_config.services.add_option(
+        'services_controller',
+        default='''[
+        {
+            "name": "collector",
+            "uri": "/submit",
+            "service_implementation_class":
+            "socorro.collector.wsgi_breakpad_collector.BreakpadCollector2015"
+        },
+        {
+            "name": "generic",
+            "uri": "/some/other/uri",
+            "service_implementation_class":
+                "socorro.collector.generic_collector.GenericCollector"
+        }
+        ]''',
+        doc='json-like list of services to be offered by this collector:'
+            '[{"name": sevice-name, "uri": uri, '
+            '"service_implementation_class": class-name}, ...]',
+        from_string_converter=web_services_from_str(),
+    )
+
+    #--------------------------------------------------------------------------
+    def main(self):
+        # modwsgi requires a module level name 'application'
+        global application
+
+        services_list = []
+        # take the list of services that have been specified in the configman
+        # setup and create a list of services appropriate for the wsgi server
+        # class.  Ensure that each service has been coupled with its namespace
+        # from the final configuration
+        for namespace, uri, service_class in (
+            self.config.services.services_controller.service_list
+        ):
+            services_list.append(
+                # a tuple associating a URI with a service class
+                (
+                    uri,
+                    # a binding of the service class with the configuration
+                    # namespace for that service class
+                    class_with_partial_init(
+                        self.config.services[namespace]
+                            .service_implementation_class,
+                        self.config.services[namespace]
+                    )
+                )
+            )
+
+        # initialize the wsgi server with the list of URI/service impl tuples
+        self.web_server = self.config.web_server.wsgi_server_class(
+            self.config,  # needs the whole config not the local namespace
+            services_list
+        )
 
         # for modwsgi the 'run' method returns the wsgi function that the web
         # server will use.  For other webservers, the 'run' method actually

--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -2,24 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import web
 import time
-import zlib
-import cgi
-import cStringIO
-
-from contextlib import closing
 
 from socorro.lib.ooid import createNewOoid
-from socorro.lib.util import DotDict
 from socorro.collector.throttler import DISCARD, IGNORE
 from socorro.lib.datetimeutil import utc_now
+from socorro.collector.wsgi_generic_collector import GenericCollectorBase
 
-from configman import RequiredConfig, Namespace, class_converter
+from configman import Namespace, class_converter
 
 
 #==============================================================================
-class BreakpadCollector(RequiredConfig):
+class BreakpadCollectorBase(GenericCollectorBase):
     #--------------------------------------------------------------------------
     # in this section, define any configuration requirements
     required_config = Namespace()
@@ -34,99 +28,41 @@ class BreakpadCollector(RequiredConfig):
         default='bp-'
     )
     required_config.add_option(
-        'accept_submitted_crash_id',
-        doc='a boolean telling the collector to use a crash_id provided in '
-            'the crash submission',
-        default=False
-    )
-    required_config.add_option(
         'accept_submitted_legacy_processing',
         doc='a boolean telling the collector to use a any legacy_processing'
             'flag submitted with the crash',
         default=False
     )
-    required_config.add_option(
-        'checksum_method',
-        doc='a reference to method that accepts a string and calculates a'
-            'hash value',
-        default='hashlib.md5',
-        from_string_converter=class_converter
-    )
 
     #--------------------------------------------------------------------------
     def __init__(self, config):
-        self.config = config
-        self.logger = self.config.logger
-        self.throttler = config.throttler
-        self.dump_id_prefix = config.collector.dump_id_prefix
-        self.crash_storage = config.crash_storage
-        self.dump_field = config.collector.dump_field
+        super(BreakpadCollectorBase, self).__init__(config)
+        self.dump_field = self._get_dump_field()
+        self.dump_id_prefix = self._get_dump_id_prefix()
+        self.accept_submitted_legacy_processing = \
+            self._get_accept_submitted_legacy_processing()
+        self.throttler = self._get_throttler()
+        self.crash_storage = self._get_crash_storage()
 
     #--------------------------------------------------------------------------
-    uri = '/submit'
-    #--------------------------------------------------------------------------
+    def _get_dump_field(self):
+        return self.config.dump_field
 
     #--------------------------------------------------------------------------
-    @staticmethod
-    def _process_fieldstorage(fs):
-        if isinstance(fs, list):
-            return [_process_fieldstorage(x) for x in fs]
-        elif fs.filename is None:
-            return fs.value
-        else:
-            return fs
+    def _get_dump_id_prefix(self):
+        return self.config.dump_id_prefix
 
     #--------------------------------------------------------------------------
-    def _form_as_mapping(self):
-        """this method returns the POST form mapping with any gzip
-        decompression automatically handled"""
-        if web.ctx.env.get('HTTP_CONTENT_ENCODING') == 'gzip':
-            # Handle gzipped form posts
-            gzip_header = 16 + zlib.MAX_WBITS
-            data = zlib.decompress(web.webapi.data(), gzip_header)
-            e = web.ctx.env.copy()
-            with closing(cStringIO.StringIO(data)) as fp:
-                # this is how web.webapi.rawinput() handles
-                # multipart/form-data, as of this writing
-                fs = cgi.FieldStorage(fp=fp, environ=e, keep_blank_values=1)
-                form = web.utils.storage(
-                    [(k, self._process_fieldstorage(fs[k])) for k in fs.keys()]
-                )
-                return form
-        return web.webapi.rawinput()
+    def _get_accept_submitted_legacy_processing(self):
+        return self.config.accept_submitted_legacy_processing
 
     #--------------------------------------------------------------------------
-    @staticmethod
-    def _no_x00_character(value):
-        if isinstance(value, unicode) and u'\u0000' in value:
-            return ''.join(c for c in value if c != u'\u0000')
-        if isinstance(value, str) and '\x00' in value:
-            return ''.join(c for c in value if c != '\x00')
-        return value
+    def _get_throttler(self):
+        return self.config.throttler
 
     #--------------------------------------------------------------------------
-    def _get_raw_crash_from_form(self):
-        """this method creates the raw_crash and the dumps mapping using the
-        POST form"""
-        dumps = DotDict()
-        raw_crash = DotDict()
-        raw_crash.dump_checksums = DotDict()
-        for name, value in self._form_as_mapping().iteritems():
-            name = self._no_x00_character(name)
-            if isinstance(value, basestring):
-                if name != "dump_checksums":
-                    raw_crash[name] = self._no_x00_character(value)
-            elif hasattr(value, 'file') and hasattr(value, 'value'):
-                dumps[name] = value.value
-                raw_crash.dump_checksums[name] = \
-                    self.config.collector.checksum_method(
-                        value.value
-                    ).hexdigest()
-            elif isinstance(value, int):
-                raw_crash[name] = value
-            else:
-                raw_crash[name] = value.value
-        return raw_crash, dumps
+    def _get_crash_storage(self):
+        return self.config.crash_storage
 
     #--------------------------------------------------------------------------
     def POST(self, *args):
@@ -137,9 +73,7 @@ class BreakpadCollector(RequiredConfig):
         # legacy - ought to be removed someday
         raw_crash.timestamp = time.time()
 
-        if (not self.config.collector.accept_submitted_crash_id
-            or 'uuid' not in raw_crash
-        ):
+        if (not self.accept_submitted_crash_id or 'uuid' not in raw_crash):
             crash_id = createNewOoid(current_timestamp)
             raw_crash.uuid = crash_id
             self.logger.info('%s received', crash_id)
@@ -148,7 +82,7 @@ class BreakpadCollector(RequiredConfig):
             self.logger.info('%s received with existing crash_id:', crash_id)
 
         if ('legacy_processing' not in raw_crash
-            or not self.config.collector.accept_submitted_legacy_processing
+            or not self.accept_submitted_legacy_processing
         ):
             raw_crash.legacy_processing, raw_crash.throttle_rate = (
                 self.throttler.throttle(raw_crash)
@@ -163,10 +97,86 @@ class BreakpadCollector(RequiredConfig):
             self.logger.info('%s ignored', crash_id)
             return "Unsupported=1\n"
 
-        self.config.crash_storage.save_raw_crash(
-          raw_crash,
-          dumps,
-          crash_id
+        raw_crash.type_tag = self.dump_id_prefix.strip('-')
+
+        self.crash_storage.save_raw_crash(
+            raw_crash,
+            dumps,
+            crash_id
         )
         self.logger.info('%s accepted', crash_id)
         return "CrashID=%s%s\n" % (self.dump_id_prefix, crash_id)
+
+
+#==============================================================================
+class BreakpadCollector(BreakpadCollectorBase):
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    uri = '/submit'
+    #--------------------------------------------------------------------------
+
+    #--------------------------------------------------------------------------
+    def _get_dump_field(self):
+        return self.config.collector.dump_field
+
+    #--------------------------------------------------------------------------
+    def _get_dump_id_prefix(self):
+        return self.config.collector.dump_id_prefix
+
+    #--------------------------------------------------------------------------
+    def _get_accept_submitted_legacy_processing(self):
+        return self.config.collector.accept_submitted_legacy_processing
+
+    #--------------------------------------------------------------------------
+    def _get_checksum_method(self):
+        return self.config.collector.checksum_method
+
+    #--------------------------------------------------------------------------
+    def _get_accept_submitted_crash_id(self):
+        return self.config.collector.accept_submitted_crash_id
+
+
+#==============================================================================
+class BreakpadCollector2015(BreakpadCollectorBase):
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+    #--------------------------------------------------------------------------
+    # throttler namespace
+    #     the namespace is for config parameters for the throttler system
+    #--------------------------------------------------------------------------
+    required_config.namespace('throttler')
+    required_config.throttler.add_option(
+        'throttler_class',
+        default='socorro.collector.throttler.LegacyThrottler',
+        doc='the class that implements the throttling action',
+        from_string_converter=class_converter
+    )
+    #--------------------------------------------------------------------------
+    # storage namespace
+    #     the namespace is for config parameters crash storage
+    #--------------------------------------------------------------------------
+    required_config.namespace('storage')
+    required_config.storage.add_option(
+        'crashstorage_class',
+        doc='the source storage class',
+        default='socorro.external.fs.crashstorage'
+                '.FSLegacyDatedRadixTreeStorage',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def _get_throttler(self):
+        return self.config.throttler.throttler_class(
+            self.config.throttler
+        )
+
+    #--------------------------------------------------------------------------
+    def _get_crash_storage(self):
+        return self.config.storage.crashstorage_class(
+            self.config.storage
+        )
+

--- a/socorro/collector/wsgi_generic_collector.py
+++ b/socorro/collector/wsgi_generic_collector.py
@@ -1,0 +1,178 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import web
+import time
+import zlib
+import cgi
+import cStringIO
+
+from contextlib import closing
+
+from socorro.lib.ooid import createNewOoid
+from socorro.lib.util import DotDict
+from socorro.collector.throttler import DISCARD, IGNORE
+from socorro.lib.datetimeutil import utc_now
+
+from configman import RequiredConfig, Namespace, class_converter
+
+
+#==============================================================================
+class GenericCollectorBase(RequiredConfig):
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+
+    required_config.add_option(
+        'accept_submitted_crash_id',
+        doc='a boolean telling the collector to use a crash_id provided in '
+            'the crash submission',
+        default=False
+    )
+    required_config.add_option(
+        'checksum_method',
+        doc='a reference to method that accepts a string and calculates a'
+            'hash value',
+        default='hashlib.md5',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.logger = self.config.logger
+        self.checksum_method = self._get_checksum_method()
+        self.accept_submitted_crash_id = self._get_accept_submitted_crash_id()
+
+    #--------------------------------------------------------------------------
+    def _get_accept_submitted_crash_id(self):
+        return self.config.accept_submitted_crash_id
+
+    #--------------------------------------------------------------------------
+    def _get_checksum_method(self):
+        return self.config.checksum_method
+
+    #--------------------------------------------------------------------------
+    def _process_fieldstorage(self, fs):
+        if isinstance(fs, list):
+            return [self._process_fieldstorage(x) for x in fs]
+        elif fs.filename is None:
+            return fs.value
+        else:
+            return fs
+
+    #--------------------------------------------------------------------------
+    def _form_as_mapping(self):
+        """this method returns the POST form mapping with any gzip
+        decompression automatically handled"""
+        if web.ctx.env.get('HTTP_CONTENT_ENCODING') == 'gzip':
+            # Handle gzipped form posts
+            gzip_header = 16 + zlib.MAX_WBITS
+            data = zlib.decompress(web.webapi.data(), gzip_header)
+            e = web.ctx.env.copy()
+            with closing(cStringIO.StringIO(data)) as fp:
+                # this is how web.webapi.rawinput() handles
+                # multipart/form-data, as of this writing
+                fs = cgi.FieldStorage(fp=fp, environ=e, keep_blank_values=1)
+                form = web.utils.storage(
+                    [(k, self._process_fieldstorage(fs[k])) for k in fs.keys()]
+                )
+                return form
+        return web.webapi.rawinput()
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _no_x00_character(value):
+        if isinstance(value, unicode) and u'\u0000' in value:
+            return ''.join(c for c in value if c != u'\u0000')
+        if isinstance(value, str) and '\x00' in value:
+            return ''.join(c for c in value if c != '\x00')
+        return value
+
+    #--------------------------------------------------------------------------
+    def _get_raw_crash_from_form(self):
+        """this method creates the raw_crash and the dumps mapping using the
+        POST form"""
+        dumps = DotDict()
+        raw_crash = DotDict()
+        raw_crash.dump_checksums = DotDict()
+        for name, value in self._form_as_mapping().iteritems():
+            name = self._no_x00_character(name)
+            if isinstance(value, basestring):
+                if name != "dump_checksums":
+                    raw_crash[name] = self._no_x00_character(value)
+            elif hasattr(value, 'file') and hasattr(value, 'value'):
+                dumps[name] = value.value
+                raw_crash.dump_checksums[name] = \
+                    self.checksum_method(value.value).hexdigest()
+            elif isinstance(value, int):
+                raw_crash[name] = value
+            else:
+                raw_crash[name] = value.value
+        return raw_crash, dumps
+
+    #--------------------------------------------------------------------------
+    def POST(self, *args):
+        raise NotImplementedError()
+
+#==============================================================================
+class GenericCollector(GenericCollectorBase):
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+
+    required_config.add_option(
+        'type_tag',
+        doc='the prefix to return to the client in front of the crash_id',
+        default='xx-'
+    )
+    #--------------------------------------------------------------------------
+    # storage namespace
+    #     the namespace is for config parameters crash storage
+    #--------------------------------------------------------------------------
+    required_config.namespace('storage')
+    required_config.storage.add_option(
+        'crashstorage_class',
+        doc='the source storage class',
+        default='socorro.external.fs.crashstorage'
+                '.FSLegacyDatedRadixTreeStorage',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        super(GenericCollector, self).__init__(config)
+        self.type_tag = self.config.type_tag
+        self.crash_storage = self.config.storage.crashstorage_class(
+            self.config.storage
+        )
+
+    #--------------------------------------------------------------------------
+    def POST(self, *args):
+        raw_crash, dumps = self._get_raw_crash_from_form()
+
+        current_timestamp = utc_now()
+        raw_crash.submitted_timestamp = current_timestamp.isoformat()
+        # legacy - ought to be removed someday
+        raw_crash.timestamp = time.time()
+
+        if (not self.config.accept_submitted_crash_id
+            or 'crash_id' not in raw_crash
+        ):
+            crash_id = createNewOoid(current_timestamp)
+            raw_crash.crash_id = crash_id
+            self.logger.info('%s received', crash_id)
+        else:
+            crash_id = raw_crash.crash_id
+            self.logger.info('%s received with existing crash_id:', crash_id)
+
+        raw_crash.type_tag = self.type_tag
+
+        self.crash_storage.save_raw_crash(
+            raw_crash,
+            dumps,
+            crash_id
+        )
+        self.logger.info('%s accepted', crash_id)
+        return "CrashID=%s%s\n" % (self.type_tag, crash_id)

--- a/socorro/unittest/collector/test_collector_app.py
+++ b/socorro/unittest/collector/test_collector_app.py
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import mock
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
-from socorro.collector.collector_app import CollectorApp
-from socorro.collector.wsgi_breakpad_collector import BreakpadCollector
+from socorro.collector.collector_app import CollectorApp, Collector2015App
+from socorro.collector.wsgi_breakpad_collector import BreakpadCollector2015
 from socorro.unittest.testbase import TestCase
 from configman.dotdict import DotDict
 
@@ -19,7 +19,7 @@ class TestCollectorApp(TestCase):
         config.logger = mock.MagicMock()
 
         config.collector = DotDict()
-        config.collector.collector_class = BreakpadCollector
+        config.collector.collector_class = BreakpadCollector2015
         config.collector.dump_id_prefix = 'bp-'
         config.collector.dump_field = 'dump'
         config.collector.accept_submitted_crash_id = False
@@ -27,18 +27,19 @@ class TestCollectorApp(TestCase):
         config.throttler = DotDict()
         self.mocked_throttler = mock.MagicMock()
         config.throttler.throttler_class = mock.MagicMock(
-          return_value=self.mocked_throttler)
+            return_value=self.mocked_throttler
+        )
 
         config.storage = mock.MagicMock()
         self.mocked_crash_storage = mock.MagicMock()
         config.storage.crashstorage_class = mock.MagicMock(
-          return_value=self.mocked_crash_storage
+            return_value=self.mocked_crash_storage
         )
 
         config.web_server = mock.MagicMock()
         self.mocked_web_server = mock.MagicMock()
         config.web_server.wsgi_server_class = mock.MagicMock(
-          return_value=self.mocked_web_server
+            return_value=self.mocked_web_server
         )
 
         return config
@@ -48,12 +49,63 @@ class TestCollectorApp(TestCase):
         c = CollectorApp(config)
         c.main()
 
-        eq_(config.crash_storage, self.mocked_crash_storage)
-        eq_(config.throttler, self.mocked_throttler)
         eq_(c.web_server, self.mocked_web_server)
 
-        config.storage.crashstorage_class.assert_called_with(config.storage)
         config.web_server.wsgi_server_class.assert_called_with(
-          config,
-          (BreakpadCollector, )
+            config,
+            (BreakpadCollector2015, )
         )
+
+
+class TestCollector2015App(TestCase):
+
+    def get_standard_config(self):
+        config = DotDict()
+
+        config.logger = mock.MagicMock()
+
+        config.services = DotDict()
+        config.services.services_controller = DotDict()
+
+        class Service1(object):
+            pass
+        config.services.service1 = DotDict()
+        config.services.service1.service_implementation_class = Service1
+
+        class Service2(object):
+            pass
+        config.services.service2 = DotDict()
+        config.services.service2.service_implementation_class = Service2
+
+        config.services.services_controller.service_list = [
+            ('service1', '/submit', Service1),
+            ('service2', '/unsubmit', Service2),
+        ]
+
+        config.web_server = DotDict()
+        self.mocked_web_server = mock.MagicMock()
+        config.web_server.wsgi_server_class = mock.MagicMock(
+            return_value=self.mocked_web_server
+        )
+
+        return config
+
+    def test_main(self):
+        config = self.get_standard_config()
+        c = Collector2015App(config)
+        c.main()
+
+        eq_(config.web_server.wsgi_server_class.call_count, 1)
+        args, kwargs = config.web_server.wsgi_server_class.call_args
+        eq_(len(args), 2)
+        eq_(len(kwargs), 0)
+
+        eq_(args[0], config)
+
+        service1_uri, service1_impl = args[1][0]
+        eq_(service1_uri, '/submit')
+        ok_(hasattr(service1_impl, 'wrapped_partial'))
+
+        service2_uri, service2_impl = args[1][1]
+        eq_(service2_uri, '/unsubmit')
+        ok_(hasattr(service2_impl, 'wrapped_partial'))

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -5,7 +5,6 @@
 import hashlib
 import StringIO
 import gzip
-import web
 
 import mock
 from nose.tools import eq_, ok_
@@ -14,7 +13,10 @@ from contextlib import closing
 
 from configman.dotdict import DotDict
 
-from socorro.collector.wsgi_breakpad_collector import BreakpadCollector
+from socorro.collector.wsgi_breakpad_collector import (
+    BreakpadCollector,
+    BreakpadCollector2015
+)
 from socorro.collector.throttler import ACCEPT, IGNORE, DEFER
 from socorro.unittest.testbase import TestCase
 
@@ -24,7 +26,7 @@ class ObjectWithValue(object):
         self.value = v
 
 
-class TestCollectorApp(TestCase):
+class TestWSGIBreakpadCollector(TestCase):
 
     def get_standard_config(self):
         config = DotDict()
@@ -78,8 +80,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
     def test_POST(self, mocked_web, mocked_webapi, mocked_utc_now, mocked_time):
         config = self.get_standard_config()
         c = BreakpadCollector(config)
@@ -107,6 +109,7 @@ class TestCollectorApp(TestCase):
             'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
             'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
         }
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         mocked_web.input.return_value = form
@@ -126,8 +129,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
     def test_POST_reject_browser_with_hangid(
         self,
         mocked_web,
@@ -158,6 +161,7 @@ class TestCollectorApp(TestCase):
         erc.throttle_rate = None
         erc.timestamp = 3.0
         erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         mocked_webapi.rawinput.return_value = rawform
@@ -172,8 +176,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
     def test_POST_with_existing_crash_id(
         self,
         mocked_web,
@@ -208,6 +212,7 @@ class TestCollectorApp(TestCase):
             'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
             'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
         }
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         mocked_web.input.return_value = form
@@ -227,8 +232,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
     def test_POST_with_existing_crash_id_and_use_it(
         self,
         mocked_web,
@@ -269,6 +274,7 @@ class TestCollectorApp(TestCase):
             'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
             'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
         }
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         mocked_web.input.return_value = form
@@ -287,8 +293,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
     def test_POST_with_existing_legacy_processing(
         self,
         mocked_web,
@@ -324,6 +330,7 @@ class TestCollectorApp(TestCase):
             'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
             'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
         }
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         mocked_web.input.return_value = form
@@ -343,8 +350,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
     def test_POST_with_existing_legacy_processing_and_use_it(
         self,
         mocked_web,
@@ -385,6 +392,7 @@ class TestCollectorApp(TestCase):
             'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
             'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
         }
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         mocked_web.input.return_value = form
@@ -403,8 +411,8 @@ class TestCollectorApp(TestCase):
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.webapi')
-    @mock.patch('socorro.collector.wsgi_breakpad_collector.web.ctx')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.ctx')
     def test_POST_with_gzip(
         self,
         mocked_web_ctx,
@@ -456,6 +464,7 @@ aux_dump contents
             'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
             'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
         }
+        erc.type_tag = 'bp'
         erc = dict(erc)
 
         with closing(StringIO.StringIO()) as s:
@@ -491,6 +500,493 @@ aux_dump contents
     def test_no_x00_character(self):
         config = self.get_standard_config()
         c = BreakpadCollector(config)
+
+        eq_(c._no_x00_character('\x00hello'), 'hello')
+        eq_(c._no_x00_character(u'\u0000bye'), 'bye')
+        eq_(c._no_x00_character(u'\u0000\x00bye'), 'bye')
+
+
+class TestWSGIBreakpadCollector2015(TestCase):
+
+    def get_standard_config(self):
+        config = DotDict()
+
+        config.logger = mock.MagicMock()
+
+        config.throttler = mock.MagicMock()
+
+        config.collector_class = BreakpadCollector2015
+        config.dump_id_prefix = 'bp-'
+        config.dump_field = 'dump'
+        config.accept_submitted_crash_id = False
+        config.accept_submitted_legacy_processing = False
+        config.checksum_method = hashlib.md5
+
+        config.storage = DotDict()
+        config.storage.crashstorage_class = mock.MagicMock()
+
+        config.throttler = DotDict()
+        config.throttler.throttler_class = mock.MagicMock()
+
+        return config
+
+    def test_setup(self):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
+        eq_(c.config, config)
+        eq_(c.logger, config.logger)
+        eq_(c.throttler, config.throttler.throttler_class.return_value)
+        eq_(c.crash_storage, config.storage.crashstorage_class.return_value)
+        eq_(c.dump_id_prefix, 'bp-')
+        eq_(c.dump_field, 'dump')
+
+    def test_make_raw_crash(self):
+        config = self.get_standard_config()
+        form = DotDict()
+        form.ProductName = 'FireSquid'
+        form.Version = '99'
+        form.dump = 'fake dump'
+        form.some_field = '\x0023'
+        form.some_other_field = ObjectWithValue('XYZ')
+
+        class BreakpadCollectorWithMyForm(config.collector_class):
+            def _form_as_mapping(self):
+                return form
+
+        c = BreakpadCollectorWithMyForm(config)
+
+        rc, dmp = c._get_raw_crash_from_form()
+        eq_(rc.ProductName, 'FireSquid')
+        eq_(rc.Version, '99')
+        eq_(rc.some_field, '23')
+        eq_(rc.some_other_field, 'XYZ')
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST(self, mocked_web, mocked_webapi, mocked_utc_now, mocked_time):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
+        rawform = DotDict()
+        rawform.ProductName = '\x00FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (ACCEPT, 100)
+        r = c.POST()
+        ok_(r.startswith('CrashID=bp-'))
+        ok_(r.endswith('120504\n'))
+        erc['uuid'] = r[11:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[11:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_reject_browser_with_hangid(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
+        rawform = DotDict()
+        rawform[u'\u0000ProductName'] = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.HangID = 'xyz'
+        rawform.ProcessType = 'browser'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.throttle_rate = None
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (IGNORE, None)
+        r = c.POST()
+        eq_(r, "Unsupported=1\n")
+        ok_(not
+            c.crash_storage.save_raw_crash.call_count
+        )
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_with_existing_crash_id(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3cx\x0042-47a5-843f-a0f892140107'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (ACCEPT, 100)
+        r = c.POST()
+        ok_(r.startswith('CrashID=bp-'))
+        ok_(r.endswith('120504\n'))
+        erc['uuid'] = r[11:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[11:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_with_existing_crash_id_and_use_it(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        config.accept_submitted_crash_id = True
+        c = BreakpadCollector2015(config)
+
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.legacy_processing = str(DEFER)
+        rawform.throttle_rate = 100
+        rawform.dump_checksums = "this is poised to overwrite and cause trouble"
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = DEFER
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (DEFER, 100)
+        r = c.POST()
+        ok_(r.startswith('CrashID=bp-'))
+        ok_(r.endswith('140107\n'))
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[11:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_with_existing_legacy_processing(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.legacy_processing = u'1'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (ACCEPT, 100)
+        r = c.POST()
+        ok_(r.startswith('CrashID=bp-'))
+        ok_(r.endswith('120504\n'))
+        erc['uuid'] = r[11:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[11:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_with_existing_legacy_processing_and_use_it(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        config.accept_submitted_crash_id = True
+        config.accept_submitted_legacy_processing = True
+        c = BreakpadCollector2015(config)
+
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99\x00'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform[u'some_field\u0000'] = '23'
+        rawform[u'some_\u0000other_field'] = ObjectWithValue('XYZ')
+        rawform.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        rawform.legacy_processing = str(DEFER)
+        rawform.throttle_rate = 100
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = DEFER
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.uuid = '332d798f-3c42-47a5-843f-a0f892140107'
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (DEFER, 100)
+        r = c.POST()
+        ok_(r.startswith('CrashID=bp-'))
+        ok_(r.endswith('140107\n'))
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[11:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.ctx')
+    def test_POST_with_gzip(
+        self,
+        mocked_web_ctx,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
+        form = """
+--socorro1234567
+Content-Disposition: form-data; name="ProductName"
+
+FireSquid
+--socorro1234567
+Content-Disposition: form-data; name="Version"
+
+99
+--socorro1234567
+Content-Disposition: form-data; name="some_field"
+
+23
+--socorro1234567
+Content-Disposition: form-data; name="some_other_field"
+
+XYZ
+--socorro1234567
+Content-Disposition: form-data; name="dump"; filename="dump"
+Content-Type: application/octet-stream
+
+fake dump
+--socorro1234567
+Content-Disposition: form-data; name="aux_dump"; filename="aux_dump"
+Content-Type: application/octet-stream
+
+aux_dump contents
+"""
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        with closing(StringIO.StringIO()) as s:
+            g = gzip.GzipFile(fileobj=s, mode='w')
+            g.write(form)
+            g.close()
+            gzipped_form = s.getvalue()
+
+        mocked_webapi.data.return_value = gzipped_form
+        mocked_web_ctx.configure_mock(
+            env={
+                'HTTP_CONTENT_ENCODING': 'gzip',
+                'CONTENT_ENCODING': 'gzip',
+                'CONTENT_TYPE':
+                    'multipart/form-data; boundary="socorro1234567"',
+                'REQUEST_METHOD': 'POST'
+            }
+        )
+
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (ACCEPT, 100)
+
+        # the call to be tested
+        r = c.POST()
+
+        # this is what should have happened
+        ok_(r.startswith('CrashID=bp-'))
+        ok_(r.endswith('120504\n'))
+        erc['uuid'] = r[11:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[11:-1]
+        )
+
+    def test_no_x00_character(self):
+        config = self.get_standard_config()
+        c = BreakpadCollector2015(config)
 
         eq_(c._no_x00_character('\x00hello'), 'hello')
         eq_(c._no_x00_character(u'\u0000bye'), 'bye')

--- a/socorro/unittest/collector/test_wsgi_generic_collector.py
+++ b/socorro/unittest/collector/test_wsgi_generic_collector.py
@@ -1,0 +1,319 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import hashlib
+import StringIO
+import gzip
+import web
+
+import mock
+from nose.tools import eq_, ok_
+from datetime import datetime
+from contextlib import closing
+
+from configman.dotdict import DotDict
+
+from socorro.collector.wsgi_generic_collector import GenericCollector
+from socorro.unittest.testbase import TestCase
+
+
+class ObjectWithValue(object):
+    def __init__(self, v):
+        self.value = v
+
+
+class TestCollectorApp(TestCase):
+
+    def get_standard_config(self):
+        config = DotDict()
+
+        config.logger = mock.MagicMock()
+
+        config.collector_class = GenericCollector
+        config.type_tag = 'XXX-'
+        config.accept_submitted_crash_id = False
+        config.checksum_method = mock.Mock()
+        config.checksum_method.return_value.hexdigest.return_value = 'a_hash'
+
+        config.storage = DotDict()
+        config.storage.crashstorage_class = mock.MagicMock()
+
+        return config
+
+    def test_setup(self):
+        config = self.get_standard_config()
+        c = GenericCollector(config)
+        eq_(c.config, config)
+        eq_(c.logger, config.logger)
+        eq_(c.crash_storage, config.storage.crashstorage_class.return_value)
+        eq_(c.type_tag, 'XXX-')
+
+    def test_make_raw_crash(self):
+        config = self.get_standard_config()
+        form = DotDict()
+        form.ProductName = 'FireSquid'
+        form.Version = '99'
+        form.dump = 'fake dump'
+        form.some_field = '\x0023'
+        form.some_other_field = ObjectWithValue('XYZ')
+
+        class GenericCollectorWithMyForm(config.collector_class):
+            def _form_as_mapping(self):
+                return form
+
+        c = GenericCollectorWithMyForm(config)
+
+        rc, dmp = c._get_raw_crash_from_form()
+        eq_(rc.ProductName, 'FireSquid')
+        eq_(rc.Version, '99')
+        eq_(rc.some_field, '23')
+        eq_(rc.some_other_field, 'XYZ')
+
+    @mock.patch('socorro.collector.wsgi_generic_collector.time')
+    @mock.patch('socorro.collector.wsgi_generic_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST(self, mocked_web, mocked_webapi, mocked_utc_now, mocked_time):
+        config = self.get_standard_config()
+        c = GenericCollector(config)
+        rawform = DotDict()
+        rawform.ProductName = '\x00FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.type_tag = 'XXX-'
+        erc.dump_checksums = {
+            'dump': 'a_hash',
+            'aux_dump': 'a_hash',
+        }
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        r = c.POST()
+        ok_(r.startswith('CrashID=XXX-'))
+        ok_(r.endswith('120504\n'))
+        erc['crash_id'] = r[12:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[12:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_generic_collector.time')
+    @mock.patch('socorro.collector.wsgi_generic_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_with_existing_crash_id(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        c = GenericCollector(config)
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.crash_id = '332d798f-3cx\x0042-47a5-843f-a0f892140107'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.type_tag = 'XXX-'
+        erc.dump_checksums = {
+            'dump': 'a_hash',
+            'aux_dump': 'a_hash',
+        }
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        r = c.POST()
+        ok_(r.startswith('CrashID=XXX-'))
+        ok_(r.endswith('120504\n'))
+        erc['crash_id'] = r[12:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[12:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_generic_collector.time')
+    @mock.patch('socorro.collector.wsgi_generic_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_POST_with_existing_crash_id_and_use_it(
+        self,
+        mocked_web,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        config.accept_submitted_crash_id = True
+        c = GenericCollector(config)
+
+        rawform = DotDict()
+        rawform.ProductName = 'FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+        rawform.aux_dump = DotDict({'value': 'aux_dump contents', 'file': 'silliness'})
+        rawform.some_field = '23'
+        rawform.some_other_field = ObjectWithValue('XYZ')
+        rawform.crash_id = '332d798f-3c42-47a5-843f-a0f892140107'
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.crash_id = '332d798f-3c42-47a5-843f-a0f892140107'
+        erc.type_tag = 'XXX-'
+        erc.dump_checksums = {
+            'dump': 'a_hash',
+            'aux_dump': 'a_hash',
+        }
+        erc = dict(erc)
+
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        r = c.POST()
+        ok_(r.startswith('CrashID=XXX-'))
+        ok_(r.endswith('140107\n'))
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[12:-1]
+        )
+
+    @mock.patch('socorro.collector.wsgi_generic_collector.time')
+    @mock.patch('socorro.collector.wsgi_generic_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.ctx')
+    def test_POST_with_gzip(
+        self,
+        mocked_web_ctx,
+        mocked_webapi,
+        mocked_utc_now,
+        mocked_time
+    ):
+        config = self.get_standard_config()
+        c = GenericCollector(config)
+        form = """
+--socorro1234567
+Content-Disposition: form-data; name="ProductName"
+
+FireSquid
+--socorro1234567
+Content-Disposition: form-data; name="Version"
+
+99
+--socorro1234567
+Content-Disposition: form-data; name="some_field"
+
+23
+--socorro1234567
+Content-Disposition: form-data; name="some_other_field"
+
+XYZ
+--socorro1234567
+Content-Disposition: form-data; name="dump"; filename="dump"
+Content-Type: application/octet-stream
+
+fake dump
+--socorro1234567
+Content-Disposition: form-data; name="aux_dump"; filename="aux_dump"
+Content-Type: application/octet-stream
+
+aux_dump contents
+"""
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        erc.some_field = '23'
+        erc.some_other_field = 'XYZ'
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.type_tag = 'XXX-'
+        erc.dump_checksums = {
+            'dump': 'a_hash',
+            'aux_dump': 'a_hash',
+        }
+        erc = dict(erc)
+
+        with closing(StringIO.StringIO()) as s:
+            g = gzip.GzipFile(fileobj=s, mode='w')
+            g.write(form)
+            g.close()
+            gzipped_form = s.getvalue()
+
+        mocked_webapi.data.return_value = gzipped_form
+        mocked_web_ctx.configure_mock(
+            env={
+                'HTTP_CONTENT_ENCODING': 'gzip',
+                'CONTENT_ENCODING': 'gzip',
+                'CONTENT_TYPE':
+                    'multipart/form-data; boundary="socorro1234567"',
+                'REQUEST_METHOD': 'POST'
+            }
+        )
+
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        r = c.POST()
+        ok_(r.startswith('CrashID=XXX-'))
+        print r
+        ok_(r.endswith('120504\n'))
+        erc['crash_id'] = r[12:-1]
+        c.crash_storage.save_raw_crash.assert_called_with(
+            erc,
+            {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
+            r[12:-1]
+        )
+
+    def test_no_x00_character(self):
+        config = self.get_standard_config()
+        c = GenericCollector(config)
+
+        eq_(c._no_x00_character('\x00hello'), 'hello')
+        eq_(c._no_x00_character(u'\u0000bye'), 'bye')
+        eq_(c._no_x00_character(u'\u0000\x00bye'), 'bye')

--- a/socorro/unittest/lib/test_converters.py
+++ b/socorro/unittest/lib/test_converters.py
@@ -5,7 +5,8 @@ from configman.converters import to_str, str_to_python_object
 
 from socorro.lib.converters import (
     str_to_classes_in_namespaces_converter,
-    change_default
+    change_default,
+    web_services_from_str,
 )
 from socorro.unittest.testbase import TestCase
 
@@ -244,3 +245,31 @@ class TestConverters(TestCase):
             Alpha.required_config.an_option.default,
             19
         )
+
+    def test_web_services_from_str(self):
+        some_services_as_string = """[
+            {
+                "name": "collector",
+                "uri": "/submit",
+                "service_implementation_class":
+                "socorro.unittest.lib.test_converters.Alpha"
+            },
+            {
+                "name": "generic",
+                "uri": "/some/other/uri",
+                "service_implementation_class":
+                "socorro.unittest.lib.test_converters.Beta"
+            }
+        ]"""
+        services_instance = web_services_from_str()(some_services_as_string)
+        service_list = services_instance.service_list
+        eq_(len(service_list), 2)
+        eq_(len(service_list[0]), 3)
+        eq_(len(service_list[1]), 3)
+        rc = services_instance.required_config
+        ok_('collector' in rc)
+        eq_(rc.collector.service_implementation_class.default, Alpha)
+        eq_(rc.collector.uri.default, "/submit")
+        ok_('generic' in rc)
+        eq_(rc.generic.service_implementation_class.default, Beta)
+        eq_(rc.generic.uri.default, "/some/other/uri")

--- a/socorro/webapi/classPartial.py
+++ b/socorro/webapi/classPartial.py
@@ -2,7 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-def classWithPartialInit(C, *args, **kwargs):
+
+def class_with_partial_init(C, *args, **kwargs):
     """
     Return a new subclass of C.
 
@@ -12,7 +13,11 @@ def classWithPartialInit(C, *args, **kwargs):
 
     """
     class W(C):
+        wrapped_partial = True
+
         def __init__(self):
             super(W, self).__init__(*args, **kwargs)
     W.__name__ = C.__name__
     return W
+
+classWithPartialInit = class_with_partial_init

--- a/socorro/webapi/servers.py
+++ b/socorro/webapi/servers.py
@@ -21,19 +21,41 @@ class WebServerBase(RequiredConfig):
         urls = []
 
         for each in services_list:
+
             if hasattr(each, 'uri'):
-                # this is the old middleware and dataservice
+                # this service has a hard coded uri embedded within
                 uri, cls = each.uri, each
+                config.logger.debug(
+                    'embedded uri class %s %s',
+                    cls.__name__,
+                    uri
+                )
             else:
-                # this is middleware_app (soon to be deprecated)
+                # this is a uri, service pair
                 uri, cls = each
+                config.logger.debug(
+                    'service pair uri class %s %s',
+                    cls.__name__,
+                    uri
+                )
 
             if isinstance(uri, basestring):
                 uri = (uri, )
 
             for a_uri in uri:
                 urls.append(a_uri)
-                urls.append(classWithPartialInit(cls, config))
+                if hasattr(cls, 'wrapped_partial'):
+                    config.logger.debug(
+                        "appending already wrapped %s",
+                        cls.__name__
+                    )
+                    urls.append(cls)
+                else:
+                    config.logger.debug(
+                        "wrapping %s",
+                        cls.__name__
+                    )
+                    urls.append(classWithPartialInit(cls, config))
 
         self.urls = tuple(urls)
 

--- a/testcrash/not_breakpad/not_a_breakpad_crash.json
+++ b/testcrash/not_breakpad/not_a_breakpad_crash.json
@@ -1,0 +1,14 @@
+{
+    "product": "NestPelletStoveController",
+    "version": "0.3",
+    "timestamp": "2015-09-15T00:00:01",
+    "remote_temp": 50,
+    "indoor_temp": 65,
+    "threshold_temp": 70,
+    "temp_units": "F",
+    "stove_status": "on",
+    "stove_level": 3,
+    "error_level": 0,
+    "error_type": "heater fault",
+    "emergency_contacts": ["x@gmail.com", "y@gmail.com", "406 555 1200"]
+}


### PR DESCRIPTION
the collector may be called on to collect things other than breakpad type crashes.  Enable the collector to have multiple services at different URLs that can route data-payloads to any other crash storage systems.
features:
1. This change should remain backwards compatible with the existing collector.
2. Separate the URI from the implementation class, so that service implementation classes can be reused
3. Config for each service should be in its own namespace
4. each service should have its own crash storage class so that different types of data-payloads may be routed to different places
5. each service implementation should brand the raw_crash with a ```type_tag``` to further allow sorting or routing
6. the ```type_tag``` should be used as the return prefix when the collector acknowledges receipt from the submitting client
7. the breakpad collector's ```dump_id_prefix``` ("BP-") should be used as the ```type_tag``` for the breakpad crashes
8. create a new ```GenericCollector``` implementation that can accept nearly any type of submission form payload and wrap it into a json "raw_crash" -- it should accept multiple file uploads and calculate hashes for them.
9. add the ```GenericCollector``` to the integration tests to prove that we can accept generic crashes.