### PR TITLE
fixes bug 1212088 - Expose graphics related CSV report via webapp

### DIFF
--- a/socorro/external/postgresql/graphics_report.py
+++ b/socorro/external/postgresql/graphics_report.py
@@ -62,9 +62,9 @@ This was the original SQL used in the old cron job:
 SQL = """
 SELECT
     r.signature,
-    'URL (removed)' as url,        -- 1
+    NULL as url,        -- 1
     'https://crash-stats.mozilla.com/report/index/' || r.uuid as uuid_url, -- 2
-    to_char(r.client_crash_date,'YYYYMMDDHH24MI') as client_crash_date,   -- 3
+    NULL as client_crash_date,   -- 3
     to_char(r.date_processed,'YYYYMMDDHH24MI') as date_processed,         -- 4
     r.last_crash, -- 5
     r.product,    -- 6
@@ -78,25 +78,21 @@ SELECT
     array(select ba.bug_id from bug_associations ba where ba.signature = r.signature) as bug_list, --14
     r.user_comments, --15
     r.uptime as uptime_seconds, --16
-    '' as email, --17
-    (select sum(adi_count) from raw_adi adi
-       where adi.date = %(date)s
-         and r.product = adi.product_name and r.version = adi.product_version
-         and substring(r.os_name from 1 for 3) = substring(adi.product_os_platform from 1 for 3)
-         and r.os_version LIKE '%%'||adi.product_os_version||'%%') as adu_count, --18
-    r.topmost_filenames, --19
-    case when (r.addons_checked is NULL) then '[unknown]'when (r.addons_checked) then 'checked' else 'not' end as addons_checked, --20
-    r.flash_version, --21
+    NULL as email, --17
+    NULL as adu_count, --18
+    NULL as topmost_filenames, --19
+    NULL as addons_checked, --20
+    NULL as flash_version, --21
     r.hangid, --22
     r.reason, --23
     r.process_type, --24
     r.app_notes, --25
-    r.install_age, --26
-    rd.duplicate_of, --27
+    NULL as install_age, --26
+    NULL as duplicate_of, --27
     r.release_channel, --28
     r.productid --29
 FROM
-    reports r left join reports_duplicates rd on r.uuid = rd.uuid
+    reports r
 WHERE
     r.date_processed BETWEEN %(yesterday)s AND %(date)s
     AND r.product = %(product)s

--- a/socorro/external/postgresql/graphics_report.py
+++ b/socorro/external/postgresql/graphics_report.py
@@ -1,0 +1,165 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+import logging
+
+from socorro.external.postgresql.base import PostgreSQLBase
+from socorro.lib import external_common
+
+
+logger = logging.getLogger("webapi")
+
+"""
+This was the original SQL used in the old cron job:
+
+
+      select
+        r.signature,  -- 0
+        r.url,        -- 1
+        'http://crash-stats.mozilla.com/report/index/' || r.uuid as uuid_url, -- 2
+        to_char(r.client_crash_date,'YYYYMMDDHH24MI') as client_crash_date,   -- 3
+        to_char(r.date_processed,'YYYYMMDDHH24MI') as date_processed,         -- 4
+        r.last_crash, -- 5
+        r.product,    -- 6
+        r.version,    -- 7
+        r.build,      -- 8
+        '' as branch, -- 9
+        r.os_name,    --10
+        r.os_version, --11
+        r.cpu_name || ' | ' || r.cpu_info as cpu_info,   --12
+        r.address,    --13
+        array(select ba.bug_id from bug_associations ba where ba.signature = r.signature) as bug_list, --14
+        r.user_comments, --15
+        r.uptime as uptime_seconds, --16
+        case when (r.email is NULL OR r.email='') then '' else r.email end as email, --17
+        (select sum(adi_count) from raw_adi adi
+           where adi.date = '%(now_str)s'
+             and r.product = adi.product_name and r.version = adi.product_version
+             and substring(r.os_name from 1 for 3) = substring(adi.product_os_platform from 1 for 3)
+             and r.os_version LIKE '%%'||adi.product_os_version||'%%') as adu_count, --18
+        r.topmost_filenames, --19
+        case when (r.addons_checked is NULL) then '[unknown]'when (r.addons_checked) then 'checked' else 'not' end as addons_checked, --20
+        r.flash_version, --21
+        r.hangid, --22
+        r.reason, --23
+        r.process_type, --24
+        r.app_notes, --25
+        r.install_age, --26
+        rd.duplicate_of, --27
+        r.release_channel, --28
+        r.productid --29
+      from
+        reports r left join reports_duplicates rd on r.uuid = rd.uuid
+      where
+        '%(yesterday_str)s' <= r.date_processed and r.date_processed < '%(now_str)s'
+        %(prod_phrase)s %(ver_phrase)s
+      order by 5 -- r.date_processed, munged
+
+"""
+
+SQL = """
+SELECT
+    r.signature,
+    'URL (removed)' as url,        -- 1
+    'https://crash-stats.mozilla.com/report/index/' || r.uuid as uuid_url, -- 2
+    to_char(r.client_crash_date,'YYYYMMDDHH24MI') as client_crash_date,   -- 3
+    to_char(r.date_processed,'YYYYMMDDHH24MI') as date_processed,         -- 4
+    r.last_crash, -- 5
+    r.product,    -- 6
+    r.version,    -- 7
+    r.build,      -- 8
+    '' as branch, -- 9
+    r.os_name,    --10
+    r.os_version, --11
+    r.cpu_name || ' | ' || r.cpu_info as cpu_info,   --12
+    r.address,    --13
+    array(select ba.bug_id from bug_associations ba where ba.signature = r.signature) as bug_list, --14
+    r.user_comments, --15
+    r.uptime as uptime_seconds, --16
+    '' as email, --17
+    (select sum(adi_count) from raw_adi adi
+       where adi.date = %(date)s
+         and r.product = adi.product_name and r.version = adi.product_version
+         and substring(r.os_name from 1 for 3) = substring(adi.product_os_platform from 1 for 3)
+         and r.os_version LIKE '%%'||adi.product_os_version||'%%') as adu_count, --18
+    r.topmost_filenames, --19
+    case when (r.addons_checked is NULL) then '[unknown]'when (r.addons_checked) then 'checked' else 'not' end as addons_checked, --20
+    r.flash_version, --21
+    r.hangid, --22
+    r.reason, --23
+    r.process_type, --24
+    r.app_notes, --25
+    r.install_age, --26
+    rd.duplicate_of, --27
+    r.release_channel, --28
+    r.productid --29
+FROM
+    reports r left join reports_duplicates rd on r.uuid = rd.uuid
+WHERE
+    r.date_processed BETWEEN %(yesterday)s AND %(date)s
+    AND r.product = %(product)s
+ORDER BY 5 -- r.date_processed, munged
+""".strip()
+
+
+class GraphicsReport(PostgreSQLBase):
+    """
+    This implementation solves a un-legacy problem.
+    We used to generate a big fat CSV file based on this query for
+    the Mozilla Graphics team so that they can, in turn, analyze
+    the data and produce pretty graphs that give them historic
+    oversight of their efforts.
+    See. http://people.mozilla.org/~bgirard/gfx_features_stats/
+
+    This report might not be perfect but the intention is to have
+    it as an postgres implementation so that it can satisfy their
+    need and let the Socorro team avoid a complicated cron job
+    that relies on dumping files to disk.
+    """
+
+    def get(self, **kwargs):
+        filters = [
+            ('date', datetime.datetime.utcnow().date(), 'date'),
+            ('product', 'Firefox', 'str'),
+        ]
+        params = external_common.parse_arguments(filters, kwargs)
+        params['yesterday'] = params['date'] - datetime.timedelta(days=1)
+        results = self.query(SQL, params)
+        header = [
+            'signature',
+            'url',
+            'uuid_url',
+            'client_crash_date',
+            'date_processed',
+            'last_crash',
+            'product',
+            'version',
+            'build',
+            'branch',
+            'os_name',
+            'os_version',
+            'cpu_info',
+            'address',
+            'bug_list',
+            'user_comments',
+            'uptime_seconds',
+            'email',
+            'adu_count',
+            'topmost_filenames',
+            'addons_checked',
+            'flash_version',
+            'hangid',
+            'reason',
+            'process_type',
+            'app_notes',
+            'install_age',
+            'duplicate_of',
+            'release_channel',
+            'productid',
+        ]
+        return {
+            'header': header,
+            'hits': results,
+        }

--- a/socorro/external/postgresql/graphics_report.py
+++ b/socorro/external/postgresql/graphics_report.py
@@ -75,7 +75,7 @@ SELECT
     r.os_version, --11
     r.cpu_name || ' | ' || r.cpu_info as cpu_info,   --12
     r.address,    --13
-    array(select ba.bug_id from bug_associations ba where ba.signature = r.signature) as bug_list, --14
+    ARRAY(SELECT 1 WHERE FALSE) as bug_list, --14
     r.user_comments, --15
     r.uptime as uptime_seconds, --16
     NULL as email, --17

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -76,7 +76,6 @@ SERVICES_LIST = (
     (r'/suspicious/(.*)', 'suspicious.SuspiciousCrashSignatures'),
     (r'/util/(versions_info)/(.*)', 'util.Util'),
     (r'/adi/(.*)', 'adi.ADI'),
-    # the legacy one
     (r'/graphics_report/', 'graphics_report.GraphicsReport'),
 )
 

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -76,6 +76,8 @@ SERVICES_LIST = (
     (r'/suspicious/(.*)', 'suspicious.SuspiciousCrashSignatures'),
     (r'/util/(versions_info)/(.*)', 'util.Util'),
     (r'/adi/(.*)', 'adi.ADI'),
+    # the legacy one
+    (r'/graphics_report/', 'graphics_report.GraphicsReport'),
 )
 
 # certain items in a URL path should NOT be split by `+`

--- a/socorro/unittest/external/postgresql/test_graphics_report.py
+++ b/socorro/unittest/external/postgresql/test_graphics_report.py
@@ -100,16 +100,14 @@ class IntegrationTestGraphicsReport(PostgreSQLTestCase):
     def test_get(self):
         api = GraphicsReport(config=self.config)
         res = api.get(product='Firefox')
-        ok_(res['header'])
-        eq_(res['header'][0], 'signature')
-        eq_(res['header'][-1], 'productid')
         assert res['hits']
+        assert len(res['hits']) == res['total']
         ok_(isinstance(res['hits'], list))
-        signatures = [x[0] for x in res['hits']]
+        signatures = [x.signature for x in res['hits']]
         eq_(signatures, ['signature', 'my signature'])
-        date_processed = [x[4] for x in res['hits']]
+        date_processed = [x.date_processed for x in res['hits']]
         # should be ordered ascending
         first, second = date_processed
         ok_(first < second)
-        bug_associations = [x[14] for x in res['hits']]
+        bug_associations = [x.bug_list for x in res['hits']]
         eq_(bug_associations, [[], []])

--- a/socorro/unittest/external/postgresql/test_graphics_report.py
+++ b/socorro/unittest/external/postgresql/test_graphics_report.py
@@ -111,3 +111,5 @@ class IntegrationTestGraphicsReport(PostgreSQLTestCase):
         # should be ordered ascending
         first, second = date_processed
         ok_(first < second)
+        bug_associations = [x[14] for x in res['hits']]
+        eq_(bug_associations, [[], []])

--- a/socorro/unittest/external/postgresql/test_graphics_report.py
+++ b/socorro/unittest/external/postgresql/test_graphics_report.py
@@ -1,0 +1,105 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+from nose.plugins.attrib import attr
+from nose.tools import eq_, ok_
+
+from socorro.external.postgresql.graphics_report import GraphicsReport
+
+from .unittestbase import PostgreSQLTestCase
+
+
+#==============================================================================
+@attr(integration='postgres')  # for nosetests
+class IntegrationTestGraphicsReport(PostgreSQLTestCase):
+    """Test socorro.external.postgresql.graphics_report.GraphicsReport
+     class. """
+
+    @classmethod
+    def setUpClass(cls):
+        """ Populate product_info table with fake data """
+        super(IntegrationTestGraphicsReport, cls).setUpClass()
+
+        cursor = cls.connection.cursor()
+
+        cursor.execute("""
+            INSERT INTO products
+            (product_name, sort, rapid_release_version, release_name)
+            VALUES
+            (
+                'Firefox',
+                1,
+                '8.0',
+                'firefox'
+            ),
+            (
+                'Fennec',
+                3,
+                '11.0',
+                'mobile'
+            ),
+            (
+                'Thunderbird',
+                2,
+                '10.0',
+                'thunderbird'
+            );
+        """)
+        today = datetime.datetime.utcnow().date()
+        cursor.execute("""
+            INSERT INTO reports
+            (id, signature, date_processed, uuid, product,
+             url, email, success, addons_checked)
+            VALUES
+            (
+                1,
+                'signature',
+                %s,
+                '1',
+                'Firefox',
+                'http://mywebsite.com',
+                'test@something.com',
+                TRUE,
+                TRUE
+            ),
+            (
+                2,
+                'my signature',
+                %s,
+                '2',
+                'Firefox',
+                'http://myotherwebsite.com',
+                'admin@example.com',
+                NULL,
+                FALSE
+            );
+        """, (today, today))
+
+        cls.connection.commit()
+
+    #--------------------------------------------------------------------------
+    @classmethod
+    def tearDownClass(cls):
+        """ Cleanup the database, delete tables and functions """
+        cursor = cls.connection.cursor()
+        cursor.execute("""
+            TRUNCATE products, reports
+            CASCADE
+        """)
+        cls.connection.commit()
+        super(IntegrationTestGraphicsReport, cls).tearDownClass()
+
+    #--------------------------------------------------------------------------
+    def test_get(self):
+        api = GraphicsReport(config=self.config)
+        res = api.get(product='Firefox')
+        ok_(res['header'])
+        eq_(res['header'][0], 'signature')
+        eq_(res['header'][-1], 'productid')
+        assert res['hits']
+        ok_(isinstance(res['hits'], list))
+        signatures = [x[0] for x in res['hits']]
+        eq_(signatures, ['my signature', 'signature'])

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -160,6 +160,7 @@ BLACKLIST = (
     'Query',
     # because it's an internal thing only
     'SuperSearchFields',
+    'GraphicsReport',
 )
 
 

--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -513,3 +513,9 @@ class GCCrashesForm(BaseForm):
                 )
 
             return cleaned_end_date
+
+
+class GraphicsReportForm(BaseForm):
+
+    date = forms.DateField()
+    product = forms.CharField(required=False)

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1758,3 +1758,23 @@ class ProductBuildTypes(SocorroMiddleware):
     API_WHITELIST = (
         'hits',
     )
+
+
+class GraphicsReport(SocorroMiddleware):
+    """The legacy solution to supply the CSV reports that the Mozilla
+    Graphics Team needs."""
+
+    # This endpoint is protected in a django view with permission
+    # requirements. That means we don't have to worry about it being
+    # overly requested by rogue clients.
+    # Also, the response payload is usually very very large meaning
+    # it will cause strain having to store it in the cacheing server
+    # when it does get re-used much by repeated queries.
+    cache_seconds = 0
+
+    URL_PREFIX = '/graphics_report/'
+
+    required_params = (
+        'product',
+        ('date', datetime.date),
+    )

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -33,6 +33,7 @@ from crashstats.supersearch.tests.common import (
     SUPERSEARCH_FIELDS_MOCKED_RESULTS,
 )
 from crashstats.supersearch.models import SuperSearchFields, SuperSearch
+from crashstats.crashstats.views import GRAPHICS_REPORT_HEADER
 from .test_models import Response
 
 
@@ -5122,45 +5123,76 @@ class TestViews(BaseTestViews):
     def test_graphics_report(self, rget):
 
         def mocked_get(url, **options):
-            header = ['signature', 'date_processed']
             hits = [
-                ['my signature', '2015-10-08 23:22:21'],
-                ['other signature', '2015-10-08 13:12:11'],
+                {
+                    'signature': 'my signature',
+                    'date_processed': '2015-10-08 23:22:21'
+                },
+                {
+                    'signature': 'other signature',
+                    'date_processed': '2015-10-08 13:12:11'
+                },
             ]
+            # value for each of these needs to be in there
+            # supplement missing ones from the fixtures we intend to return
+            for hit in hits:
+                for head in GRAPHICS_REPORT_HEADER:
+                    if head not in hit:
+                        hit[head] = None
             return Response({
-                'header': header,
                 'hits': hits,
+                'total': len(hits)
             })
 
         rget.side_effect = mocked_get
 
         url = reverse('crashstats:graphics_report')
+
+        # viewing this report requires that you're signed in
         response = self.client.get(url)
         eq_(response.status_code, 403)
+
+        # But being signed in isn't good enough, you need the right
+        # permissions too.
         user = self._login()
         response = self.client.get(url)
         eq_(response.status_code, 403)
+
+        # give the user the right permission
         group = Group.objects.create(name='Hackers')
         permission = Permission.objects.get(codename='run_long_queries')
         group.permissions.add(permission)
         user.groups.add(group)
+
+        # But even with the right permissions you still need to
+        # provide the right minimal parameters.
         response = self.client.get(url)
         eq_(response.status_code, 400)
+
+        # Let's finally get it right. Permission AND the date parameter.
         data = {'date': datetime.datetime.utcnow().date()}
         response = self.client.get(url, data)
         eq_(response.status_code, 200)
         eq_(response['Content-Type'], 'text/csv')
         eq_(response['Content-Length'], str(len(response.content)))
-        # the content should be parseable
+
+        # the response content should be parseable
         length = len(response.content)
         inp = StringIO(response.content)
         reader = csv.reader(inp, delimiter='\t')
         lines = list(reader)
         assert len(lines) == 3
         header = lines[0]
-        eq_(header, ['signature', 'date_processed'])
+        eq_(header, list(GRAPHICS_REPORT_HEADER))
         first = lines[1]
-        eq_(first, ['my signature', '2015-10-08 23:22:21'])
+        eq_(
+            first[GRAPHICS_REPORT_HEADER.index('signature')],
+            'my signature'
+        )
+        eq_(
+            first[GRAPHICS_REPORT_HEADER.index('date_processed')],
+            '2015-10-08 23:22:21'
+        )
 
         # now fetch it with gzip
         response = self.client.get(url, data, HTTP_ACCEPT_ENCODING='gzip')
@@ -5168,9 +5200,9 @@ class TestViews(BaseTestViews):
         eq_(response['Content-Type'], 'text/csv')
         eq_(response['Content-Length'], str(len(response.content)))
         eq_(response['Content-Encoding'], 'gzip')
-        compressed = len(response.content)
-        ok_(compressed < length)
+        ok_(len(response.content) < length)
 
+    def test_graphics_report_not_available_via_regular_web_api(self):
         # check that the model isn't available in the API documentation
         api_url = reverse('api:model_wrapper', args=('GraphicsReport',))
         response = self.client.get(reverse('api:documentation'))

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -186,6 +186,9 @@ urlpatterns = patterns(
     url(r'^permissions/$',
         views.permissions,
         name='permissions'),
+    url(r'^graphics_report/$',
+        views.graphics_report,
+        name='graphics_report'),
     # if we do a permanent redirect, the browser will "cache" the redirect and
     # it will make it very hard to ever change the DEFAULT_PRODUCT
     url(r'^$',


### PR DESCRIPTION
@AdrianGaudebert r?
cc @twobraids 

I'd like to get some early eyes on this whilst I wait for the Graphics team to get back to me about which columns we can blanket out. E.g. `adu_count`. 
Once we have the most expensive columns blanket'ed out (e.g. `adu_count` and `duplicate_of`) that query will become many many times faster. 

How to test this? Run the branch and load http://socorro.dev/graphics_report/?date=2015-10-08 for example. Note that you need to be logged in. 

How to test it on the command line...
First you need to generate an API token that has the "Run long queries" permission. 
Then something like this:
```
curl -v -H "Auth-Token: 12312312312312312" http://socorro.dev/graphics_report/?date=2015-10-08
```
Or if you want to test that it gets gzipped properly, download it like this:
```
curl --compressed -v -H "Auth-Token: 12312312312312312" http://socorro.dev/graphics_report/?date=2015-10-08 > /tmp/reports.csv
```
And then you should be able open `/tmp/reports.csv` in Excel or Quip or Libreoffice or whatever you prefer. 

