### PR TITLE
fixes bug 1216807 - Get rid of funfactory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -133,8 +133,6 @@ django-browserid==0.10.1
 fancy-tag==0.2.0
 # sha256: vsCdiBnI0dPE-Z_55Mb4faMhyrJsYNMdbCvAlYdwGY8
 https://github.com/mozilla/django-session-csrf/archive/f00ad91.zip#egg=django-session-csrf
-# sha256: UvCV-GFHuwtfYjva-VJVLReOu8XqyI2RsvWR09IsO4A
-funfactory==2.3.0
 # sha256: xJWo39CpwdPY7QISG7sotsnTTU2jCqk6fmOcDz17Bjk
 jingo==0.7.1
 # sha256: fjEbGTXZzUaSH2AmQWeicWQX00adBDuSIR7AwpQiKO8

--- a/webapp-django/bin/linting.py
+++ b/webapp-django/bin/linting.py
@@ -25,9 +25,6 @@ import sys
 # Only blanket whole files if you desperately have to
 #
 EXCEPTIONS = (
-    # has a exceptional use of `...import *`
-    'settings/base.py:5:',
-
     # has a well known `...import *` trick that we like
     'settings/__init__.py',
 

--- a/webapp-django/crashstats/base/helpers.py
+++ b/webapp-django/crashstats/base/helpers.py
@@ -4,6 +4,13 @@ import urllib
 import jinja2
 from jingo import register
 
+from django.contrib.staticfiles.storage import staticfiles_storage
+
+
+@register.function
+def static(path):
+    return staticfiles_storage.url(path)
+
 
 @register.function
 @jinja2.contextfunction

--- a/webapp-django/crashstats/base/monkeypatches.py
+++ b/webapp-django/crashstats/base/monkeypatches.py
@@ -1,0 +1,12 @@
+
+
+def patch():
+    import jingo.monkey
+    jingo.monkey.patch()
+
+    import session_csrf
+    session_csrf.monkeypatch()
+
+    import jingo
+    from compressor.contrib.jinja2ext import CompressorExtension
+    jingo.env.add_extension(CompressorExtension)

--- a/webapp-django/crashstats/crashstats/helpers.py
+++ b/webapp-django/crashstats/crashstats/helpers.py
@@ -27,8 +27,6 @@ def truncatechars(str_, max_length):
 @register.filter
 def urlencode(txt):
     """Url encode a path."""
-    # originally taken from funfactory but improved to support non-ascii
-    # Unicode characters
     if isinstance(txt, unicode):
         txt = txt.encode('utf-8')
     return urllib.quote_plus(txt)

--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -33,12 +33,7 @@ DATABASES = {
     }
 }
 
-# see ("https://docs.djangoproject.com/en/1.4/topics/auth/",
-#      "#how-django-stores-passwords")
-# for how django stores passwords,
-# To avoid depending on django_sha2 which requires bcrypt to be installed,
-# we override whatever funfactory sets up.
-# And because this is for running tests, we use the simplest hasher possible.
+# Because this is for running tests, we use the simplest hasher possible.
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -4,12 +4,13 @@ from django.conf import settings
 from django.conf.urls import patterns, include
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
+from .base.monkeypatches import patch
 from .crashstats import urls
 from .supersearch import urls as supersearch_urls
 from .authentication import urls as auth_urls
 from .monitoring import urls as monitoring_urls
 
-from funfactory.monkeypatches import patch
+
 patch()
 
 handler500 = 'crashstats.base.views.handler500'

--- a/webapp-django/manage.py
+++ b/webapp-django/manage.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 import os
-import warnings
+import sys
 
-# Edit this if necessary or override the variable in your environment.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crashstats.settings')
+if __name__ == '__main__':
+    # Note! If you for some reason change that change the wsgi
+    # starting-point script too.
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crashstats.settings')
 
-from funfactory import manage
+    from django.core.management import execute_from_command_line
 
-# re-enable deprecation warnings per https://code.djangoproject.com/ticket/18985
-warnings.simplefilter("default", DeprecationWarning)
-manage.setup_environ(__file__, more_pythonic=True)
-
-if __name__ == "__main__":
-    manage.main()
+    execute_from_command_line(sys.argv)

--- a/webapp-django/wsgi/socorro-crashstats.py
+++ b/webapp-django/wsgi/socorro-crashstats.py
@@ -1,12 +1,6 @@
 import os
-import site
 
-# Add the app dir to the python path so we can import manage.
-wsgidir = os.path.dirname(__file__)
-site.addsitedir(os.path.abspath(os.path.join(wsgidir, '../')))
-
-# manage adds /apps, /lib, and /vendor to the Python path.
-import manage
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crashstats.settings')
 
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()


### PR DESCRIPTION
This might need some care when reviewing. I'm quite confident about the code changes, but what I'm less confident about is the django-compressor stuff. 

I was able to set
```
COMPRESS_ENABLED=False
COMPRESS_OFFLINE=False
```
and run the site fine. The `.less` files were converted to `.css` just fine. 

Also, I was able to change to 
```
COMPRESS_ENABLED=True
COMPRESS_OFFLINE=True
```
and run
```
./manage.py collectstatic --noinput && ./manage.py compress --engine=jinja2 --force
```
like I always do and then runserver and that worked fine too. 
