### PR TITLE
crashmover service should run as socorro user. if it does not and it …

### DIFF
--- a/config/package/usr/lib/systemd/system/socorro-crashmover.service
+++ b/config/package/usr/lib/systemd/system/socorro-crashmover.service
@@ -2,6 +2,7 @@
 Description=Socorro Crashmover
 
 [Service]
+User=socorro
 WorkingDirectory=/home/socorro
 Environment=VENV=/data/socorro/socorro-virtualenv
 ExecStart=/bin/bash -c "/usr/bin/envconsul -upcase=false -prefix socorro/common -prefix socorro/crashmover $VENV/bin/socorro crashmover"


### PR DESCRIPTION
…starts up before collector, the ./crashes dir will be owned by root

r? @jdotpz 