### PR TITLE
Fixes Bug1208129 - add proto_signature to processed crash

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -821,6 +821,7 @@ class SignatureGenerationRule(Rule):
             processed_crash.get('hang_type', ''),
             crashed_thread,
         )
+        processed_crash.proto_signature = ' | '.join(signature_list)
         processed_crash.signature = signature
         if signature_notes:
             processor_meta.processor_notes.extend(signature_notes)

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1452,6 +1452,7 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
         ok_('aggs' in query)
         ok_('size' in query)
 
+    @minimum_es_version('1.0')
     def test_get_with_zero(self):
         res = self.api.get(
             _results_number=0,

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -119,8 +119,8 @@ class TestCSignatureTool(BaseTestClass):
             expectedRegEx.signatures_with_line_numbers_re,
             s.signatures_with_line_numbers_re
         )
-        self.assert_equal_with_nicer_output(fixupSpace, s.fixup_space)
-        self.assert_equal_with_nicer_output(fixupComma, s.fixup_comma)
+        eq_(fixupSpace.pattern, s.fixup_space.pattern)
+        eq_(fixupComma.pattern, s.fixup_comma.pattern)
 
     #--------------------------------------------------------------------------
     def test_C_db_tool_init(self):
@@ -1122,6 +1122,7 @@ class TestSignatureGeneration(TestCase):
                 'length'
             ]
         )
+        ok_('proto_signature' not in processed_crash)
 
     #--------------------------------------------------------------------------
     def test_action_2(self):
@@ -1144,6 +1145,17 @@ class TestSignatureGeneration(TestCase):
             '| MsgWaitForMultipleObjects | F_1152915508_________________'
             '_________________'
         )
+        eq_(
+            processed_crash.proto_signature,
+            'NtWaitForMultipleObjects | WaitForMultipleObjectsEx | '
+            'WaitForMultipleObjectsExImplementation | '
+            'RealMsgWaitForMultipleObjectsEx | MsgWaitForMultipleObjects | '
+            'F_1152915508__________________________________ | '
+            'F2166389______________________________________ | '
+            'F_917831355___________________________________ | '
+            'F1315696776________________________________ | '
+            'F_1428703866________________________________'
+        )
         eq_(processor_meta.processor_notes, [])
 
     #--------------------------------------------------------------------------
@@ -1164,6 +1176,18 @@ class TestSignatureGeneration(TestCase):
         eq_(
             processed_crash.signature,
             'Alpha<T>::Echo<T>'
+        )
+        eq_(
+            processed_crash.proto_signature,
+            'NtWaitForMultipleObjects | Alpha<T>::Echo<T> | '
+            'WaitForMultipleObjectsExImplementation | '
+            'RealMsgWaitForMultipleObjectsEx | '
+            'MsgWaitForMultipleObjects | '
+            'F_1152915508__________________________________ | '
+            'F2166389______________________________________ | '
+            'F_917831355___________________________________ | '
+            'F1315696776________________________________ | '
+            'F_1428703866________________________________'
         )
         eq_(processor_meta.processor_notes, [])
 
@@ -1193,6 +1217,10 @@ class TestSignatureGeneration(TestCase):
         eq_(
             processed_crash.signature,
             'EMPTY: no crashing thread identified'
+        )
+        eq_(
+            processed_crash.proto_signature,
+            ''
         )
         eq_(
             processor_meta.processor_notes,
@@ -1245,6 +1273,10 @@ class TestSignatureGeneration(TestCase):
         eq_(
             processed_crash.signature,
             'user2.dll@0x20869'
+        )
+        eq_(
+            processed_crash.proto_signature,
+            '@0x5e39bf21 | @0x5e39bf21 | @0x5e39bf21 | user2.dll@0x20869'
         )
         eq_(processor_meta.processor_notes, [])
 


### PR DESCRIPTION
one of the eternal complaints about Socorro is the inability to search for crashes based on frames of the crashing thread's stack.  While the signature is based on the frames of the crashing thread, it is heavily edited.  The stack frames themselves are removed from the processed crash because of disk space issues.  

During the process of creating a signature, there is a point when all the normalized frame signature are assembled into a list.  This is just before the application of the skip list regular expressions.  Taking this list of normalized frame signatures and concatenating them into one long string introduces a way to search the stack for patterns in calls.  

Normally, after signature generation is complete, the list is thrown away.  Rather than that, we should explore its usefulness as a search tool.  I've dubbed this string the "proto_signature" and saved it under that name in the processed crash.

It isn't very useful for bucketing on its own, but an searchable exploratory tool it may be very useful.