### PR TITLE
bug 1012759 - API to audit uploaded symbols

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -27,6 +27,7 @@ from .cleaner import Cleaner
 MODELS_MODULES = (
     models,
     crashstats.supersearch.models,
+    crashstats.symbols.models,
 )
 
 

--- a/webapp-django/crashstats/crashstats/management/__init__.py
+++ b/webapp-django/crashstats/crashstats/management/__init__.py
@@ -19,6 +19,7 @@ PERMISSIONS = {
     'run_custom_queries': 'Run Custom Queries in Super Search',
     'run_long_queries': 'Run Long Queries',
     'upload_symbols': 'Upload Symbols Files',
+    'view_all_symbol_uploads': 'View all Symbol Uploads',
 }
 
 

--- a/webapp-django/crashstats/symbols/tests/test_api.py
+++ b/webapp-django/crashstats/symbols/tests/test_api.py
@@ -1,0 +1,114 @@
+import json
+
+from nose.tools import eq_, ok_
+
+from django.contrib.auth.models import User, Permission
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from crashstats.tokens.models import Token
+from crashstats.symbols.models import SymbolsUpload
+from crashstats.crashstats.tests.test_views import BaseTestViews
+
+
+class TestAPI(BaseTestViews):
+
+    def test_empty_get(self):
+        url = reverse('api:model_wrapper', args=('UploadedSymbols',))
+
+        response = self.client.get(url)
+        eq_(response.status_code, 403)
+        ok_('requires' in response.content)
+        ok_('View all Symbol Uploads' in response.content)
+
+        # create a user, who has this permission
+        perm = Permission.objects.get(name='View all Symbol Uploads')
+        assert perm.codename == 'view_all_symbol_uploads'
+        user = User.objects.create_user('bob', 'bob@example.com', 'secret')
+
+        token = Token.objects.create(user=user)
+        token.permissions.add(perm)
+
+        response = self.client.get(url, HTTP_AUTH_TOKEN=token.key)
+        eq_(response.status_code, 400)
+
+        # we're missing required params
+        today = timezone.now()
+        params = {
+            'start_date': today.date(),
+            'end_date': today.date(),
+        }
+        response = self.client.get(url, params, HTTP_AUTH_TOKEN=token.key)
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 0)
+        eq_(results['hits'], [])
+
+    def test_search_by_params(self):
+        url = reverse('api:model_wrapper', args=('UploadedSymbols',))
+
+        user = self._login()
+        self._add_permission(user, 'view_all_symbol_uploads')
+        today = timezone.now()
+
+        upload = SymbolsUpload.objects.create(
+            user=user,
+            filename='symbolics.zip',
+            size=1234,
+            content_type='application/zip',
+            content=(
+                "+somebucket,file1.sym\n"
+                "=somebucket,file2.sym\n"
+            )
+        )
+        params = {
+            'start_date': today.date(),
+            'end_date': today.date(),
+        }
+        response = self.client.get(url, params)
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 1)
+        expect = {
+            'id': upload.id,
+            'filename': 'symbolics.zip',
+            'content': {
+                'existed': ['somebucket,file2.sym'],
+                'added': ['somebucket,file1.sym'],
+            },
+            'user': user.email,
+            'date': upload.created.isoformat(),
+            'size': 1234,
+            'content_type': 'application/zip',
+        }
+        eq_(results['hits'], [expect])
+
+        # Ok, basics work, now try to filter by something more advanced
+        response = self.client.get(url, dict(params, user_search='xxx'))
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 0)
+
+        assert user.email == 'test@mozilla.com', user.email
+        response = self.client.get(url, dict(params, user_search='TEST'))
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 1)
+
+        response = self.client.get(url, dict(params, filename_search='xxx'))
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 0)
+        response = self.client.get(url, dict(params, filename_search='bolic'))
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 1)
+
+        response = self.client.get(url, dict(params, content_search='xxx'))
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 0)
+        response = self.client.get(url, dict(params, content_search='file1'))
+        eq_(response.status_code, 200)
+        results = json.loads(response.content)
+        eq_(results['total'], 1)

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -103,7 +103,7 @@ def unpack_and_upload(iterator, symbols_upload, bucket_name, bucket_location):
         key = bucket.get_key(key_name)
 
         # let's assume first that we need to add a new key
-        prefix = "+"
+        prefix = '+'
         if key:
             # key already exists, but is it the same size?
             if key.size != member.size:


### PR DESCRIPTION
@AdrianGaudebert r?

Note! This is the first time we use our Public API to expose something stored "in Django". 
I chose to not bother with the caching. First of all, this endpoint requires auth so it's quite unlikely that one of the people with a permission will abuse it. And it's simple and fast anyway. The other reason is that I didn't want to spend time inventing that when there wasn't a real need. One thing at a time. 

This commit doesn't have a "fixes" in the commit message. 
That's because, once deployed on stage and prod we need to execute the `./manage.py syncdb` run so that it picks up the new permission that I defined in the `crashstats/management/__init__.py`

Also, even when that's done, I don't think the bug is ready until the likes of Ted and Benjamin gets his group(s) configured so they can actually use this new endpoint. 