### PR TITLE
fixes bug1216742:  [no merge - work in progress] move FTS transforms into their own hierarchy 	

### DIFF
--- a/scripts/defaults
+++ b/scripts/defaults
@@ -22,9 +22,9 @@ export rmq_host=${rmq_host:-"localhost"}
 export rmq_user=${rmq_user:-"guest"}
 export rmq_password=${rmq_password:-"guest"}
 export rmq_virtual_host=${rmq_virtual_host:-"/"}
-export rmq_normal_queue_name=${rmq_normal_queue_name:-"socoro.integrationtest.normal"}
-export rmq_priority_queue_name=${rmq_priority_queue_name:-"socoro.integrationtest.priority"}
-export rmq_reprocessing_queue_name=${rmq_reprocessing_queue_name:-"socoro.integrationtest.reprocessing"}
+export rmq_normal_queue_name=${rmq_normal_queue_name:-"socorro.integrationtest.normal"}
+export rmq_priority_queue_name=${rmq_priority_queue_name:-"socorro.integrationtest.priority"}
+export rmq_reprocessing_queue_name=${rmq_reprocessing_queue_name:-"socorro.integrationtest.reprocessing"}
 
 export elasticSearchHostname=${elasticSearchHostname:-"localhost"}
 export elasticsearch_urls=${elasticsearch_urls:-"http://localhost:9200"}

--- a/socorro/app/fts_worker_methods.py
+++ b/socorro/app/fts_worker_methods.py
@@ -1,0 +1,400 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from socorro.external.crashstorage_base import (
+    CrashStorageBase,
+    CrashIDNotFound,
+    NullCrashStorage,
+    MemoryDumpsMapping
+)
+# renaming to make it clear that this is not a DotDict from configman
+from socorro.lib.util import DotDict as SocorroDotDict
+
+from configman import Namespace
+from functools import wraps
+
+
+#==============================================================================
+class RejectJob(Exception):
+    """Used as an exception by the workers when they cannot load a crash for
+    some reason.  When it is instantiated, the reason for the failure is
+    given as the string to the constructor.  In the initial implementation
+    of this class, the only use is on receiving a CrashIDNotFound exception.
+    However, this class is available to be used for other reasons to reject
+    crashes from within the worker methods."""
+    pass
+
+
+#------------------------------------------------------------------------------
+def exception_wrapper(fn):
+    """The worker methods classes all wrap access to the Crashstorage system
+    in some exception handlers. Since that is boilerplate, it is offered here
+    as a decorator on the calls to reduce code clutter."""
+    @wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return fn(self, *args, **kwargs)
+        except CrashIDNotFound, x:
+            message = "%r could not be found" % x
+            self.config.logger.warning(message, exc_info=True)
+            raise RejectJob(message)
+        except Exception as x:
+            self.config.logger.error(
+                "error reading raw_crash: %r",
+                x,
+                exc_info=True
+            )
+            raise
+    return wrapper
+
+
+#------------------------------------------------------------------------------
+def NullTransform(*args, **kwargs):
+    """when the app passes None to the FTSWorkerMethod deriviative, it is
+    saying that we want the data to pass from the fetch to the save without
+    being changed.  This is the case of the crashmover or the submitter apps.
+    They don't change the data that flows through them.
+
+    This method is a conveniennce that gets saved as the transformation method
+    allowing the transformation method to be called sans exception handling.
+    """
+    pass
+
+
+
+#==============================================================================
+class FTSWorkerMethodBase(CrashStorageBase):
+    """This base class for the worker methods class wraps all the access to the
+    crashstorage system in exception handlers.
+
+    On instantiation, the fetch store, the save store and the transformation
+    method are all part of initialization.  That initialization happens in the
+    FTS Apps' method called '_setup_source_and_destination'. The fetch and
+    save crashstores are defined in configuration.  The transform is passed in
+    as a parameter in the call.  The source of the transformation is defined
+    by the application.
+
+    For example, the ProcesorApp is a class that derives from the
+    FetchTransformSaveApp.  It the ProcessorApp's configuration, it has two
+    important parameters: the 'worker_task.worker_task_impl' and
+    'processor.processor_class'.
+
+    The 'worker_task.worker_task_impl' is a class from this hierachy.  For the
+    processor, that is likely the class 'ProcessorWorkerMethod'.
+
+    The 'processor.processor_class' for the processor is instatiated in the
+    processor's '_setup_source_and_destination' method which is then passed
+    down to the 'FetchTransformSaveApp' '_setup_source_and_destination' method
+    as the 'transform_fn'.
+
+    This class derives from the CrashStorage system of classes because it
+    offers the same API and could be used as a 2 element crashstore, where the
+    division of labor is between the save and get/fetch methods.  It deviates
+    from the standard crashstorage hierarchy by being initialized with other
+    crashstorage instances in its constructor rather than through the config
+    system of dependency injection. The inclusion of this class in the
+    crashstorage hierarchy is an early step in an evolutionary change that will
+    see CrashStorage, FTS_worker_methods, and TransformRules all move toward
+    drop in compatibility with each other.
+    """
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    def __init__(
+        self,
+        config,
+        fetch_store=None,
+        save_store=None,
+        transform_fn=None,
+        quit_check=None
+    ):
+        super(FTSWorkerMethodBase, self).__init__(config)
+        self.fetch_store = fetch_store if fetch_store else NullCrashStorage(
+            config
+        )
+        self.save_store = save_store if save_store else NullCrashStorage(
+            config
+        )
+        if transform_fn is None:
+            transform_fn = NullTransform
+        self.transformation_fn = transform_fn
+        self.quick_check = quit_check
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # CrashStorage method forwards
+    # methods in this section implement forwarding the crashstorage api methods
+    # to the member crashstorage instances. All the 'save' methods forward to
+    # the save crashstore, while the 'get' methods forward to the fetch
+    # crashstore. All are wrapped with the standard exception handler decorator
+    # so that they behave the same way
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def save_raw_crash(self, raw_crash, dumps, crash_id):
+        self.save_store.save_raw_crash(
+            raw_crash,
+            dumps,
+            crash_id
+        )
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def save_raw_crash_with_file_dumps(self, raw_crash, dumps, crash_id):
+        self.save_store.save_raw_crash_with_file_dumps(
+            raw_crash,
+            dumps,
+            crash_id
+        )
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def save_processed(self, processed_crash):
+        self.save_store.save_processed(processed_crash)
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def save_raw_and_processed(
+        self,
+        raw_crash,
+        dumps,
+        processed_crash,
+        crash_id
+    ):
+        self.save_store.save_raw_and_processed(
+            raw_crash,
+            dumps,
+            processed_crash,
+            crash_id
+        )
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def get_raw_crash(self, crash_id):
+        return self.fetch_store.get_raw_crash(crash_id)
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def get_raw_dump(self, crash_id, name=None):
+        return self.fetch_store.get_raw_dump(crash_id, name)
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def get_raw_dumps(self, crash_id):
+        return self.fetch_store.get_raw_dumps(crash_id)
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def get_raw_dumps_as_files(self, crash_id):
+        return self.fetch_store.get_raw_dumps_as_files(crash_id)
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def get_unredacted_processed(self, crash_id):
+        return self.fetch_store.get_unredacted_processed(crash_id)
+
+    #--------------------------------------------------------------------------
+    @exception_wrapper
+    def remove(self, crash_id):
+        self.save_store.remove(crash_id)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # other methods
+    # the methods in this section are misc support methods
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    #--------------------------------------------------------------------------
+    def __call__(self, crash_id):
+        """the classes in this hierarchy are functors, classes meant to be
+        invoked as if they were functions.  Derived classes are to implement
+        the '_call_impl' method to define  what the worker method does with the
+        crashstorage instances.  This method adds a standard logging and
+        exception handling so that all derived classes behave the same way."""
+        self.config.logger.info("starting job: %s", crash_id)
+        try:
+            self._call_impl(crash_id)
+            self.config.logger.info("finished successful job: %s", crash_id)
+        except Exception, x:
+            self.config.logger.warning(
+                'finished failed job: %s (%r)',
+                crash_id,
+                x
+            )
+            if isinstance(x, RejectJob):
+                return
+            raise
+
+    #--------------------------------------------------------------------------
+    def _call_impl(self, crash_id):
+        """each derived class is to implement this method to define how the
+        FTS app is to interact with the crashstorage instances.  For example:
+        read a raw_crash from the fetch crashstore, transform it in some
+        manner, then save it to the save crashstore."""
+        raise NotImplementedError()
+
+
+#==============================================================================
+class RawCrashCopyWorkerMethod(FTSWorkerMethodBase):
+    """this worker method implementation reads raw crashes and dumps from the
+    fetch crashstore, applies a transformation and then saves them to the
+    save crashstore.  If the transformation is the NullTransformation (do not
+    change the raw crash or dumps), then this is the implementation of a
+    copy function.  This is the method used by the SubmiterApp as it just
+    copies crashes from one crash storage system and submits them unchanged
+    to another."""
+
+    #--------------------------------------------------------------------------
+    def _call_impl(self, crash_id):
+        raw_crash = self.get_raw_crash(crash_id)
+        raw_dumps = self.get_raw_dumps(crash_id)
+
+        # the following call implements a transformation of the raw_crashs,
+        # and raw_dumps.  Since they are both MutableMappings, any changes
+        # happen to directly to them rather than making new ones and returning
+        # them.
+        self.transformation_fn(raw_crash=raw_crash, raw_dumps=raw_dumps)
+        # where did this transformation come from?  Who set it?
+        # the transformation_fn was specified in the constructor for this
+        # class.  Most likely a App instantiated this class in its
+        # '_setup_source_and_destination' method.  Apps like the processor,
+        # will instantiate their own transformation object.  The transformation
+        # object is a functor, an object that defines __call__ and can be
+        # called as a function.  Processor2015 defines a transformation object
+        # based on the TransformRule system.
+
+        self.save_raw_crash(raw_crash, raw_dumps, crash_id)
+
+
+#==============================================================================
+class RawCrashMoveWorkerMethod(RawCrashCopyWorkerMethod):
+    """this worker method implementation derives from the copy class above, but
+    adds the step of deleting the original raw_crash and dumps from the fetch
+    crashstore after a successful copy.  This is the implementation of the
+    worker method for CrashMoverApp"""
+
+    #--------------------------------------------------------------------------
+    def _call_impl(self, crash_id):
+        self.config.logger.debug(
+            'RawCrashMoveWorkerMethod._call_impl with %s',
+            crash_id
+        )
+        super(RawCrashMoveWorkerMethod, self)._call_impl(crash_id)
+        self.remove(crash_id)
+
+
+#==============================================================================
+class ProcessedCrashCopyWorkerMethod(FTSWorkerMethodBase):
+    """this worker method implementation copies processed crashes from the
+    fetch crashstore to the save crashstore.  With a null transformation, it
+    just copies.  This implementation is useful there needs to be an ad hoc
+    change to processed crashes to correct an error or add/remove information
+    from the processed crashes.
+    """
+
+    #--------------------------------------------------------------------------
+    def _call_impl(self, crash_id):
+        self.config.logger.debug(
+            'ProcessedCrashCopyWorkerMethod._call_impl with %s',
+            crash_id
+        )
+        processed_crash = self.get_unredacted_processed(crash_id)
+
+        # see the commentary in the similar call in the class
+        # RawCrashCopyWorkerMethod above for an explaination of this call:
+        self.transformation_fn(processed_crash=processed_crash)
+
+        self.save_processed(processed_crash)
+
+
+#==============================================================================
+class CopyAllWorkerMethod(FTSWorkerMethodBase):
+    """this worker method implementation copies raw_crashs, raw_dumps and
+    processed crashes from the fetch crashstore to the save crashstore.  This
+    is useful as the basis for an app that mirgrates from one storage location
+    to another.  For example, if a Socorro installation has been running with
+    a filesystem primary storage and needs to migrate to Amazon S3, an FTS App
+    with this worker implemention will do the job."""
+
+    #--------------------------------------------------------------------------
+    def _call_impl(self, crash_id):
+        self.config.logger.debug(
+            'CopyAllWorkerMethod._call_impl with %s',
+            crash_id
+        )
+        raw_crash = self.get_raw_crash(crash_id)
+        raw_dumps = self.get_raw_dumps(crash_id)
+        processed_crash = self.get_unredacted_processed(crash_id)
+
+        # see the commentary in the similar call in the class
+        # RawCrashCopyWorkerMethod above for an explaination of this call:
+        processed_crash = self.transformation_fn(
+            raw_crash=raw_crash,
+            raw_dumps=raw_crash,
+            processed_crash=processed_crash
+        )
+
+        self.save_raw_and_processed(
+            raw_crash,
+            raw_dumps,
+            processed_crash,
+            crash_id
+        )
+
+
+#==============================================================================
+class ProcessorWorkerMethod(FTSWorkerMethodBase):
+    """this worker method implementation has been optimized for the processor
+    that needs to have the raw_dumps in the form of files on a filesystem.  It
+    follows the same form of the CopyAllWorkerMethod above, but requires that
+    raw_dumps get written to the file system, then ensures that any temporary
+    files are removed when the worker is done."""
+
+    #--------------------------------------------------------------------------
+    def _call_impl(self, crash_id):
+        raw_crash = self.get_raw_crash(crash_id)
+        raw_dumps = self.get_raw_dumps_as_files(crash_id)
+        try:
+            try:
+                processed_crash = self.get_unredacted_processed(crash_id)
+            except RejectJob:
+                # this just means that this crash was not previously processed
+                # we'll start with an empty processed crash instead
+                processed_crash = SocorroDotDict()
+
+            # see the commentary in the similar call in the class
+            # RawCrashCopyWorkerMethod above for an explaination of this call:
+            processed_crash = self.transformation_fn(
+                raw_crash=raw_crash,
+                raw_dumps=raw_dumps,
+                processed_crash=processed_crash
+            )
+
+            self.save_raw_and_processed(
+                raw_crash,
+                # while the processor will resave raw crashes, it declines
+                # to resave the raw dumps, so it does not pass them into this
+                # call
+                None,
+                processed_crash,
+                crash_id
+            )
+            self.config.logger.info('saved - %s', crash_id)
+        finally:
+            raw_dumps.remove_temp_files()
+
+
+#==============================================================================
+class NoDumpsProcessorWorkerMethod(ProcessorWorkerMethod):
+    """this worker method implementation has been optimized for the processor
+    that needs to have the raw_dumps in the form of files on a filesystem.  It
+    follows the same form of the CopyAllWorkerMethod above, but requires that
+    raw_dumps get written to the file system, then ensures that any temporary
+    files are removed when the worker is done."""
+
+    #--------------------------------------------------------------------------
+    def get_raw_dumps_as_files(self, crash_id):
+        return MemoryDumpsMapping({})
+
+
+

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -66,6 +66,13 @@ class MemoryDumpsMapping(dict):
         without having to do any conversion."""
         return self
 
+    #--------------------------------------------------------------------------
+    def remove_temp_files(self):
+        """there are no tempfiles, this call can be ignored.  This method
+        exists so that FileDumpsMapping & MemoryDumpsMapping can be perfectly
+        interchangable."""
+        pass
+
 
 #==============================================================================
 class FileDumpsMapping(dict):
@@ -111,6 +118,19 @@ class FileDumpsMapping(dict):
                 in_memory_dumps[dump_key] = f.read()
         return in_memory_dumps
 
+    #--------------------------------------------------------------------------
+    def remove_temp_files(self):
+        """if any of the files in this FileDumpsMapping are temporary,
+        delete them"""
+        for dump_key, dump_path in self.iteritems():
+            if "TEMPORARY" in dump_path:
+                try:
+                    os.unlink(dump_path)
+                except OSError:
+                    self.config.logger.warning(
+                        'unable to delete %s. manual deletion is required.',
+                        dump_path
+                    )
 
 #==============================================================================
 class Redactor(RequiredConfig):
@@ -419,6 +439,54 @@ class NullCrashStorage(CrashStorageBase):
         parameters:
            crash_id - the id of a crash to fetch"""
         pass
+
+
+#==============================================================================
+class DryRunCrashStorage(CrashStorageBase):
+    """a testing crashstorage that just announces what it was told to do on
+    stdout, but actually does nothing
+    """
+    #--------------------------------------------------------------------------
+    def save_raw_crash(self, raw_crash, dumps, crash_id):
+        print "save_raw_crash: crash_id"
+
+    #--------------------------------------------------------------------------
+    def save_raw_crash_with_file_dumps(self, raw_crash, dumps, crash_id):
+        print "save_raw_crash_with_file_dumps: crash_id"
+
+    #--------------------------------------------------------------------------
+    def save_processed(self, processed_crash):
+        print "save_processed: crash_id"
+
+    #--------------------------------------------------------------------------
+    def get_raw_crash(self, crash_id):
+        print "get_raw_crash: %s" % crash_id
+        return SocorroDotDict()
+
+    #--------------------------------------------------------------------------
+    def get_raw_dump(self, crash_id, name):
+        print "get_raw_dump: %s" % crash_id
+        return ''
+
+    #--------------------------------------------------------------------------
+    def get_raw_dumps(self, crash_id):
+        print "get_raw_dumps: %s" % crash_id
+        return SocorroDotDict()
+
+    #--------------------------------------------------------------------------
+    def get_raw_dumps_as_files(self, crash_id):
+        print "get_raw_dumps_as_files: %s" % crash_id
+        return SocorroDotDict()
+
+    #--------------------------------------------------------------------------
+    def get_unredacted_processed(self, crash_id):
+        print "get_unredacted_processed: %s" % crash_id
+        return SocorroDotDict()
+
+    #--------------------------------------------------------------------------
+    def remove(self, crash_id):
+        print "remove: %s" % crash_id
+
 
 
 #==============================================================================

--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -92,7 +92,10 @@ class TaskManager(RequiredConfig):
         self.job_param_source_iter = job_source_iterator
         self.task_func = task_func
         self.quit = False
-        self.logger.debug('TaskManager finished init')
+        self.logger.debug(
+            'TaskManager finished init using worker method %s',
+            task_func
+        )
 
     #--------------------------------------------------------------------------
     def quit_check(self):

--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -471,6 +471,14 @@ class TransformRuleSystem(RequiredConfig):
                 return False
         return None
 
+    #--------------------------------------------------------------------------
+    def close(self):
+        for a_rule in self.rules:
+            try:
+                a_rule.close()
+            except AttributeError:
+                # it's ok for a rule to not have a close method
+                pass
 
 #------------------------------------------------------------------------------
 # Useful rule predicates and actions

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -58,98 +58,33 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         from_string_converter=class_converter
     )
 
-    ###########################################################################
-    ### TODO: implement an __init__ and a waiting func.  The waiting func
-    ### will take registrations of periodic things to do over some time
-    ### interval.  the first periodic thing is the rereading of the
-    ### signature generation stuff from the database.
-    ###########################################################################
-
     #--------------------------------------------------------------------------
     @staticmethod
     def get_application_defaults():
         return {
             "source.crashstorage_class": FSDatedPermanentStorage,
             "destination.crashstorage_class": FSDatedPermanentStorage,
+            "worker_task.worker_task_impl":
+                "socorro.app.fts_worker_methods.ProcessorWorkerMethod",
         }
 
     #--------------------------------------------------------------------------
-    def _transform(self, crash_id):
-        """this implementation is the framework on how a raw crash is
-        converted into a processed crash.  The 'crash_id' passed in is used as
-        a key to fetch the raw crash from the 'source', the conversion funtion
-        implemented by the 'processor_class' is applied, the
-        processed crash is saved to the 'destination'"""
-        try:
-            raw_crash = self.source.get_raw_crash(crash_id)
-            dumps = self.source.get_raw_dumps_as_files(crash_id)
-        except CrashIDNotFound:
-            self.processor.reject_raw_crash(
-                crash_id,
-                'this crash cannot be found in raw crash storage'
+    def _setup_source_and_destination(self, transform_fn=None):
+        """this method instantiates the 'processor.processor_class' which
+        implements the transform method to be run by the workers to transform
+        raw crashes into processed crashes.
+        """
+        if transform_fn is None:
+            self.processor = self.config.processor.processor_class(
+                self.config.processor,
+                self.quit_check
             )
-            return
-        except Exception, x:
-            self.config.logger.warning(
-                'error loading crash %s',
-                crash_id,
-                exc_info=True
-            )
-            self.processor.reject_raw_crash(
-                crash_id,
-                'error in loading: %s' % x
-            )
-            return
+            transform_fn = self.processor.process_crash
 
-        try:
-            processed_crash = self.source.get_unredacted_processed(
-                crash_id
-            )
-        except CrashIDNotFound:
-            processed_crash = DotDict()
+        super(ProcessorApp, self)._setup_source_and_destination(
+            transform_fn=transform_fn
+        )
 
-        try:
-            if 'uuid' not in raw_crash:
-                raw_crash.uuid = crash_id
-            processed_crash = (
-                self.processor.process_crash(
-                    raw_crash,
-                    dumps,
-                    processed_crash,
-                )
-            )
-            """ bug 866973 - save_raw_and_processed() instead of just
-                save_processed().  The raw crash may have been modified
-                by the processor rules.  The individual crash storage
-                implementations may choose to honor re-saving the raw_crash
-                or not.
-            """
-            self.destination.save_raw_and_processed(
-                raw_crash,
-                None,
-                processed_crash,
-                crash_id
-            )
-            self.config.logger.info('saved - %s', crash_id)
-        finally:
-            # earlier, we created the dumps as files on the file system,
-            # we need to clean up after ourselves.
-            for a_dump_pathname in dumps.itervalues():
-                try:
-                    if "TEMPORARY" in a_dump_pathname:
-                        os.unlink(a_dump_pathname)
-                except OSError, x:
-                    # the file does not actually exist
-                    self.config.logger.info(
-                        'deletion of dump failed: %s',
-                        x,
-                    )
-
-    #--------------------------------------------------------------------------
-    def _setup_source_and_destination(self):
-        """this method simply instatiates the source, destination,
-        new_crash_source, and the processor algorithm implementation."""
-        super(ProcessorApp, self)._setup_source_and_destination()
         if self.config.companion_process.companion_class:
             self.companion_process = \
                 self.config.companion_process.companion_class(
@@ -165,16 +100,14 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         # while the threaded_task_manager processes crashes.
         self.waiting_func = None
 
-        self.processor = self.config.processor.processor_class(
-            self.config.processor,
-            self.quit_check
-        )
-
     #--------------------------------------------------------------------------
     def _cleanup(self):
         """when  the processor shutsdown, this function cleans up"""
         if self.companion_process:
             self.companion_process.close()
+        self.config.logger.debug('telling processor to close')
+        self.processor.close()
+        self.config.logger.debug('processor done closing')
 
 
 if __name__ == '__main__':

--- a/socorro/unittest/app/test_fts_worker_methods.py
+++ b/socorro/unittest/app/test_fts_worker_methods.py
@@ -1,0 +1,493 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_, ok_, assert_raises
+from mock import Mock
+
+from configman.dotdict import DotDictWithAcquisition
+
+from socorro.app.fts_worker_methods import (
+    NullTransform,
+    FTSWorkerMethodBase,
+    RawCrashCopyWorkerMethod,
+    RawCrashMoveWorkerMethod,
+    ProcessedCrashCopyWorkerMethod,
+    CopyAllWorkerMethod,
+    ProcessorWorkerMethod,
+    RejectJob
+)
+from socorro.lib.util import DotDict as SocorroDotDict
+from socorro.external.crashstorage_base import NullCrashStorage
+from socorro.unittest.testbase import TestCase
+
+an_id = 'not a real id'
+dump_name = 'dummy_dump_name'
+a_raw_crash = {
+    'crash_id': an_id,
+}
+a_raw_dump = 'a dump contents'
+raw_dumps = {
+    'dump': a_raw_dump,
+    dump_name: 'more dump contents',
+}
+a_processed_crash = {
+    'crash_id': an_id,
+}
+
+#==============================================================================
+class TestFTSWorkerMethods(TestCase):
+
+    #--------------------------------------------------------------------------
+    def get_config(self):
+        config = DotDictWithAcquisition()
+        config.logger = Mock()
+        config.redactor_class = Mock()
+        return config
+
+    #--------------------------------------------------------------------------
+    def test_FTSWorkerMethodBase_all_None(self):
+        config = self.get_config()
+        fts_worker_method = FTSWorkerMethodBase(config)
+        ok_(isinstance(fts_worker_method.fetch_store, NullCrashStorage))
+        ok_(isinstance(fts_worker_method.save_store, NullCrashStorage))
+        ok_(fts_worker_method.transformation_fn is NullTransform)
+        ok_(fts_worker_method.quick_check is None)
+        ok_(fts_worker_method.save_raw_crash({}, {}, an_id) is None)
+        ok_(
+            fts_worker_method.save_raw_crash_with_file_dumps({}, {}, an_id)
+            is None
+        )
+        ok_(fts_worker_method.save_processed({}) is None)
+        eq_(fts_worker_method.get_raw_crash(an_id), {})
+        eq_(fts_worker_method.get_raw_dump(an_id, dump_name), '')
+        eq_(fts_worker_method.get_raw_dumps(an_id), {})
+        eq_(fts_worker_method.get_raw_dumps_as_files(an_id), {})
+        eq_(fts_worker_method.get_unredacted_processed(an_id), {})
+        eq_(fts_worker_method.get_processed(an_id), {})
+        ok_(fts_worker_method.remove(an_id) is None)
+
+        assert_raises(NotImplementedError, fts_worker_method, an_id)
+
+    #--------------------------------------------------------------------------
+    def test_FTSWorkerMethodBase_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = FTSWorkerMethodBase(
+            config,
+            Mock(),
+            Mock(),
+            Mock(),
+            Mock(),
+        )
+
+        ok_(fts_worker_method.save_raw_crash({}, {}, an_id) is None)
+        fts_worker_method.save_store.save_raw_crash.called_once_with(
+            {},
+            {},
+            an_id
+        )
+
+        ok_(
+            fts_worker_method.save_raw_crash_with_file_dumps(
+                {},
+                {},
+                an_id
+            ) is None
+        )
+        fts_worker_method.save_store.save_raw_crash_with_file_dumps \
+            .called_once_with({}, {}, an_id)
+
+        ok_(fts_worker_method.save_processed({}) is None)
+        fts_worker_method.save_store.save_processed.called_once_with({})
+
+        fts_worker_method.get_raw_crash(an_id),
+        fts_worker_method.fetch_store.save_processed.called_once_with(an_id)
+
+        fts_worker_method.get_raw_dump(an_id, dump_name)
+        fts_worker_method.fetch_store.get_raw_dump.called_once_with(
+            an_id,
+            dump_name
+        )
+
+        fts_worker_method.get_raw_dumps(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps.called_once_with(an_id)
+
+        fts_worker_method.get_raw_dumps_as_files(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps_as_files.called_once_with(
+            an_id,
+        )
+
+        fts_worker_method.get_unredacted_processed(an_id)
+        fts_worker_method.fetch_store.get_unredacted_processed \
+            .called_once_with(an_id)
+
+        fts_worker_method.get_processed(an_id)
+        fts_worker_method.fetch_store.get_processed.called_once_with(an_id)
+
+        fts_worker_method.remove(an_id)
+        fts_worker_method.fetch_store.remove.called_once_with(an_id)
+
+    #--------------------------------------------------------------------------
+    def test_RawCrashCopyWorkerMethod_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = RawCrashCopyWorkerMethod(
+            config,
+            fetch_store=Mock(),
+            save_store=Mock(),
+            transform_fn=Mock(),
+            quit_check=Mock(),
+        )
+        fts_worker_method.fetch_store.get_raw_crash.return_value = a_raw_crash
+        fts_worker_method.fetch_store.get_raw_dumps.return_value = raw_dumps
+
+        # the call to be tested
+        fts_worker_method(an_id)
+
+        # this is what should have happened:
+        # first with the fetch_store
+        fts_worker_method.fetch_store.get_raw_crash.called_once_with(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps.called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.save_raw_and_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.get_unredacted_processed.call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.remove.call_count, 0)
+
+        # then with the transformation
+        fts_worker_method.transformation_fn.called_once_with(
+            raw_crash=a_raw_crash,
+            raw_dumps=raw_dumps
+        )
+
+        # and then with the save_store
+        fts_worker_method.save_store.save_raw_crash.called_once_with(
+            a_raw_crash,
+            raw_dumps
+        )
+        eq_(fts_worker_method.save_store.save_raw_crash_with_file_dumps.call_count, 0)
+        eq_(fts_worker_method.save_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.save_raw_and_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(fts_worker_method.save_store.get_unredacted_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.remove.call_count, 0)
+
+    #--------------------------------------------------------------------------
+    def test_RawCrashMoveWorkerMethod_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = RawCrashCopyWorkerMethod(
+            config,
+            fetch_store=Mock(),
+            save_store=Mock(),
+            transform_fn=Mock(),
+            quit_check=Mock(),
+        )
+        fts_worker_method.fetch_store.get_raw_crash.return_value = a_raw_crash
+        fts_worker_method.fetch_store.get_raw_dumps.return_value = raw_dumps
+
+        # the call to be tested
+        fts_worker_method(an_id)
+
+        # this is what should have happened:
+        # first with the fetch_store
+        fts_worker_method.fetch_store.get_raw_crash.called_once_with(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps.called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.save_raw_and_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.get_unredacted_processed.call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.get_processed.call_count, 0)
+        fts_worker_method.fetch_store.remove.called_once_with(an_id)
+
+        # then with the transformation
+        fts_worker_method.transformation_fn.called_once_with(
+            raw_crash=a_raw_crash,
+            raw_dumps=raw_dumps
+        )
+
+        # and then with the save_store
+        fts_worker_method.save_store.save_raw_crash.called_once_with(
+            a_raw_crash,
+            raw_dumps
+        )
+        fts_worker_method.save_store.remove.called_once_with(an_id)
+        eq_(fts_worker_method.save_store.save_raw_crash_with_file_dumps.call_count, 0)
+        eq_(fts_worker_method.save_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.save_raw_and_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(fts_worker_method.save_store.get_unredacted_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.remove.call_count, 0)
+
+
+    #--------------------------------------------------------------------------
+    def test_ProcessedCrashCopyWorkerMethod_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = ProcessedCrashCopyWorkerMethod(
+            config,
+            fetch_store=Mock(),
+            save_store=Mock(),
+            transform_fn=Mock(),
+            quit_check=Mock(),
+        )
+        fts_worker_method.fetch_store.get_unredacted_processed.return_value = \
+            a_processed_crash
+
+        # the call to be tested
+        fts_worker_method(an_id)
+
+        # this is what should have happened:
+        # first with the fetch_store
+        eq_(fts_worker_method.fetch_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.save_raw_and_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.fetch_store.get_raw_dumps_as_files.call_count, 0)
+        fts_worker_method.fetch_store.get_unredacted_processed \
+            .called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.remove.call_count, 0)
+
+        # then with the transformation
+        fts_worker_method.transformation_fn.called_once_with(
+            processed_crash=a_processed_crash,
+        )
+
+        # and then with the save_store
+        eq_(fts_worker_method.save_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.save_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        fts_worker_method.save_store.save_processed.called_once_with(
+            a_processed_crash
+        )
+        eq_(fts_worker_method.save_store.save_raw_and_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(fts_worker_method.save_store.get_unredacted_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.remove.call_count, 0)
+
+
+    #--------------------------------------------------------------------------
+    def test_CopyAllWorkerMethod_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = ProcessedCrashCopyWorkerMethod(
+            config,
+            fetch_store=Mock(),
+            save_store=Mock(),
+            transform_fn=Mock(),
+            quit_check=Mock(),
+        )
+        fts_worker_method.fetch_store.get_raw_crash.return_value = a_raw_crash
+        fts_worker_method.fetch_store.get_raw_dumps.return_value = raw_dumps
+        fts_worker_method.fetch_store.get_unredacted_processed.return_value = \
+            a_processed_crash
+
+        # the call to be tested
+        fts_worker_method(an_id)
+
+        # this is what should have happened:
+        # first with the fetch_store
+        eq_(fts_worker_method.fetch_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.save_raw_and_processed.call_count, 0)
+        fts_worker_method.fetch_store.get_raw_crash.called_once_with(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps.called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_raw_dumps_as_files.call_count, 0)
+        fts_worker_method.fetch_store.get_unredacted_processed \
+            .called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.remove.call_count, 0)
+
+        # then with the transformation
+        fts_worker_method.transformation_fn.called_once_with(
+            raw_crash=a_raw_crash,
+            raw_dumps=raw_dumps,
+            processed_crash=a_processed_crash,
+        )
+
+        # and then with the save_store
+        eq_(fts_worker_method.save_store.save_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.save_raw_crash_with_file_dumps.call_count, 0)
+        fts_worker_method.save_store.save_processed.called_once_with(
+            a_processed_crash
+        )
+        fts_worker_method.save_store.save_raw_and_processed.called_once_with(
+            a_raw_crash,
+            raw_dumps,
+            a_processed_crash,
+            an_id
+        )
+        eq_(fts_worker_method.save_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(fts_worker_method.save_store.get_unredacted_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.remove.call_count, 0)
+
+    #--------------------------------------------------------------------------
+    def test_ProcessorWorkerMethod_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = ProcessedCrashCopyWorkerMethod(
+            config,
+            fetch_store=Mock(),
+            save_store=Mock(),
+            transform_fn=Mock(),
+            quit_check=Mock(),
+        )
+        fts_worker_method.fetch_store.get_raw_crash.return_value = a_raw_crash
+        fts_worker_method.fetch_store.get_raw_dumps.return_value = raw_dumps
+        fts_worker_method.fetch_store.get_unredacted_processed.return_value = \
+            a_processed_crash
+
+        # the call to be tested
+        fts_worker_method(an_id)
+
+        # this is what should have happened:
+        # first with the fetch_store
+        eq_(fts_worker_method.fetch_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.save_raw_and_processed.call_count, 0)
+        fts_worker_method.fetch_store.get_raw_crash.called_once_with(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps.called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_raw_dumps_as_files.call_count, 0)
+        fts_worker_method.fetch_store.get_unredacted_processed \
+            .called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.remove.call_count, 0)
+
+        # then with the transformation
+        fts_worker_method.transformation_fn.called_once_with(
+            raw_crash=a_raw_crash,
+            raw_dumps=raw_dumps,
+            processed_crash=a_processed_crash,
+        )
+
+        # and then with the save_store
+        eq_(fts_worker_method.save_store.save_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.save_raw_crash_with_file_dumps.call_count, 0)
+        fts_worker_method.save_store.save_processed.called_once_with(
+            a_processed_crash
+        )
+        fts_worker_method.save_store.save_raw_and_processed.called_once_with(
+            a_raw_crash,
+            None,
+            a_processed_crash,
+            an_id
+        )
+        eq_(fts_worker_method.save_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(fts_worker_method.save_store.get_unredacted_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.remove.call_count, 0)
+
+
+    #--------------------------------------------------------------------------
+    def test_ProcessorWorkerMethod_no_preexisting_processed_all_Mocked(self):
+        config = self.get_config()
+        fts_worker_method = ProcessedCrashCopyWorkerMethod(
+            config,
+            fetch_store=Mock(),
+            save_store=Mock(),
+            transform_fn=Mock(),
+            quit_check=Mock(),
+        )
+        fts_worker_method.fetch_store.get_raw_crash.return_value = a_raw_crash
+        fts_worker_method.fetch_store.get_raw_dumps.return_value = raw_dumps
+        fts_worker_method.fetch_store.get_unredacted_processed.side_effect = \
+            RejectJob('nope')
+
+        # the call to be tested
+        fts_worker_method(an_id)
+
+        # this is what should have happened:
+        # first with the fetch_store
+        eq_(fts_worker_method.fetch_store.save_raw_crash.call_count, 0)
+        eq_(
+            fts_worker_method.fetch_store.save_raw_crash_with_file_dumps
+                .call_count,
+            0
+        )
+        eq_(fts_worker_method.fetch_store.save_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.save_raw_and_processed.call_count, 0)
+        fts_worker_method.fetch_store.get_raw_crash.called_once_with(an_id)
+        fts_worker_method.fetch_store.get_raw_dumps.called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_raw_dumps_as_files.call_count, 0)
+        fts_worker_method.fetch_store.get_unredacted_processed \
+            .called_once_with(an_id)
+        eq_(fts_worker_method.fetch_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.fetch_store.remove.call_count, 0)
+
+        # then with the transformation
+        fts_worker_method.transformation_fn.called_once_with(
+            raw_crash=a_raw_crash,
+            raw_dumps=raw_dumps,
+            processed_crash=SocorroDotDict(),
+        )
+
+        # and then with the save_store
+        eq_(fts_worker_method.save_store.save_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.save_raw_crash_with_file_dumps.call_count, 0)
+        fts_worker_method.save_store.save_processed.called_once_with(
+            a_processed_crash
+        )
+        fts_worker_method.save_store.save_raw_and_processed.called_once_with(
+            a_raw_crash,
+            None,
+            a_processed_crash,
+            an_id
+        )
+        eq_(fts_worker_method.save_store.get_raw_crash.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dump.call_count, 0)
+        eq_(fts_worker_method.save_store.get_raw_dumps_as_files.call_count, 0)
+        eq_(fts_worker_method.save_store.get_unredacted_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.get_processed.call_count, 0)
+        eq_(fts_worker_method.save_store.remove.call_count, 0)
+
+


### PR DESCRIPTION
Each of the FTS has had to define its own transformation method.  This is the method that is run by the workers to transform a raw_crash into a processed crash.  At least, that's what the transform method does in the Processor.  In the crashmover, the transform method just moves raw crashes and dumps from one crashstore to another.  The submitter is very similar to the crashmover, but its transform copies rather than deletes.  The seldom used processed crash copier has a transform method that duplicates just the processed crashes from one storage system to another.  

Rather than have this mash up of each type of app defining its own transform and then duplicating code sections, move all these transforms into their own class hierarchy.  Any app can then just select a goal like "move raw crashes", "copy all crashes", or even copy/move things other than crashes.  

At the same time, disambiguate the word transform, because as it stands right now, it refers to two things: 
    1) the method run by the worker that includes all the steps of FTS.
    2) the T in FTS, how a crash is changed from one form to another.

From now on the former "transform methods" should be referred to as "FTS worker methods".  This leaves the word "transform" as referring only to the T of FTS: the act of 
converting one thing into another.

That gives the apps the ability to define the actual transform, the T, between the fetch and the save of FTS.  Separating these methods makes it simpler to mix and match the components.  It also then sets the stage for creating special purpose processors, copiers, movers, etc.  In a future step, we can get rid of the special apps like processor, submitter, mover as they can be composed from components and the base FTS app can run them.  

The processor consists of:
   1) the iteration system that consumes infinitely
   2) the FTS worker method that both fetches and saves raw_crashes, dumps & processed crashes
   3) a transformation method that applies the rule processing system.

The submitter consists of:
   1) a user selectable iteration system that can work either finitely or infinitely.
   2) an FTS worker method that only reads raw_crashes and dumps
   3) a transformation that doesn't change anything

The crashmover is just like the submitter, except in only allows the infinite iterator

This is opening the door to special purpose FTS apps such as a copier that can read from a PG query and write to the RabbitMQ reprocessing queue.  Another special purpose app came about when a release was made with the wrong channel.  We hand coded a processor that copied and fixed just the affected crashes.  How about a submitter that filters out PII before sending a crash on to a special purpose processor?  Sure thing!  This new system will allow that sort of change without having to add new code.