### PR TITLE
fixes bug 1207638 - All .html templates to use 4 spaces for indentation

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
@@ -1,157 +1,156 @@
 {% extends "crashstats_base.html" %}
+
 {% block site_css %}
-  {{ super() }}
-  {% compress css %}
-      <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-      <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-      <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-      <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
-      <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
-  {% endcompress %}
-  {% compress css %}
-      <link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/daily.less') }}">
-  {% endcompress %}
+{{ super() }}
+{% compress css %}
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
+{% endcompress %}
+{% compress css %}
+<link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/daily.less') }}">
+{% endcompress %}
 {% endblock %}
 
-{% block page_title %}
-Crashes per Active Daily Install for {{ product }}
-{% endblock %}
+{% block page_title %}Crashes per Active Daily Install for {{ product }}{% endblock %}
 
 {% block content %}
 <div id="mainbody">
 
-<div class="page-heading">
-    <p class="old-new-report-link">
-        <a href="{{ new_daily_report_url }}">View the <b>new</b> <i>Crashes per user</i> report</a>
-    </p>
-    <h2>Crashes per Active Daily Install</h2>
-</div>
-
-
-<div class="panel daily_search">
-    <div class="title daily_search_title">
-        <h2>Options</h2>
+    <div class="page-heading">
+        <p class="old-new-report-link">
+            <a href="{{ new_daily_report_url }}">View the <b>new</b> <i>Crashes per user</i> report</a>
+        </p>
+        <h2>Crashes per Active Daily Install</h2>
     </div>
 
-    <div class="body daily_search_body">
-        <div id="daily_search">
-        <div id="daily_search_version">
-            <p>All ADI ratios are generated per 100 ADIs, not per single ADI. "3.5 crashes/ADI" means that there are 3.5 crashes per 100 installations, not per installation. This ratio also does not distinguish between installs who crash multiple times and multiple crashing installs.</p>
-            <form id="daily_search_version_form" name="daily_search_version_form" action="{{ url('crashstats:daily') }}">
 
-                <table class="by_version">
-                    <tr>
-                        <th>Product</th>
-                        <td>
-                          <label class="visually-hidden" for="daily_search_version_form_products">Select Product</label>
-                        <select id="daily_search_version_form_products" name="p">
-                          {% for product_name in releases %}
-                            <option value="{{ product_name }}" {% if product == product_name %}selected{% endif %}>{{ product_name }}</option>
+    <div class="panel daily_search">
+        <div class="title daily_search_title">
+            <h2>Options</h2>
+        </div>
+
+        <div class="body daily_search_body">
+            <div id="daily_search">
+                <div id="daily_search_version">
+                    <p>All ADI ratios are generated per 100 ADIs, not per single ADI. "3.5 crashes/ADI" means that there are 3.5 crashes per 100 installations, not per installation. This ratio also does not distinguish between installs who crash multiple
+                        times and multiple crashing installs.</p>
+                    <form id="daily_search_version_form" name="daily_search_version_form" action="{{ url('crashstats:daily') }}">
+
+                        <table class="by_version">
+                            <tr>
+                                <th>Product</th>
+                                <td>
+                                    <label class="visually-hidden" for="daily_search_version_form_products">Select Product</label>
+                                    <select id="daily_search_version_form_products" name="p">
+                                        {% for product_name in releases %}
+                                        <option value="{{ product_name }}" {% if product == product_name %}selected{% endif %}>{{ product_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </td>
+                            </tr>
+
+                            {% for i in range(4)|reverse %}
+                            <tr>
+                                {% if loop.first %}
+                                <th rowspan="4">Versions</th>
+                                {% endif %}
+
+                                <td>
+                                    <label class="visually-hidden" for="version{{ i }}">Select Version</label>
+                                    <select id="version{{ i }}" name="v">
+                                        <option value="">-- versions --</option>
+                                        {% for version in available_versions %}
+                                        <option value="{{ version }}" {% if version == versions[i] %} selected {% endif %}>{{ version }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </td>
+                            </tr>
                             {% endfor %}
-                        </select>
-                        </td>
-                    </tr>
 
-                    {% for i in range(4)|reverse %}
-                    <tr>
-                        {% if loop.first %}
-                        <th rowspan="4">Versions</th>
-                        {% endif %}
+                            <tr>
+                                <th>Type</th>
+                                <td>
+                                    <fieldset>
+                                        <legend class="visually-hidden">Hang Types</legend>
+                                        <span class="radio-item">
+                                            <label for="hang_type_any">
+                                                <input type="radio" id="hang_type_any" name="hang_type" value="any" {% if hang_type=='any' %} checked="checked" {% endif %} /> Any
+                                            </label>
+                                        </span>
 
-                        <td>
-                          <label class="visually-hidden" for="version{{ i }}">Select Version</label>
-                            <select id="version{{ i }}" name="v">
-                                <option value="">-- versions --</option>
-                                {% for version in available_versions %}
-                                  <option value="{{ version }}" {% if version == versions[i] %} selected {% endif %}>{{ version }}</option>
-                                {% endfor  %}
-                            </select>
-                        </td>
-                    </tr>
-                    {% endfor %}
+                                        <span class="radio-item">
+                                            <label for="hang_type_crash">
+                                                <input type="radio" id="hang_type_crash" name="hang_type" value="crash" {% if hang_type=='crash' %} checked="checked" {% endif %} /> Crash
+                                            </label>
+                                        </span>
 
-                    <tr>
-                        <th>Type</th>
-                        <td>
-                          <fieldset>
-                            <legend class="visually-hidden">Hang Types</legend>
-                            <span class="radio-item">
-                              <label for="hang_type_any">
-                                <input type="radio" id="hang_type_any" name="hang_type" value="any" {% if hang_type == 'any' %} checked="checked" {% endif %} /> Any
-                              </label>
-                            </span>
+                                        <span class="radio-item">
+                                            <label for="hang_type_hang-p">
+                                                <input type="radio" id="hang_type_hang-p" name="hang_type" value="hang-p" {% if hang_type=='hang-p' %} checked="checked" {% endif %} /> Plugin Hang
+                                            </label>
+                                        </span>
+                                    </fieldset>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>O/S</th>
+                                <td>
+                                    <fieldset>
+                                        <legend class="visually-hidden">Operating Systems</legend>
+                                        <label for="os_Windows_check">
+                                            <input id="os_Windows_check" type="checkbox" name="os" value="Windows" {% if 'Windows' in os_names %} checked="checked" {% endif %}/> Windows
+                                        </label>
 
-                            <span class="radio-item">
-                              <label for="hang_type_crash">
-                                <input type="radio" id="hang_type_crash" name="hang_type" value="crash" {% if hang_type == 'crash' %} checked="checked" {% endif %} /> Crash
-                              </label>
-                            </span>
+                                        <label for="os_Mac_check">
+                                            <input id="os_Mac_check" type="checkbox" name="os" value="Mac OS X" {% if 'Mac OS X' in os_names %} checked="checked" {% endif %}/> Mac OS X
+                                        </label>
 
-                            <span class="radio-item">
-                              <label for="hang_type_hang-p">
-                                <input type="radio" id="hang_type_hang-p" name="hang_type" value="hang-p" {% if hang_type == 'hang-p' %} checked="checked" {% endif %} /> Plugin Hang
-                              </label>
-                            </span>
-                          </fieldset>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>O/S</th>
-                        <td>
-                          <fieldset>
-                            <legend class="visually-hidden">Operating Systems</legend>
-                            <label for="os_Windows_check">
-                              <input id="os_Windows_check" type="checkbox" name="os" value="Windows" {% if 'Windows' in os_names %} checked="checked" {% endif %}/> Windows
-                            </label>
+                                        <label for="os_Linux_check">
+                                            <input id="os_Linux_check" type="checkbox" name="os" value="Linux" {% if 'Linux' in os_names %} checked="checked" {% endif %}/> Linux
+                                        </label>
+                                    </fieldset>
+                                </td>
+                            </tr>
 
-                            <label for="os_Mac_check">
-                              <input id="os_Mac_check" type="checkbox" name="os" value="Mac OS X" {% if 'Mac OS X' in os_names %} checked="checked" {% endif %}/> Mac OS X
-                            </label>
+                            <tr>
+                                <th>Date Range</th>
+                                <td>
+                                    <fieldset>
+                                        <legend class="visually-hidden">Date Range Type</legend>
+                                        <span class="radio-item">
+                                            <label for="by_build">
+                                                <input type="radio" name="date_range_type" id="by_build" value="build" {% if date_range_type=='build' %} checked="checked" {% endif %}/> Build Date
+                                            </label>
+                                        </span>
+                                        <span class="radio-item">
+                                            <label for="crash">
+                                                <input type="radio" name="date_range_type" id="crash" value="report" {% if date_range_type=='report' %} checked="checked" {% endif %}/> Crash Date
+                                            </label>
+                                        </span>
+                                    </fieldset>
+                                </td>
+                            </tr>
 
-                            <label for="os_Linux_check">
-                              <input id="os_Linux_check" type="checkbox" name="os" value="Linux" {% if 'Linux' in os_names %} checked="checked" {% endif %}/> Linux
-                            </label>
-                          </fieldset>
-                        </td>
-                    </tr>
+                            <tr class="datepicker-daily">
+                                <th>When</th>
+                                <td>
+                                    <label class="visually-hidden" for="when_date_start">Start Date</label>
+                                    <input class="date" id="when_date_start" type="text" name="date_start" value="{{ start_date }}" /> &nbsp; to &nbsp;
+                                    <label class="visually-hidden" for="when_date_end">End Date</label>
+                                    <input class="date" id="when_date_end" type="text" name="date_end" value="{{ end_date }}" />
+                                </td>
+                            </tr>
+                        </table>
 
-                    <tr>
-                        <th>Date Range</th>
-                        <td>
-                          <fieldset>
-                              <legend class="visually-hidden">Date Range Type</legend>
-                              <span class="radio-item">
-                                  <label for="by_build">
-                                      <input type="radio" name="date_range_type" id="by_build" value="build" {% if date_range_type == 'build' %} checked="checked" {% endif %}/> Build Date
-                                  </label>
-                              </span>
-                              <span class="radio-item">
-                                  <label for="crash">
-                                      <input type="radio" name="date_range_type" id="crash" value="report" {% if date_range_type == 'report' %} checked="checked" {% endif %}/> Crash Date
-                                  </label>
-                              </span>
-                            </fieldset>
-                          </td>
-                    </tr>
-
-                    <tr class="datepicker-daily">
-                        <th>When</th>
-                        <td>
-                          <label class="visually-hidden" for="when_date_start">Start Date</label>
-                          <input class="date" id="when_date_start" type="text" name="date_start" value="{{ start_date }}" />
-                          &nbsp; to &nbsp;
-                          <label class="visually-hidden" for="when_date_end">End Date</label>
-                          <input class="date" id="when_date_end" type="text" name="date_end" value="{{ end_date }}" />
-                        </td>
-                    </tr>
-                </table>
-
-                <input id="daily_search_version_form_submit" type="submit" name="submit" value="Generate">
-            </form>
-        </div>
+                        <input id="daily_search_version_form_submit" type="submit" name="submit" value="Generate">
+                    </form>
+                </div>
+            </div>
         </div>
     </div>
-</div>
 
     <div class="panel daily_graph">
         <div class="title">
@@ -159,10 +158,10 @@ Crashes per Active Daily Install for {{ product }}
         </div>
 
         <div class="body">
-                <div id="crashes-per-adi-graph"></div>
-                <div id="crashes-per-adi-legend" class="crashes-per-adi-legend"></div>
+            <div id="crashes-per-adi-graph"></div>
+            <div id="crashes-per-adi-legend" class="crashes-per-adi-legend"></div>
             <p class="adu-chart-help">This graph uses an approximate <a href="https://wiki.mozilla.org/Socorro/SocorroUI/Branches_Admin#Throttle">throttle value</a> for each version, which may not be completely accurate for the entire time period.</p>
-            </div>
+        </div>
     </div>
 
 
@@ -183,79 +182,70 @@ Crashes per Active Daily Install for {{ product }}
         </div>
 
         <div class="body">
-          {% if data_table.totals %}
+            {% if data_table.totals %}
             <table id="crash_data" class="data-table crash_data zebra">
                 <tr>
                     <th class="date" rowspan="2">Date</th>
-                  {% for version in versions %}
+                    {% for version in versions %}
                     <th class="version" colspan="4">{{ version }}</th>
-                  {% endfor %}
+                    {% endfor %}
                 </tr>
                 <tr>
-                  {% for version in versions %}
+                    {% for version in versions %}
                     <th class="stat">Crashes</th>
                     <th class="stat">ADI</th>
                     <th class="stat" title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">Throttle</th>
                     <th class="stat">Ratio</th>
-                  {% endfor %}
+                    {% endfor %}
                 </tr>
                 {% for crash_date in dates %}
                 <tr>
-                  <td>{{ crash_date }}</td>
-                    {% if crash_date in data_table.dates %}
-                      {% for version in versions %}
-                        {% set foundversion = [] %}
-                        {% for crash_info in data_table.dates[crash_date] %}
-                          {% if crash_info.version == version %}
-                      <td>{{ crash_info.report_count | digitgroupseparator }}</td>
-                      <td>{{ crash_info.adu | digitgroupseparator }}</td>
-                      <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling."
-                      >{% if crash_info.throttle %}{{ crash_info.throttle * 100 }}%{% else %}-{% endif %}</td>
-                      <td>{{ crash_info.crash_hadu }}</td>
-                            {% do foundversion.append(1) %}
-                          {% endif %}
-                        {% endfor %}
-                        {% if not foundversion %}
-                      <td>-</td>
-                      <td>-</td>
-                      <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">-</td>
-                      <td>-</td>
-                        {% endif %}
-                      {% endfor %}
-                    {% else %}
-                      {% for version in versions %}
-                      <td>-</td>
-                      <td>-</td>
-                      <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">-</td>
-                      <td>-</td>
-                      {% endfor %}
-                    {% endif %}
+                    <td>{{ crash_date }}</td>
+                    {% if crash_date in data_table.dates %} {% for version in versions %} {% set foundversion = [] %} {% for crash_info in data_table.dates[crash_date] %} {% if crash_info.version == version %}
+                    <td>{{ crash_info.report_count | digitgroupseparator }}</td>
+                    <td>{{ crash_info.adu | digitgroupseparator }}</td>
+                    <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">{% if crash_info.throttle %}{{ crash_info.throttle * 100 }}%{% else %}-{% endif %}</td>
+                    <td>{{ crash_info.crash_hadu }}</td>
+                    {% do foundversion.append(1) %} {% endif %} {% endfor %} {% if not foundversion %}
+                    <td>-</td>
+                    <td>-</td>
+                    <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">-</td>
+                    <td>-</td>
+                    {% endif %} {% endfor %} {% else %} {% for version in versions %}
+                    <td>-</td>
+                    <td>-</td>
+                    <td title="The throttle rate is the effective throttle rate - the combined throttle rate for client-side throttling and server-side throttling.">-</td>
+                    <td>-</td>
+                    {% endfor %} {% endif %}
                 </tr>
                 {% endfor %}
             </table>
-          {% else %}
-          <p>
-            No data is available for this query.
-          </p>
-          {% endif %}
+            {% else %}
+            <p>
+                No data is available for this query.
+            </p>
+            {% endif %}
         </div>
     </div>
 </div>
 {% endblock %}
+
 {% block site_js %}
-  {{ super() }}
-
-  {% compress js %}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-  {% endcompress %}
-
-  {% compress js %}
-  <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-  <script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/daily.js') }}"></script>
-  {% endcompress %}
-  <script>
-    var data = {{ graph_data | json_dumps }};
+{{ super() }}
+{% compress js %}
+<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
+{% endcompress %}
+{% compress js %}
+<script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
+<script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
+<script src="{{ static('crashstats/js/socorro/daily.js') }}"></script>
+{% endcompress %}
+<script>
+    var data = {
+        {
+            graph_data | json_dumps
+        }
+    };
     window.socGraphByReportType = false;
-  </script>
+</script>
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index_not_found.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index_not_found.html
@@ -1,19 +1,20 @@
 {% extends "crashstats_base.html" %}
 
 {% block content %}
-
-  <div id="mainbody">
+<div id="mainbody">
     <div class="page-heading">
-      <h2>Crash Not Found</h2>
+        <h2>Crash Not Found</h2>
     </div>
     <div class="panel">
-      <div class="body">
-        <p>We couldn't find the OOID you're after. If you recently submitted this crash, it may still be in the queue.</p>
+        <div class="body">
+            <p>We couldn't find the OOID you're after. If you recently submitted this crash, it may still be in the queue.</p>
 
-        <p>If you believe this message is an error, please
-        submit a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&amp;component=General&amp;bug_file_loc={{ request.build_absolute_uri() }}">Bugzilla ticket</a> describing what happened, and please include the URL for this page.</p>
-      </div>
+            <p>
+                If you believe this message is an error, please submit a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&amp;component=General&amp;bug_file_loc={{ request.build_absolute_uri() }}">Bugzilla ticket</a> describing what happened,
+                and please include the URL for this page.
+            </p>
+        </div>
     </div>
-  </div>
+</div>
 
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index_pending.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index_pending.html
@@ -1,29 +1,32 @@
 {% extends "crashstats_base.html" %}
 
 {% block content %}
-
-  <div id="mainbody">
+<div id="mainbody">
     <div id="checking" class="pendingStatus">
-      <form><input type="hidden" id="count" name="count" value="0" /></form>
-      <h3>Please Wait...</h3>
-      <p>Fetching this archived report will take 30 seconds to 5 minutes</p>
-      <img src="{{ static('img/ajax-loader.gif') }}">
-      <p id="next_attempt">Next attempt in <span id="counter" name="counter">30</span> seconds...</p>
-      <p id="processing" class="pendingProcessing" style="display:none">Querying for archived report...</p>
+        <form>
+            <input type="hidden" id="count" name="count" value="0" />
+        </form>
+        <h3>Please Wait...</h3>
+        <p>Fetching this archived report will take 30 seconds to 5 minutes</p>
+        <img src="{{ static('img/ajax-loader.gif') }}">
+        <p id="next_attempt">Next attempt in
+            <span id="counter" name="counter">30</span> seconds...</p>
+        <p id="processing" class="pendingProcessing" style="display:none">Querying for archived report...</p>
     </div>
 
     <div id="fail" class="pendingStatus" style="display:none;">
-      <h3>Oh Noes!</h3>
-      <p>This archived report could not be located.</p>
+        <h3>Oh Noes!</h3>
+        <p>This archived report could not be located.</p>
     </div>
 
-  </div>
+</div>
 
 {% endblock %}
+
 {% block site_js %}
-  {{ super() }}
-  <script type="text/javascript" src="{{ static('crashstats/js/socorro/pending.js') }}"></script>
-  <script type="text/javascript">
-   document.onload = pendingReportTimer("{{ url('crashstats:report_pending', crash_id) }}");
-  </script>
+{{ super() }}
+<script type="text/javascript" src="{{ static('crashstats/js/socorro/pending.js') }}"></script>
+<script type="text/javascript">
+    document.onload = pendingReportTimer("{{ url('crashstats:report_pending', crash_id) }}");
+</script>
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index_too_old.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index_too_old.html
@@ -1,12 +1,10 @@
 {% extends "crashstats_base.html" %}
 
 {% block content %}
-
-  <div id="mainbody">
+<div id="mainbody">
     <div id="fail" class="pendingStatus">
-      <h3>Oh Noes!</h3>
-      <p>This archived report has expired because it is greater than 3 years of age.</p>
+        <h3>Oh Noes!</h3>
+        <p>This archived report has expired because it is greater than 3 years of age.</p>
     </div>
-  </div>
-
+</div>
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_list.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_list.html
@@ -1,180 +1,193 @@
 {% extends "crashstats/report_list_base.html" %}
 
 {% block site_css %}
-  {{ super() }}
-
-  {% compress css %}
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-  {% endcompress %}
-
-  {% compress css %}
-  <link media="screen" href="{{ static('crashstats/css/report_list.less') }}" type="text/less" rel="stylesheet" />
-  <link media="screen" href="{{ static('crashstats/css/accordion.less') }}" type="text/less" rel="stylesheet" />
-  {% endcompress %}
+{{ super() }}
+{% compress css %}
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
+<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
+{% endcompress %}
+{% compress css %}
+<link media="screen" href="{{ static('crashstats/css/report_list.less') }}" type="text/less" rel="stylesheet" />
+<link media="screen" href="{{ static('crashstats/css/accordion.less') }}" type="text/less" rel="stylesheet" />
+{% endcompress %}
 {% endblock %}
-
 
 {% block report %}
 <div id="report-list" class="no-border ui-tabs ui-widget ui-widget-content ui-corner-all">
     <ul id="report-list-nav" class="ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all">
-        <li class="ui-state-default ui-corner-top"><a href="#sigsummary" class="ui-tabs-anchor"><span>Signature Summary</span></a></li>
-        <li class="ui-state-default ui-corner-top"><a href="#graph" class="ui-tabs-anchor"><span>Graph</span></a></li>
-        <li class="ui-state-default ui-corner-top"><a href="#table" class="ui-tabs-anchor"><span>Table</span></a></li>
-        <li class="ui-state-default ui-corner-top"><a href="#reports" class="ui-tabs-anchor"><span>Reports</span></a></li>
-        <li class="ui-state-default ui-corner-top"><a href="#bugzilla" class="ui-tabs-anchor"><span>Bugzilla</span></a></li>
-        <li class="ui-state-default ui-corner-top"><a href="#comments" class="ui-tabs-anchor"><span>Comments</span></a></li>
-        <li class="ui-state-default ui-corner-top"><a id="correlations-report-list" href="#correlations" class="ui-tabs-anchor"><span>Correlations</span></a></li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#sigsummary" class="ui-tabs-anchor">
+                <span>Signature Summary</span>
+            </a>
+        </li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#graph" class="ui-tabs-anchor">
+                <span>Graph</span>
+            </a>
+        </li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#table" class="ui-tabs-anchor">
+                <span>Table</span>
+            </a>
+        </li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#reports" class="ui-tabs-anchor">
+                <span>Reports</span>
+            </a>
+        </li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#bugzilla" class="ui-tabs-anchor">
+                <span>Bugzilla</span>
+            </a>
+        </li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#comments" class="ui-tabs-anchor">
+                <span>Comments</span>
+            </a>
+        </li>
+        <li class="ui-state-default ui-corner-top">
+            <a id="correlations-report-list" href="#correlations" class="ui-tabs-anchor">
+                <span>Correlations</span>
+            </a>
+        </li>
         {% if request.user.has_perm('crashstats.view_pii') %}
-        <li class="ui-state-default ui-corner-top"><a href="#sigurls" class="ui-tabs-anchor"><span>URLs</span></a></li>
+        <li class="ui-state-default ui-corner-top">
+            <a href="#sigurls" class="ui-tabs-anchor">
+                <span>URLs</span>
+            </a>
+        </li>
         {% endif %}
     </ul>
 
     <div id="sigsummary" data-url="{{ url('crashstats:signature_summary') }}?range_value={{ current_day }}&amp;range_unit=days&amp;signature={{ signature|urlencode }}{% for product_version in product_versions %}&amp;version={{ product_version }}{% endfor %}&amp;date={{ end_date | urlencode }}">
 
-       <p class="loading-placeholder">
-         <img src="{{ static('img/loading.png') }}" alt="Loading">
-         Loading signature summary...
-       </p>
-
-       <p class="loading-failed">
-         Unable to load signature summary. Please try again later.
-       </p>
-
-      <div class="inner">
-      {# the signature_summary.html doesn't contain any generated data so no point in loading it as a partial #}
-      {% include "crashstats/signature_summary.html" %}
-      </div>
-
-    </div>
-
-    <div id="graph" class="ui-tabs-hide"
-         data-partial-url="{{ url('crashstats:report_list_partial', 'graph') }}"
-         data-jsonurl="{{ url('crashstats:adu_by_signature_json') }}"
-         data-signature="{{ signature }}"
-         data-product="{{ product }}">
-
-      <p class="loading-placeholder">
-        <img src="{{ static('img/loading.png') }}" alt="Loading">
-        Loading content...
-      </p>
-
-       <p class="loading-failed">
-         Unable to load graph data. Please try again later.
-       </p>
-
-       <div class="inner"></div>
-
-    </div>
-
-    <div id="table" class="ui-tabs-hide"
-         data-partial-url="{{ url('crashstats:report_list_partial', 'table') }}">
-
-       <p class="loading-placeholder">
-         <img src="{{ static('img/loading.png') }}" alt="Loading">
-         Loading build table...
-       </p>
-       <p class="loading-failed">
-         Unable to load build table. Please try again later.
-       </p>
-
-       <div class="inner"></div>
-
-    </div>
-
-    <div id="reports" class="ui-tabs-hide"
-         data-partial-url="{{ url('crashstats:report_list_partial', 'reports') }}">
-
-       <p class="loading-placeholder">
-         <img src="{{ static('img/loading.png') }}" alt="Loading">
-         Loading reports...
-       </p>
-       <p class="loading-failed">
-         Unable to load reports. Please try again later.
-       </p>
-
-       {% include "crashstats/reports_columns_form_hint.html" %}
-
-       <div class="inner"></div>
-
-       {% include "crashstats/reports_columns_form.html" %}
-
-    </div><!-- /reports -->
-
-    <div id="bugzilla" class="ui-tabs-hide"
-         data-partial-url="{{ url('crashstats:report_list_partial', 'bugzilla') }}">
-
-       <p class="loading-placeholder">
-         <img src="{{ static('img/loading.png') }}" alt="Loading">
-         Loading bugs...
-       </p>
-       <p class="loading-failed">
-         Unable to load bugs. Please try again later.
-       </p>
-
-       <div class="inner"></div>
-
-    </div><!-- /bugzilla -->
-
-    <div id="comments" class="ui-tabs-hide"
-          data-partial-url="{{ url('crashstats:report_list_partial', 'comments') }}">
-
-       <p class="loading-placeholder">
-         <img src="{{ static('img/loading.png') }}" alt="Loading">
-         Loading comments...
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading signature summary...
         </p>
 
-       <div class="inner"></div>
+        <p class="loading-failed">
+            Unable to load signature summary. Please try again later.
+        </p>
+
+        <div class="inner">
+            {# the signature_summary.html doesn't contain any generated data so no point in loading it as a partial #} {% include "crashstats/signature_summary.html" %}
+        </div>
 
     </div>
 
-    <div id="correlations" class="ui-tabs-hide"
-         data-partial-url="{{ url('crashstats:report_list_partial', 'correlations') }}">
+    <div id="graph" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'graph') }}" data-jsonurl="{{ url('crashstats:adu_by_signature_json') }}" data-signature="{{ signature }}" data-product="{{ product }}">
 
-      <p class="loading-placeholder">
-        <img src="{{ static('img/loading.png') }}" alt="Loading">
-        Loading correlations...
-      </p>
-      <p class="loading-failed">
-        Unable to load correlations. Please try again later.
-      </p>
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading content...
+        </p>
 
-      <div class="inner"></div>
+        <p class="loading-failed">
+            Unable to load graph data. Please try again later.
+        </p>
 
-    </div><!-- /correlation -->
+        <div class="inner"></div>
+
+    </div>
+
+    <div id="table" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'table') }}">
+
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading build table...
+        </p>
+        <p class="loading-failed">
+            Unable to load build table. Please try again later.
+        </p>
+
+        <div class="inner"></div>
+
+    </div>
+
+    <div id="reports" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'reports') }}">
+
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading reports...
+        </p>
+        <p class="loading-failed">
+            Unable to load reports. Please try again later.
+        </p>
+
+        {% include "crashstats/reports_columns_form_hint.html" %}
+
+        <div class="inner"></div>
+
+        {% include "crashstats/reports_columns_form.html" %}
+
+    </div>
+    <!-- /reports -->
+
+    <div id="bugzilla" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'bugzilla') }}">
+
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading bugs...
+        </p>
+        <p class="loading-failed">
+            Unable to load bugs. Please try again later.
+        </p>
+
+        <div class="inner"></div>
+
+    </div>
+    <!-- /bugzilla -->
+
+    <div id="comments" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'comments') }}">
+
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading comments...
+        </p>
+
+        <div class="inner"></div>
+
+    </div>
+
+    <div id="correlations" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'correlations') }}">
+
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading correlations...
+        </p>
+        <p class="loading-failed">
+            Unable to load correlations. Please try again later.
+        </p>
+
+        <div class="inner"></div>
+
+    </div>
+    <!-- /correlation -->
 
     {% if request.user.has_perm('crashstats.view_pii') %}
-    <div id="sigurls" class="ui-tabs-hide"
-         data-partial-url="{{ url('crashstats:report_list_partial', 'sigurls') }}">
+    <div id="sigurls" class="ui-tabs-hide" data-partial-url="{{ url('crashstats:report_list_partial', 'sigurls') }}">
 
-      <p class="loading-placeholder">
-        <img src="{{ static('img/loading.png') }}" alt="Loading">
-	Loading signature URLs...
-      </p>
-      <p class="loading-failed">
-        Unable to load signature URLs. Please try again later.
-      </p>
+        <p class="loading-placeholder">
+            <img src="{{ static('img/loading.png') }}" alt="Loading"> Loading signature URLs...
+        </p>
+        <p class="loading-failed">
+            Unable to load signature URLs. Please try again later.
+        </p>
 
-      <div class="inner"></div>
+        <div class="inner"></div>
 
-    </div><!-- /sigurls -->
+    </div>
+    <!-- /sigurls -->
     {% endif %}
 
 </div>
 
 {% endblock %}
 
+
 {% block site_js %}
 {{ super() }}
-
 <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
 
 {% compress js %}
 <script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
 <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
 {% endcompress %}
-
 {% compress js %}
 <script type="text/javascript" src="{{ static('crashstats/js/jquery/plugins/jquery.cookie.js') }}"></script>
 <script type="text/javascript" src="{{ static('crashstats/js/socorro/correlation.js') }}"></script>
@@ -194,11 +207,11 @@
 {% endcompress %}
 
 <script type="text/javascript">
-var SocReport = {
-    base: '{{ url('crashstats:correlations_json') }}',
-    product: '{{ product }}',
-    signature: '{{ signature|urlencode }}'
-};
+    var SocReport = {
+        base: '{{ url('crashstats:correlations_json') }}',
+        product: '{{ product }}',
+        signature: '{{ signature|urlencode }}'
+    };
 </script>
 
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/reports_columns_form.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/reports_columns_form.html
@@ -1,32 +1,32 @@
-     <form action="" class="visually-hidden" id="reports-form">
-       <table>
-         <tr>
-           <th>Available columns</th>
-           <th>&nbsp;</th>
-           <th>Chosen columns</th>
-         </tr>
-         <tr>
-           <td>
-             <select name="available" size="12" multiple>
-               {% for column in all_reports_columns %}
-               <option value="{{ column.value }}">{{ column.label }}</option>
-               {% endfor %}
-             </select>
-           </td>
-           <td>
-             <button name="remove">&laquo;</button>
-             <button name="add">&raquo;</button>
-           </td>
-           <td>
-             <select name="chosen" size="12" multiple>
-             </select>
-           </td>
-         </tr>
-         <tr>
-           <td colspan="3" style="text-align:center">
-             <button name="save" class="disabled">Save and reload</button>
-           </td>
-         </tr>
-       </table>
-       <p>* Fields specifically from the raw crash</p>
-     </form>
+<form action="" class="visually-hidden" id="reports-form">
+    <table>
+        <tr>
+            <th>Available columns</th>
+            <th>&nbsp;</th>
+            <th>Chosen columns</th>
+        </tr>
+        <tr>
+            <td>
+                <select name="available" size="12" multiple>
+                    {% for column in all_reports_columns %}
+                    <option value="{{ column.value }}">{{ column.label }}</option>
+                    {% endfor %}
+                </select>
+            </td>
+            <td>
+                <button name="remove">&laquo;</button>
+                <button name="add">&raquo;</button>
+            </td>
+            <td>
+                <select name="chosen" size="12" multiple>
+                </select>
+            </td>
+        </tr>
+        <tr>
+            <td colspan="3" style="text-align:center">
+                <button name="save" class="disabled">Save and reload</button>
+            </td>
+        </tr>
+    </table>
+    <p>* Fields specifically from the raw crash</p>
+</form>

--- a/webapp-django/crashstats/crashstats/templates/crashstats/reports_columns_form_hint.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/reports_columns_form_hint.html
@@ -1,3 +1,3 @@
 <p class="reports-form-hint visually-hidden">
-  <a href="#reports-form">Change columns in table</a>
+    <a href="#reports-form">Change columns in table</a>
 </p>

--- a/webapp-django/crashstats/crashstats/templates/crashstats/signature_summary.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/signature_summary.html
@@ -1,10 +1,13 @@
 {% if selected_products or product_versions %}
 
-<p>The signature summary report is for {% if selected_products %} {{ product }} {% if product_versions %} with the version being
- one of {{ product_versions|join(', ') }}{% endif %}{% endif %}.
+<p>
+    The signature summary report is for
+    {% if selected_products %} {{ product }} {% if product_versions %}
+    with the version being one of <b>{{ product_versions|join(', ') }}</b>{% endif %}{% endif %}.
 
- <a href="{{ url('crashstats:report_list') }}?signature={{ signature | urlencode }}&amp;range_value={{ current_day }}&amp;range_unit=days&amp;date={{ end_date }}">View ALL products and versions for this signature.</a>
+    <a href="{{ url('crashstats:report_list') }}?signature={{ signature | urlencode }}&amp;range_value={{ current_day }}&amp;range_unit=days&amp;date={{ end_date }}">View ALL products and versions for this signature.</a>
 
+</p>
 {% endif %}
 
 <div class="signature-summary"></div>

--- a/webapp-django/crashstats/crashstats/templates/crashstats/topchangers.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/topchangers.html
@@ -1,57 +1,58 @@
 {% extends "crashstats_base.html" %}
 
-{% block page_title %}
-Top Changing Top Crashers for {{ product }}
-{% endblock %}
+{% block page_title %}Top Changing Top Crashers for {{ product }}{% endblock %}
 
 {% block content %}
 <div id="mainbody">
-  <div class="page-heading">
-    <h2>Top Changers</h2>
-    <ul class="options">
-    {% for day in possible_days %}
-      <li><a href="{{ change_query_string(days=day) }}" {% if days == day %}class="selected"{% endif %}>{{ day }} days</a></li>
-    {% endfor %}
-    </ul>
-  </div>
+    <div class="page-heading">
+        <h2>Top Changers</h2>
+        <ul class="options">
+            {% for day in possible_days %}
+            <li><a href="{{ change_query_string(days=day) }}" {% if days == day %}class="selected" {% endif %}>{{ day }} days</a></li>
+            {% endfor %}
+        </ul>
+    </div>
 
-  <div class="panel">
-    <div class="title">
-      <h2>{{ product }} {{ versions|join(', ') }}</h2>
-    </div>
-    <div class="body">
-        {% if topchangers %}
-        <table class="top_changers data-table tablesorter">
-          <tr>
-            <th scope="col">Change</th>
-            <th scope="col">Rank</th>
-            <th scope="col">Signature</th>
-          </tr>
-          {% for result in topchangers|dictsort|reverse %}
-          {% with changer = result[1][0] %}
-          <tr>
-            {% if changer.changeInRank <= -5 %}
-              <td class="trend down">{{ changer.changeInRank }}</td>
-            {% elif changer.changeInRank >= 5 %}
-              <td class="trend up">{{ changer.changeInRank }}</td>
+    <div class="panel">
+        <div class="title">
+            <h2>{{ product }} {{ versions|join(', ') }}</h2>
+        </div>
+        <div class="body">
+            {% if topchangers %}
+            <table class="top_changers data-table tablesorter">
+                <tr>
+                    <th scope="col">Change</th>
+                    <th scope="col">Rank</th>
+                    <th scope="col">Signature</th>
+                </tr>
+                {% for result in topchangers|dictsort|reverse %}
+                {% with changer = result[1][0] %}
+                <tr>
+                    {% if changer.changeInRank <=- 5 %}
+                    <td class="trend down">{{ changer.changeInRank }}</td>
+                    {% elif changer.changeInRank >= 5 %}
+                    <td class="trend up">{{ changer.changeInRank }}</td>
+                    {% else %}
+                    <td>{{ changer.changeInRank }}</td>
+                    {% endif %}
+                    <td>{{ changer.currentRank + 1 }}</td>
+                    <td>
+                        <a class="signature" href="{{ url('crashstats:report_list') }}?product={{ product }}&amp;range_value={{ days }}&amp;range_unit=days&amp;signature={{ changer.signature|urlencode }}{% for product_version in product_versions %}&amp;version={{ product_version }}{% endfor %}"
+                            title="View reports with this crasher.">{{ changer.signature }}</a>
+                    </td>
+                </tr>
+                {% endwith %}
+                {% endfor %}
+            </table>
             {% else %}
-              <td>{{ changer.changeInRank }}</td>
+            <p>There were no top changers that matched the criteria you specified.</p>
             {% endif %}
-            <td>{{ changer.currentRank + 1 }}</td>
-            <td><a class="signature" href="{{ url('crashstats:report_list') }}?product={{ product }}&amp;range_value={{ days }}&amp;range_unit=days&amp;signature={{ changer.signature|urlencode }}{% for product_version in product_versions %}&amp;version={{ product_version }}{% endfor %}" title="View reports with this crasher.">{{ changer.signature }}</a></td>
-          </tr>
-          {% endwith %}
-          {% endfor %}
-        </table>
-        {% else %}
-          <p>There were no top changers that matched the criteria you specified.</p>
-        {% endif %}
+        </div>
     </div>
-  </div>
 </div>
 {% endblock %}
 
 {% block site_js %}
-  {{ super() }}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
+{{ super() }}
+<script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
@AdrianGaudebert r?

Now, when I run
```
git ls-files | grep '\.html' | xargs python indentations.py | grep -v 4
```
it yields nothing. Meaning, we're done!