### PR TITLE
fixes bug 1212969 - display copyable token without whitespace

### DIFF
--- a/webapp-django/crashstats/tokens/static/tokens/css/home.css
+++ b/webapp-django/crashstats/tokens/static/tokens/css/home.css
@@ -14,6 +14,8 @@ code, pre {
 p.code code {
     font-size: 1.5em;
     padding: 6px;
+    display: flex;
+    float: left;
 }
 p.example code,
 pre.example {
@@ -30,6 +32,16 @@ p.code .rest-hidden {
 div.token {
     border-bottom: 1px solid #ccc;
     padding: 25px 5px;
+}
+
+/* The `p.code code` selector, defined above, is a `display:flexbox`
+   so that each element within gets bunched up to each other without
+   any whitespace padding.
+   Then to make this button appear "to the right" of this, we have to
+   hack its position. */
+div.token button {
+    position: relative;
+    top: -8px;
 }
 
 table.meta-data th {

--- a/webapp-django/crashstats/tokens/templates/tokens/home.html
+++ b/webapp-django/crashstats/tokens/templates/tokens/home.html
@@ -46,7 +46,8 @@
                     <time class="ago" data-date="{{ token.created.isoformat() }}">{{ token.created.isoformat() }}</time>
                 </h4>
                 <p class="code">
-                    <code>{{ token.key[:12] }}
+                    <code>
+                        <span>{{ token.key[:12] }}</span>
                         <span class="rest-hidden">{{ token.key[12:] }}</span>
                         <span class="rest-cover">...</span>
                     </code>


### PR DESCRIPTION
@AdrianGaudebert r?

Turns out, it's [not trivial](https://css-tricks.com/fighting-the-space-between-inline-block-elements/) to get rid of those spaces between the tags. But I think I got it working. 