### PR TITLE
fixes Bug 1212334 - disambiguate crash dumps being in memory or files

### DIFF
--- a/socorro/collector/wsgi_generic_collector.py
+++ b/socorro/collector/wsgi_generic_collector.py
@@ -14,6 +14,7 @@ from socorro.lib.ooid import createNewOoid
 from socorro.lib.util import DotDict
 from socorro.collector.throttler import DISCARD, IGNORE
 from socorro.lib.datetimeutil import utc_now
+from socorro.external.crashstorage_base import MemoryDumpsMapping
 
 from configman import RequiredConfig, Namespace, class_converter
 
@@ -94,7 +95,7 @@ class GenericCollectorBase(RequiredConfig):
     def _get_raw_crash_from_form(self):
         """this method creates the raw_crash and the dumps mapping using the
         POST form"""
-        dumps = DotDict()
+        dumps = MemoryDumpsMapping()
         raw_crash = DotDict()
         raw_crash.dump_checksums = DotDict()
         for name, value in self._form_as_mapping().iteritems():

--- a/socorro/external/http/crashstorage.py
+++ b/socorro/external/http/crashstorage.py
@@ -84,6 +84,7 @@ class HTTPPOSTCrashStorage(CrashStorageBase):
 
     #--------------------------------------------------------------------------
     def _submit_crash_via_http_POST(self, raw_crash, dumps, crash_id):
+        in_memory_dumps = dumps.as_memory_dumps_mapping()
         for dump_name, dump in dumps.iteritems():
             if not dump_name:
                 dump_name = self.config.dump_field_name

--- a/socorro/unittest/collector/test_submitter_app.py
+++ b/socorro/unittest/collector/test_submitter_app.py
@@ -88,11 +88,15 @@ class TestSubmitterFileSystemWalkerSource(TestCase):
         config = self.get_standard_config()
         sub_walker = SubmitterFileSystemWalkerSource(config)
 
-        dump_pathnames = ['raw_crash_file',
-            '/some/path/6611a662-e70f-4ba5-a397-69a3a2121129.dump',
-            '/some/path/6611a662-e70f-4ba5-a397-69a3a2121129.flash1.dump',
-            '/some/path/6611a662-e70f-4ba5-a397-69a3a2121129.flash2.dump',
-            ]
+        dump_pathnames = (
+            '6611a662-e70f-4ba5-a397-69a3a2121129',
+            (
+                'raw_crash_file',
+                '/some/path/6611a662-e70f-4ba5-a397-69a3a2121129.dump',
+                '/some/path/6611a662-e70f-4ba5-a397-69a3a2121129.flash1.dump',
+                '/some/path/6611a662-e70f-4ba5-a397-69a3a2121129.flash2.dump',
+            ),
+        )
         raw_dumps_files = sub_walker.get_raw_dumps_as_files(dump_pathnames)
 
         dump_names = {'upload_file_minidump':

--- a/socorro/unittest/external/fs/test_crash_data.py
+++ b/socorro/unittest/external/fs/test_crash_data.py
@@ -33,9 +33,13 @@ class IntegrationTestCrashData(TestCase):
             fake_raw_dump_1 = 'peter is a swede'
             fake_raw_dump_2 = 'lars is a norseman'
             fake_raw_dump_3 = 'adrian is a frenchman'
-            fake_dumps = {'upload_file_minidump': fake_raw_dump_1,
-                          'lars': fake_raw_dump_2,
-                          'adrian': fake_raw_dump_3}
+            fake_dumps = crashstorage.MemoryDumpsMapping(
+                {
+                    'upload_file_minidump': fake_raw_dump_1,
+                    'lars': fake_raw_dump_2,
+                    'adrian': fake_raw_dump_3
+                }
+            )
             fake_raw = {
                 'name': 'Peter',
                 'legacy_processing': 0,

--- a/socorro/unittest/external/fs/test_fsdatedradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fsdatedradixtreestorage.py
@@ -5,7 +5,10 @@ from configman import ConfigurationManager
 from nose.tools import eq_, ok_, assert_raises
 
 from socorro.external.fs.crashstorage import FSDatedRadixTreeStorage
-from socorro.external.crashstorage_base import CrashIDNotFound
+from socorro.external.crashstorage_base import (
+    CrashIDNotFound,
+    MemoryDumpsMapping,
+)
 from socorro.unittest.testbase import TestCase
 
 
@@ -44,10 +47,10 @@ class TestFSDatedRadixTreeStorage(TestCase):
             {  # raw crash
                 "test": "TEST"
             },
-            {  # dumps
+            MemoryDumpsMapping({  # dumps
                 'foo': 'bar',
                 self.fsrts.config.dump_field: 'baz'
-            },
+            }),
             self.CRASH_ID_1
         )
 

--- a/socorro/unittest/external/fs/test_fslegacydatedradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fslegacydatedradixtreestorage.py
@@ -8,7 +8,10 @@ from socorro.external.fs.crashstorage import (
     FSLegacyDatedRadixTreeStorage,
     FSTemporaryStorage
 )
-from socorro.external.crashstorage_base import CrashIDNotFound
+from socorro.external.crashstorage_base import (
+    CrashIDNotFound,
+    MemoryDumpsMapping,
+)
 from socorro.unittest.testbase import TestCase
 
 
@@ -44,18 +47,18 @@ class TestFSLegacyDatedRadixTreeStorage(TestCase):
     def _make_test_crash(self):
         self.fsrts.save_raw_crash({
             "test": "TEST"
-        }, {
+        }, MemoryDumpsMapping({
             'foo': 'bar',
             self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_1)
+        }), self.CRASH_ID_1)
 
     def _make_test_crash_3(self):
         self.fsrts.save_raw_crash({
             "test": "TEST"
-        }, {
+        }, MemoryDumpsMapping({
             'foo': 'bar',
             self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_3)
+        }), self.CRASH_ID_3)
 
 
     def test_save_raw_crash(self):
@@ -91,10 +94,10 @@ class TestFSLegacyDatedRadixTreeStorage(TestCase):
 
     def test_get_raw_dumps(self):
         self._make_test_crash()
-        eq_(self.fsrts.get_raw_dumps(self.CRASH_ID_1), {
+        eq_(self.fsrts.get_raw_dumps(self.CRASH_ID_1), MemoryDumpsMapping({
             'foo': 'bar',
             self.fsrts.config.dump_field: 'baz'
-        })
+        }))
         assert_raises(CrashIDNotFound, self.fsrts.get_raw_dumps,
                           self.CRASH_ID_2)
 
@@ -214,28 +217,34 @@ class TestFSTemporaryStorage(TestCase):
         return config_manager
 
     def _make_test_crash(self):
-        self.fsrts.save_raw_crash({
-            "test": "TEST"
-        }, {
-            'foo': 'bar',
-            self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_1)
+        self.fsrts.save_raw_crash(
+            {"test": "TEST"},
+            MemoryDumpsMapping({
+                'foo': 'bar',
+                self.fsrts.config.dump_field: 'baz'
+            }),
+            self.CRASH_ID_1
+        )
 
     def _make_test_crash_3(self):
-        self.fsrts.save_raw_crash({
-            "test": "TEST"
-        }, {
-            'foo': 'bar',
-            self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_3)
+        self.fsrts.save_raw_crash(
+            {"test": "TEST"},
+            MemoryDumpsMapping({
+                'foo': 'bar',
+                self.fsrts.config.dump_field: 'baz'
+            }),
+            self.CRASH_ID_3
+        )
 
     def _make_test_crash_4(self):
-        self.fsrts.save_raw_crash({
-            "test": "TEST"
-        }, {
-            'foo': 'bar',
-            self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_4)
+        self.fsrts.save_raw_crash(
+            {"test": "TEST"},
+            MemoryDumpsMapping({
+                'foo': 'bar',
+                self.fsrts.config.dump_field: 'baz'
+            }),
+            self.CRASH_ID_4
+        )
 
     def test_save_raw_crash(self):
         self._make_test_crash()
@@ -270,10 +279,10 @@ class TestFSTemporaryStorage(TestCase):
 
     def test_get_raw_dumps(self):
         self._make_test_crash()
-        eq_(self.fsrts.get_raw_dumps(self.CRASH_ID_1), {
+        eq_(self.fsrts.get_raw_dumps(self.CRASH_ID_1), MemoryDumpsMapping({
             'foo': 'bar',
             self.fsrts.config.dump_field: 'baz'
-        })
+        }))
         assert_raises(CrashIDNotFound, self.fsrts.get_raw_dumps,
                           self.CRASH_ID_2)
 
@@ -404,10 +413,10 @@ class TestFSTemporaryStorage(TestCase):
         # save crash 1 in old system
         self.fsrts_old.save_raw_crash({
             "test": "TEST"
-        }, {
+        }, MemoryDumpsMapping({
             'foo': 'bar',
             self.fsrts.config.dump_field: 'baz'
-        }, self.CRASH_ID_1)
+        }), self.CRASH_ID_1)
         ok_(os.path.exists(
             './crashes/20071025/date/00/00_00/0bba929f-8721-460c-dead-'
             'a43c20071025'

--- a/socorro/unittest/external/fs/test_fsradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fsradixtreestorage.py
@@ -5,7 +5,10 @@ from configman import ConfigurationManager
 from nose.tools import eq_, ok_, assert_raises
 
 from socorro.external.fs.crashstorage import FSRadixTreeStorage
-from socorro.external.crashstorage_base import CrashIDNotFound
+from socorro.external.crashstorage_base import (
+    CrashIDNotFound,
+    MemoryDumpsMapping,
+)
 from socorro.unittest.testbase import TestCase
 
 
@@ -42,10 +45,10 @@ class TestFSRadixTreeStorage(TestCase):
     def _make_test_crash(self, crash_id=CRASH_ID_1):
         self.fsrts.save_raw_crash({
             "test": "TEST"
-        }, {
+        }, MemoryDumpsMapping({
             'foo': 'bar',
             self.fsrts.config.dump_field: 'baz'
-        }, crash_id)
+        }), crash_id)
 
     def _make_processed_test_crash(self):
         self.fsrts.save_processed({
@@ -105,10 +108,13 @@ class TestFSRadixTreeStorage(TestCase):
 
     def test_get_raw_dumps(self):
         self._make_test_crash()
-        eq_(self.fsrts.get_raw_dumps(self.CRASH_ID_1), {
-            'foo': 'bar',
-            self.fsrts.config.dump_field: 'baz'
-        })
+        eq_(
+            self.fsrts.get_raw_dumps(self.CRASH_ID_1),
+            MemoryDumpsMapping({
+                'foo': 'bar',
+                self.fsrts.config.dump_field: 'baz'
+            }),
+        )
         assert_raises(CrashIDNotFound, self.fsrts.get_raw_dumps,
                           self.CRASH_ID_2)
 

--- a/socorro/unittest/external/happybase/test_crashstorage.py
+++ b/socorro/unittest/external/happybase/test_crashstorage.py
@@ -6,7 +6,10 @@ import mock
 import json
 
 from socorro.lib.util import SilentFakeLogger, DotDict
-from socorro.external.crashstorage_base import Redactor
+from socorro.external.crashstorage_base import (
+    Redactor,
+    MemoryDumpsMapping,
+)
 from socorro.external.happybase.crashstorage import HBaseCrashStorage, CrashIDNotFound
 from socorro.database.transaction_executor import TransactionExecutor
 from socorro.unittest.testbase import TestCase
@@ -106,7 +109,7 @@ class TestCrashStorage(TestCase):
     def test_save_raw_crash(self):
         self.storage.save_raw_crash({
             "submitted_timestamp": "2013-01-09T22:21:18.646733+00:00"
-        }, {}, "0bba929f-8721-460c-dead-a43c20071027")
+        }, MemoryDumpsMapping(), "0bba929f-8721-460c-dead-a43c20071027")
         with self.storage.hbase() as conn:
             self.assertEqual(conn.table.call_count, 1)
             self.assertEqual(conn.table.return_value.put.call_count, 1)
@@ -115,7 +118,7 @@ class TestCrashStorage(TestCase):
         self.storage.save_raw_crash({
             "submitted_timestamp": "2013-01-09T22:21:18.646733+00:00",
             "HangID": "?"
-        }, {}, "0bba929f-8721-460c-dead-a43c20071027")
+        }, MemoryDumpsMapping(), "0bba929f-8721-460c-dead-a43c20071027")
         with self.storage.hbase() as conn:
             self.assertEqual(conn.table.call_count, 1)
             self.assertEqual(conn.table.return_value.put.call_count, 1)

--- a/socorro/unittest/external/hb/test_crashstorage.py
+++ b/socorro/unittest/external/hb/test_crashstorage.py
@@ -8,7 +8,10 @@ import mock
 from nose.tools import eq_, assert_raises
 
 from socorro.lib.util import SilentFakeLogger, DotDict
-from socorro.external.crashstorage_base import Redactor
+from socorro.external.crashstorage_base import (
+    Redactor,
+    MemoryDumpsMapping
+)
 from socorro.external.hb.crashstorage import HBaseCrashStorage, CrashIDNotFound
 from socorro.database.transaction_executor import TransactionExecutor
 from socorro.unittest.testbase import TestCase
@@ -106,7 +109,7 @@ class TestCrashStorage(TestCase):
     def test_save_raw_crash(self):
         self.storage.save_raw_crash({
             "submitted_timestamp": "2013-01-09T22:21:18.646733+00:00"
-        }, {}, "0bba929f-8721-460c-dead-a43c20071027")
+        }, MemoryDumpsMapping(), "0bba929f-8721-460c-dead-a43c20071027")
         with self.storage.hbase() as conn:
             eq_(conn.client.mutateRow.call_count, 5)
 
@@ -114,7 +117,7 @@ class TestCrashStorage(TestCase):
         self.storage.save_raw_crash({
             "submitted_timestamp": "2013-01-09T22:21:18.646733+00:00",
             "HangID": "?"
-        }, {}, "0bba929f-8721-460c-dead-a43c20071027")
+        }, MemoryDumpsMapping(), "0bba929f-8721-460c-dead-a43c20071027")
         with self.storage.hbase() as conn:
             eq_(conn.client.mutateRow.call_count, 7)
 

--- a/socorro/unittest/external/hbase/test_crashstorage.py
+++ b/socorro/unittest/external/hbase/test_crashstorage.py
@@ -13,7 +13,11 @@ from configman import ConfigurationManager
 
 from socorro.external.hbase import hbase_client
 
-from socorro.external.crashstorage_base import CrashIDNotFound, Redactor
+from socorro.external.crashstorage_base import (
+    CrashIDNotFound,
+    Redactor,
+    MemoryDumpsMapping
+)
 from socorro.external.hbase.crashstorage import HBaseCrashStorage
 from socorro.external.hbase.connection_context import \
      HBaseConnectionContextPooled
@@ -108,9 +112,11 @@ else:
                 fake_raw_dump_1 = 'peter is a swede'
                 fake_raw_dump_2 = 'lars is a norseman'
                 fake_raw_dump_3 = 'adrian is a frenchman'
-                fake_dumps = {'upload_file_minidump': fake_raw_dump_1,
-                              'lars': fake_raw_dump_2,
-                              'adrian': fake_raw_dump_3}
+                fake_dumps = MemoryDumpsMapping({
+                    'upload_file_minidump': fake_raw_dump_1,
+                     'lars': fake_raw_dump_2,
+                     'adrian': fake_raw_dump_3
+                })
                 crashstorage.save_raw_crash(json.loads(raw),
                                             fake_dumps,
                                             crash_id)

--- a/socorro/unittest/external/http/test_crashstorage.py
+++ b/socorro/unittest/external/http/test_crashstorage.py
@@ -14,6 +14,7 @@ from socorro.database.transaction_executor import (
     TransactionExecutor,
     TransactionExecutorWithLimitedBackoff
 )
+from socorro.external.crashstorage_base import MemoryDumpsMapping
 from socorro.unittest.testbase import TestCase
 
 
@@ -56,10 +57,10 @@ class TestCrashStorage(TestCase):
             "Product": "FireSquid",
             "Version": "-33",
         }
-        dumps = {
+        dumps = MemoryDumpsMapping({
             'upload_file_minidump': 'dump #1',
             'browser': 'dump #2'
-        }
+        })
         crash_id = "0bba929f-8721-460c-dead-a43c20071027"
         with patch("socorro.external.http.crashstorage.poster") as m_poster:
             with patch("socorro.external.http.crashstorage.urllib2") as m_urllib:
@@ -90,10 +91,10 @@ class TestCrashStorage(TestCase):
             "Product": "FireSquid",
             "Version": "-33",
         }
-        dumps = {
+        dumps = MemoryDumpsMapping({
             'upload_file_minidump': 'dump #1',
             'browser': 'dump #2'
-        }
+        })
         crash_id = "0bba929f-8721-460c-dead-a43c20071027"
         with patch("socorro.external.http.crashstorage.poster") as m_poster:
             with patch("socorro.external.http.crashstorage.urllib2") as m_urllib:

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -14,7 +14,9 @@ from socorro.external.crashstorage_base import (
     PrimaryDeferredStorage,
     PrimaryDeferredProcessedStorage,
     Redactor,
-    BenchmarkingCrashStorage
+    BenchmarkingCrashStorage,
+    MemoryDumpsMapping,
+    FileDumpsMapping
 )
 from socorro.unittest.testbase import TestCase
 from configman import Namespace, ConfigurationManager
@@ -854,6 +856,23 @@ class TestBench(TestCase):
                 1
             )
             mock_logging.debug.reset_mock()
+
+
+class TestDumpsMappings(TestCase):
+
+    def test_simple(self):
+        mdm = MemoryDumpsMapping({
+            'upload_file_minidump': 'binary_data',
+            'moar_dump': "more binary data",
+        })
+        ok_(mdm.as_memory_dumps_mapping() is mdm)
+        fdm = mdm.as_file_dumps_mapping(
+            'a',
+            '/tmp',
+            'dump'
+        )
+        ok_(fdm.as_file_dumps_mapping() is fdm)
+        eq_(fdm.as_memory_dumps_mapping(), mdm)
 
 
 


### PR DESCRIPTION
_**This PR may look daunting but it isn't that complicated.** It introduces two classes that take the place of what were simple ```dict``` mappings.  It touches a lot of files, but in a very rote manner._

There has been a bifurcation in the crash storage data throughout the history of the classes.  The crash dumps have two different representations:

    1) a mapping of crash names to binary data blobs
    2) a mapping of crash names to file pathnames.

It has been a manner of gentleman's agreement that two types do not mix. However, as the two methods have evolved in parallel the distinction has become more and more inconvenient.

This PR introduces two classes that encapsulate the two representations.  They each include a method to turn itself into the other. Any crash storage class on receiving a mapping of names/dumps can then just call the method to convert what they've got into what they want.  

In addition, each of the crashstorage classes all implemented the same thing when asked to produce the dumps as files on a file system.  This eliminates that duplication - there is only one place where a dumps are written to a file system for temporary use. 