### PR TITLE
fixes bug 1214436 - Ability to sync featured versions from prod

### DIFF
--- a/webapp-django/crashstats/manage/static/manage/js/featured-versions.js
+++ b/webapp-django/crashstats/manage/static/manage/js/featured-versions.js
@@ -2,14 +2,14 @@
 (function ($, document) {
     'use strict';
 
-    function submit_form($form) {
+    function submitForm() {
         // check that every product has at least one featured version
         var no_empty = true;
         $('.product').each(function() {
             if ($('input[type="checkbox"]', this).length && !$('input[type="checkbox"]:checked', this).length) {
                 var product = $('h4', this).text();
                 no_empty = false;
-                alert("No versions selected for " + product);
+                alert('No versions selected for ' + product);
             }
         });
         return no_empty;
@@ -19,8 +19,40 @@
 
         // hijack form submissions
         $('form.products').submit(function() {
-            return submit_form($(this));
+            return submitForm($(this));
         });
+
+        if (document.location.host !== 'crash-stats.mozilla.com') {
+            // indicate what prod has for its featured versions
+            $.getJSON('https://crash-stats.mozilla.com/api/CurrentVersions/')
+            .done(function(products) {
+                $('.featured-on-prod').show();
+                var featured = {};
+                $.each(products, function(i, product) {
+                    if (product.featured) {
+                        if (!featured[product.product]) {
+                            featured[product.product] = [];
+                        }
+                        featured[product.product].push(product.version);
+                    }
+                });
+
+                $('.featured-on-prod button').on('click', function() {
+                    $('input[type="checkbox"]:checked').attr('checked', false);
+                    $('tbody tr').each(function() {
+                        var product = $('td', this).eq(0).text();
+                        var version = $('td', this).eq(1).text();
+                        if (featured[product].indexOf(version) > -1) {
+                            $('input[type="checkbox"]', this).attr('checked', true);
+                        }
+                    });
+                    $('.featured-on-prod p:hidden').show(600);
+                });
+            })
+            .fail(function() {
+                console.error.apply(console, arguments);
+            });
+        }
     });
 
 }($, document));

--- a/webapp-django/crashstats/manage/templates/manage/featured_versions.html
+++ b/webapp-django/crashstats/manage/templates/manage/featured_versions.html
@@ -49,6 +49,14 @@
             <li><a href="#{{ product }}">{{ product }}</a></li>
             {% endfor %}
         </ul>
+
+        <div class="featured-on-prod" style="display:none">
+            <button type="button">Set the same as crash-stats.mozilla.com</button>
+            <p style="display:none">
+                Checkboxes updated to match <code>crash-stats.mozilla.com</code>.<br>
+                Verify and press <b>Update Featured Versions</b> below.
+            </p>
+        </div>
     </div>
 </div>
 <div class="panel">


### PR DESCRIPTION
@AdrianGaudebert r?

So this is the least hacky thing I can image we start with. I first tried to write it as a script that anybody could own and run with an API token. But then I needed a new permission (and possibly tie that to a group) and our FeaturedReleases model couldn't accept anything other than multipart form.

I say we make this available and it only shows on stage or localhost and it'll make stage look more sane and should solve the problem for QA. 