### PR TITLE
fixes Bug 1212917 - refactor iteration - push to base classes

### DIFF
--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -146,6 +146,8 @@ class SocorroApp(RequiredConfig):
     #--------------------------------------------------------------------------
     def __init__(self, config):
         self.config = config
+        # give a name to this running instance of the program.
+        self.app_instance_name = self._app_instance_name()
 
     #--------------------------------------------------------------------------
     @staticmethod
@@ -162,6 +164,17 @@ class SocorroApp(RequiredConfig):
         """derived classes must override this function with business logic"""
         raise NotImplementedError(
             "A definition of 'main' in a derived class is required"
+        )
+
+    #--------------------------------------------------------------------------
+    def _app_instance_name(self):
+        # originally, only the processors had instance names.  By putting this
+        # call here, all the apps have instance names that can be used to
+        # tag output that is traceble back to an app/machine/process.
+        return "%s_%s_%d" % (
+            self.app_name,
+            os.uname()[1].replace('.', '_'),
+            os.getpid()
         )
 
     #--------------------------------------------------------------------------

--- a/socorro/external/postgresql/crash_migration_app.py
+++ b/socorro/external/postgresql/crash_migration_app.py
@@ -63,12 +63,7 @@ class CrashMigrationApp(RawAndProcessedCopierApp):
                 'ESCrashStorageNoStackwalkerOutput',
         }
 
-    def source_iterator(self):
-        for x in self.get_all_crash_ids():
-            yield (x, {})  # (args, kwargs)
-        raise StopIteration()
-
-    def get_all_crash_ids(self):
+    def _create_iter(self):
         connection = self.source.database.connection()
         sql = 'select uuid from raw_crashes;'
         return execute_query_iter(connection, sql)

--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -147,29 +147,29 @@ class TaskManager(RequiredConfig):
         called at least once after the end of the task loop."""
         self.logger.debug('threadless start')
         try:
-            while True:
-                for job_params in self._get_iterator():  # may never raise
-                                                         # StopIteration
-                    self.quit_check()
-                    if job_params is None:
-                        if self.config.quit_on_empty_queue:
-                            raise KeyboardInterrupt
-                        self.logger.info("there is nothing to do.  Sleeping "
-                                         "for %d seconds" %
-                                         self.config.idle_delay)
-                        self._responsive_sleep(self.config.idle_delay)
-                        continue
-                    self.quit_check()
-                    try:
-                        args, kwargs = job_params
-                    except ValueError:
-                        args = job_params
-                        kwargs = {}
-                    try:
-                        self.task_func(*args, **kwargs)
-                    except Exception:
-                        self.config.logger.error("Error in processing a job",
-                                                 exc_info=True)
+            for job_params in self._get_iterator():  # may never raise
+                                                     # StopIteration
+                self.config.logger.debug('received %r', job_params)
+                self.quit_check()
+                if job_params is None:
+                    if self.config.quit_on_empty_queue:
+                        raise KeyboardInterrupt
+                    self.logger.info("there is nothing to do.  Sleeping "
+                                     "for %d seconds" %
+                                     self.config.idle_delay)
+                    self._responsive_sleep(self.config.idle_delay)
+                    continue
+                self.quit_check()
+                try:
+                    args, kwargs = job_params
+                except ValueError:
+                    args = job_params
+                    kwargs = {}
+                try:
+                    self.task_func(*args, **kwargs)
+                except Exception:
+                    self.config.logger.error("Error in processing a job",
+                                             exc_info=True)
         except KeyboardInterrupt:
             self.logger.debug('queuingThread gets quit request')
         finally:

--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -224,6 +224,7 @@ class ThreadedTaskManager(TaskManager):
         try:
             for job_params in self._get_iterator():  # may never raise
                                                      # StopIteration
+                self.config.logger.debug('received %r', job_params)
                 if job_params is None:
                     if self.config.quit_on_empty_queue:
                         self.wait_for_empty_queue(
@@ -239,8 +240,6 @@ class ThreadedTaskManager(TaskManager):
                 self.quit_check()
                 #self.logger.debug("queuing job %s", job_params)
                 self.task_queue.put((self.task_func, job_params))
-            else:
-                self.logger.debug("the loop didn't actually loop")
         except Exception:
             self.logger.error('queuing jobs has failed', exc_info=True)
         except KeyboardInterrupt:
@@ -261,7 +260,6 @@ class ThreadedTaskManager(TaskManager):
         This is useful for maintaining transactional integrity on a resource
         connection."""
         return threading.currentThread().getName()
-
 
 
 #==============================================================================

--- a/socorro/unittest/app/test_generic_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_generic_fetch_transform_save_app.py
@@ -7,6 +7,7 @@ from mock import Mock
 
 from socorro.app.fetch_transform_save_app import FetchTransformSaveApp
 from socorro.lib.threaded_task_manager import ThreadedTaskManager
+from socorro.lib.task_manager import TaskManager
 from socorro.lib.util import DotDict, SilentFakeLogger
 from socorro.unittest.testbase import TestCase
 
@@ -22,7 +23,7 @@ class TestFetchTransformSaveApp(TestCase):
             def _setup_source_and_destination(self):
                 pass
 
-            def source_iterator(self):
+            def _create_iter(self):
                 for x in xrange(5):
                     yield ((x,), {})
 
@@ -34,10 +35,11 @@ class TestFetchTransformSaveApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': 'all',
           'source': DotDict({'crashstorage_class': None}),
           'destination': DotDict({'crashstorage_class': None}),
           'producer_consumer': DotDict({'producer_consumer_class':
-                                          ThreadedTaskManager,
+                                          TaskManager,
                                         'logger': logger,
                                         'number_of_threads': 1,
                                         'maximum_queue_size': 1}
@@ -55,7 +57,7 @@ class TestFetchTransformSaveApp(TestCase):
 
     def test_bogus_source_and_destination(self):
         class NonInfiniteFTSAppClass(FetchTransformSaveApp):
-            def source_iterator(self):
+            def _basic_iterator(self):
                 for x in self.source.new_crashes():
                     yield ((x,), {})
 
@@ -100,6 +102,7 @@ class TestFetchTransformSaveApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': 'all',
           'source': DotDict({'crashstorage_class':
                                  FakeStorageSource}),
           'destination': DotDict({'crashstorage_class':
@@ -134,6 +137,8 @@ class TestFetchTransformSaveApp(TestCase):
 
             def new_crashes(self):
                 if self.first:
+                    # make the iterator act as if exhausted on the very
+                    # first try
                     self.first = False
                 else:
                     for k in range(999):
@@ -163,6 +168,7 @@ class TestFetchTransformSaveApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': 'forever',
           'source': DotDict({'crashstorage_class':
                                  FakeStorageSource}),
           'destination': DotDict({'crashstorage_class':
@@ -182,6 +188,8 @@ class TestFetchTransformSaveApp(TestCase):
         no_finished_function_counter = 0
         for x, y in zip(xrange(1002), (a for a in fts_app.source_iterator())):
             if x == 0:
+                # the iterator is exhausted on the 1st try and should have
+                # yielded a None before starting over
                 ok_(y is None)
             elif x < 1000:
                 if x - 1 != y[0][0] and not error_detected:
@@ -216,6 +224,7 @@ class TestFetchTransformSaveApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': 'forever',
           'source': DotDict({'crashstorage_class':
                                  None}),
           'destination': DotDict({'crashstorage_class':
@@ -266,6 +275,7 @@ class TestFetchTransformSaveApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': 'forever',
           'source': DotDict({'crashstorage_class':
                                  FakeStorageSource}),
           'destination': DotDict({'crashstorage_class':

--- a/socorro/unittest/app/test_socorro_app.py
+++ b/socorro/unittest/app/test_socorro_app.py
@@ -220,6 +220,7 @@ class TestSocorroWelcomeApp(TestCase):
     def test_app_replacement(self):
         config = DotDict()
         config.application = MyProcessor
+        config.number_of_submissions = 1
 
         with mock.patch(
             'socorro.app.socorro_app.command_line',

--- a/socorro/unittest/collector/test_crash_mover_app.py
+++ b/socorro/unittest/collector/test_crash_mover_app.py
@@ -21,7 +21,7 @@ class TestCrashMoverApp(TestCase):
             def _setup_source_and_destination(self):
                 pass
 
-            def source_iterator(self):
+            def _basic_iterator(self):
                 for x in xrange(5):
                     yield ((x,), {})
 
@@ -33,6 +33,7 @@ class TestCrashMoverApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': "all",
           'source': DotDict({'crashstorage_class': None}),
           'destination': DotDict({'crashstorage_class': None}),
           'producer_consumer': DotDict({'producer_consumer_class':
@@ -54,7 +55,7 @@ class TestCrashMoverApp(TestCase):
 
     def test_bogus_source_and_destination(self):
         class NonInfiniteFTSAppClass(CrashMoverApp):
-            def source_iterator(self):
+            def _basic_iterator(self):
                 for x in self.source.new_crashes():
                     yield ((x,), {})
 
@@ -100,6 +101,7 @@ class TestCrashMoverApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': "all",
           'source': DotDict({'crashstorage_class':
                                  FakeStorageSource}),
           'destination': DotDict({'crashstorage_class':
@@ -157,6 +159,7 @@ class TestCrashMoverApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': "all",
           'source': DotDict({'crashstorage_class':
                                  FakeStorageSource}),
           'destination': DotDict({'crashstorage_class':
@@ -204,6 +207,7 @@ class TestCrashMoverApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': "all",
           'source': DotDict({'crashstorage_class':
                                  None}),
           'destination': DotDict({'crashstorage_class':
@@ -255,6 +259,7 @@ class TestCrashMoverApp(TestCase):
           'logger': logger,
           'number_of_threads': 2,
           'maximum_queue_size': 2,
+          'number_of_submissions': "all",
           'source': DotDict({'crashstorage_class':
                                  FakeStorageSource}),
           'destination': DotDict({'crashstorage_class':

--- a/socorro/unittest/collector/test_submitter_app.py
+++ b/socorro/unittest/collector/test_submitter_app.py
@@ -335,7 +335,7 @@ class TestSubmitterApp(TestCase):
         config.submitter = DotDict()
         config.submitter.delay = 0
         config.submitter.dry_run = False
-        config.submitter.number_of_submissions = "all"
+        config.number_of_submissions = "all"
 
         config.logger = mock.MagicMock()
 
@@ -377,7 +377,7 @@ class TestSubmitterApp(TestCase):
         config.submitter = DotDict()
         config.submitter.delay = 0
         config.submitter.dry_run = False
-        config.submitter.number_of_submissions = "all"
+        config.number_of_submissions = "all"
 
         config.logger = mock.MagicMock()
 
@@ -424,7 +424,7 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to all
         # It raises StopIterations after all the elements were called
         config = self.get_standard_config()
-        config.submitter.number_of_submissions = "all"
+        config.number_of_submissions = "all"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()
@@ -440,9 +440,10 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to forever
         # It never raises StopIterations
         config = self.get_standard_config()
-        config.submitter.number_of_submissions = "forever"
+        config.number_of_submissions = "forever"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
+        sub._setup_task_manager()
         itera = sub.source_iterator()
 
         sub.source.new_crashes = lambda: iter([1, 2, 3])
@@ -457,7 +458,7 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to an integer > number of items
         # It raises StopIterations after some number of elements were called
         config = self.get_standard_config()
-        config.submitter.number_of_submissions = "5"
+        config.number_of_submissions = "5"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()
@@ -475,7 +476,7 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to an integer < number of items
         # It raises StopIterations after some number of elements were called
         config = self.get_standard_config()
-        config.submitter.number_of_submissions = "1"
+        config.number_of_submissions = "1"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()
@@ -492,7 +493,7 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to all
         # It raises StopIterations after all the elements were called
         config = self.get_new_crash_source_config()
-        config.submitter.number_of_submissions = "all"
+        config.number_of_submissions = "all"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()
@@ -509,9 +510,10 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to forever
         # It never raises StopIterations
         config = self.get_new_crash_source_config()
-        config.submitter.number_of_submissions = "forever"
+        config.number_of_submissions = "forever"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
+        sub._setup_task_manager()
         itera = sub.source_iterator()
 
         # setup a fake iter using two form of the data to ensure it deals
@@ -529,7 +531,7 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to an integer > number of items
         # It raises StopIterations after some number of elements were called
         config = self.get_new_crash_source_config()
-        config.submitter.number_of_submissions = "5"
+        config.number_of_submissions = "5"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()
@@ -548,7 +550,7 @@ class TestSubmitterApp(TestCase):
         # Test with number of submissions equal to an integer < number of items
         # It raises StopIterations after some number of elements were called
         config = self.get_new_crash_source_config()
-        config.submitter.number_of_submissions = "1"
+        config.number_of_submissions = "1"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()
@@ -565,7 +567,7 @@ class TestSubmitterApp(TestCase):
         # than a crash_id
         # It raises StopIterations after some number of elements were called
         config = self.get_new_crash_source_config()
-        config.submitter.number_of_submissions = "2"
+        config.number_of_submissions = "2"
         sub = SubmitterApp(config)
         sub._setup_source_and_destination()
         sub._setup_task_manager()

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -45,16 +45,17 @@ class TestProcessorApp(TestCase):
           return_value=mocked_processor
         )
 
+        config.number_of_submissions = 'forever'
         config.new_crash_source = DotDict()
-        sequence_generator = sequencer(((1,), {}),
-                                       2,  # ensure both forms acceptable
-                                       None,
-                                       ((3,), {}))
-        mocked_new_crash_source = mock.Mock(side_effect=sequence_generator)
-        mocked_new_crash_source.id = 'mocked_new_crash_source'
-        config.new_crash_source.new_crash_source_class = mock.Mock(
-          return_value=mocked_new_crash_source
-        )
+        class FakedNewCrashSource(object):
+            def __init__(self, *args, **kwargs):
+                pass
+            def new_crashes(self):
+                return sequencer(((1,), {}),
+                                 2,  # ensure both forms acceptable
+                                 None,
+                                 ((3,), {}))()
+        config.new_crash_source.new_crash_source_class = FakedNewCrashSource
 
         config.companion_process = DotDict()
         mocked_companion_process = mock.Mock()


### PR DESCRIPTION
unify the iterator models between the processor and submitter families of FTS apps.  Since the correlation reports will be encoded as TransformRules, this means using the processor as the base app class.  However, the processor is long running and its iteratation system doen't ever raise the StopIteration exception.  The submitter app class has the ability to allow an iterator to run to exhaustion and then quit, but doesn't have a good method of using a TransformRule system.

Push all the iteration down to the FetchTransformSaveApp class rather that repeating components through the class hierarchy.  Give the processor the ability to limit iteration to "forever", "all" or a specific number of iterations.

DO NOT BREAK BACKWARDS COMPATIBILITY WITH EXISTING CONFIGURATION.