### PR TITLE
Fixes bug 1207085 - Do not consider `0` as a falsy value in API.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,9 +52,9 @@ psycopg2==2.6.1
 # sha256: U6gisBsElN-WWMBOhyFhgOXsvoWxeGc92Eix-AnVwQA
 # sha256: u5PYXKflDWjkGXhSu226YJi7dyUA-C9dsv9KgHEVBck
 elasticsearch==1.2
-# sha256: vjtAX2ezbybvBNNKkSJSvps-Q0bxtfXQK_0jzH3ZQeg
-# sha256: LUb7Hnm9I9XqRjMDxvW0U1bj3LyHzeau5XioOynYK8A
-elasticsearch-dsl==0.0.3
+# sha256: 8UuM7WZr4UJlQTP-ZznWVrMZxKnsMiitFEvQ8o42pDU
+# sha256: Tpdx2a8EZIlHF_PQUFBrYhfHmXcO4AtKaAO5xkWQAY4
+elasticsearch-dsl==0.0.8
 # sha256: QQvqlt8kefozmGxAw-76nB57qVp_cHEcMVhgu-LWbH8
 # sha256: 2Fg3nvWYjUU0u4kJQy1pdCIQCq_ycimdZhM5g2ttrps
 urllib3==1.9.1

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1451,3 +1451,9 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
         ok_('query' in query)
         ok_('aggs' in query)
         ok_('size' in query)
+
+    def test_get_with_zero(self):
+        res = self.api.get(
+            _results_number=0,
+        )
+        eq_(len(res['hits']), 0)

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -674,10 +674,12 @@ class SocorroMiddleware(SocorroCommon):
 
         for param in self.get_annotated_params():
             name = param['name']
-            if param['required'] and not kwargs.get(name):
-                raise RequiredParameterError(name)
             value = kwargs.get(name)
-            if not value:
+
+            # 0 is a perfectly fine value, it should not be considered "falsy".
+            if not value and value is not 0:
+                if param['required']:
+                    raise RequiredParameterError(name)
                 continue
 
             if isinstance(value, param['type']):

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -104,6 +104,16 @@ class TestModels(DjangoTestCase):
         eq_(result['from_date'], datetime.date.today().strftime('%Y-%m-%d'))
         ok_('os' not in result)
 
+        # The value `0` is a perfectly fine value and should be kept in the
+        # parameters, and not ignored as a "falsy" value.
+        api = models.CrashesByExploitability()
+        inp = {
+            'batch': 0,
+        }
+        result = api.kwargs_to_params(inp)
+        # no interesting conversion or checks here
+        eq_(result, inp)
+
     def test_kwargs_to_params_exceptions(self):
         """the method kwargs_to_params() can take extra care of some special
         cases"""

--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -213,7 +213,7 @@ class TestViews(BaseTestViews):
 
             # Make sure a negative page does not lead to negative offset value.
             # But instead it is considered as the page 1 and thus is not added.
-            ok_('_results_offset' not in params)
+            eq_(params.get('_results_offset'), 0)
 
             hits = []
             for i in range(140):
@@ -511,7 +511,7 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             assert '_columns' in params
 
-            if '_results_offset' in params:
+            if params.get('_results_offset') != 0:
                 hits_range = range(100, 140)
             else:
                 hits_range = range(100)


### PR DESCRIPTION
@peterbe r?

I'm also upgrading ``elasticsearch-dsl`` to fix a bug: when you were querying for 0 results, it would instead return Elasticsearch's default number of results, which is 10. That's fixed with the latest version. 