### PR TITLE
fixes bug 1214718 - SuperSearch should guard against massive _results_number

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -224,6 +224,8 @@ class SuperSearch(SearchBase):
                         results_from = param.value[0]
                     elif param.name == '_results_number':
                         results_number = param.value[0]
+                        if results_number > 1000:
+                            raise BadArgumentError('_results_number too large')
                     elif param.name == '_facets_size':
                         facets_size = param.value[0]
 

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1527,3 +1527,11 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
             _results_number=0,
         )
         eq_(len(res['hits']), 0)
+
+    @minimum_es_version('1.0')
+    def test_get_with_too_many(self):
+        assert_raises(
+            BadArgumentError,
+            self.api.get,
+            _results_number=1001,
+        )


### PR DESCRIPTION
@AdrianGaudebert What should the number be? Should it be tied to the "Run long queries" permission?
