### PR TITLE
Fixes Bug 1218220 - split the boto connection from the crashstorage class

### DIFF
--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -1,0 +1,245 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import boto
+import boto.s3.connection
+import boto.exception
+
+import json
+import os
+import socket
+import datetime
+import contextlib
+
+from configman import Namespace, RequiredConfig, class_converter
+from configman.converters import class_converter, py_obj_to_str
+from socorro.lib.util import DotDict
+from socorro.lib.converters import change_default
+
+class BotoNotFound(Exception):
+    pass
+
+
+#==============================================================================
+class ConnectionContext(RequiredConfig):
+
+    required_config = Namespace()
+    required_config.add_option(
+        'host',
+        doc="The hostname (leave empty for AWS)",
+        default="",
+        reference_value_from='resource.boto',
+    )
+    required_config.add_option(
+        'port',
+        doc="The network port (leave at 0 for AWS)",
+        default=0,
+        reference_value_from='resource.boto',
+    )
+    required_config.add_option(
+        'access_key',
+        doc="access key",
+        default="",
+        reference_value_from='resource.boto',
+    )
+    required_config.add_option(
+        'secret_access_key',
+        doc="secret access key",
+        default="",
+        secret=True,
+        reference_value_from='secrets.boto',
+    )
+    required_config.add_option(
+        'bucket_name',
+        doc="The name of the bucket.",
+        default='crashstats',
+        reference_value_from='resource.boto',
+        likely_to_be_changed=True,
+    )
+    required_config.add_option(
+        'prefix',
+        doc="a prefix to use inside the bucket",
+        default='',
+        reference_value_from='resource.boto',
+        likely_to_be_changed=True,
+    )
+    required_config.add_option(
+        'calling_format',
+        doc="fully qualified python path to the boto calling format function",
+        default='boto.s3.connection.SubdomainCallingFormat',
+        from_string_converter=class_converter,
+        reference_value_from='resource.boto',
+        likely_to_be_changed=True,
+    )
+
+    operational_exceptions = (
+        socket.timeout,
+        # wild guesses at retriable exceptions
+        boto.exception.PleaseRetryException,
+        boto.exception.ResumableTransferDisposition,
+        boto.exception.ResumableUploadException,
+    )
+
+    conditional_exceptions = (
+        boto.exception.StorageResponseError
+    )
+
+    #--------------------------------------------------------------------------
+    def is_operational_exception(self, x):
+        if "not found, no value returned" in str(x):
+            # the not found error needs to be re-tryable to compensate for
+            # eventual consistency.  However, a method capable of raising this
+            # exception should never be used with a transaction executor that
+            # has infinite back off.
+            return True
+        #elif   # for further cases...
+        return False
+
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, quit_check_callback=None):
+        self.config =  config
+
+        self._connect_to_endpoint = boto.connect_s3
+        self._calling_format = config.calling_format
+        self._CreateError = boto.exception.S3CreateError
+        self._S3ResponseError = boto.exception.S3ResponseError
+        self._open = open
+
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def build_s3_dirs(prefix, name_of_thing, id):
+        """
+        Use S3 pseudo-directories to make it easier to list/expire later
+        {{prefix}}/{{version}}/{{name_of_thing}}/{{id}}
+        """
+        version = 'v1'
+        return '%s/%s/%s/%s' % (prefix, version, name_of_thing, id)
+
+    #--------------------------------------------------------------------------
+    def _get_bucket(self, conn, bucket_name):
+        try:
+            return self._bucket_cache
+        except AttributeError:
+            self._bucket_cache = conn.get_bucket(bucket_name)
+            return self._bucket_cache
+
+    #--------------------------------------------------------------------------
+    def _get_or_create_bucket(self, conn, bucket_name):
+        try:
+            return self._bucket_cache
+        except AttributeError:
+            try:
+                self._bucket_cache = conn.get_bucket(bucket_name)
+            except self._S3ResponseError:
+                self._bucket_cache = conn.create_bucket(bucket_name)
+            return self._bucket_cache
+
+    #--------------------------------------------------------------------------
+    def submit_to_boto_s3(self, id, name_of_thing, thing):
+        """submit something to boto.
+        """
+        if not isinstance(thing, basestring):
+            raise Exception('can only submit strings to boto')
+
+        conn = self._connect()
+        bucket = self._get_or_create_bucket(conn, self.config.bucket_name)
+
+        key = self.build_s3_dirs(self.config.prefix, name_of_thing, id)
+
+        storage_key = bucket.new_key(key)
+        storage_key.set_contents_from_string(thing)
+
+    #--------------------------------------------------------------------------
+    def fetch_from_boto_s3(self, id, name_of_thing):
+        """retrieve something from boto.
+        """
+        conn = self._connect()
+        bucket = self._get_bucket(conn, self.config.bucket_name)
+
+        key = self.build_s3_dirs(self.config.prefix, name_of_thing, id)
+
+        storage_key = bucket.get_key(key)
+        if storage_key is None:
+            raise BotoNotFound('%s not found, no value returned' % id)
+        return storage_key.get_contents_as_string()
+
+    #--------------------------------------------------------------------------
+    def _connect(self):
+        try:
+            return self.connection
+        except AttributeError:
+            kwargs = {
+                "aws_access_key_id": self.config.access_key,
+                "aws_secret_access_key": self.config.secret_access_key,
+                "is_secure": True,
+                "calling_format": self._calling_format(),
+            }
+            if self.config.host:
+                kwargs["host"] = self.config.host
+            if self.config.port:
+                kwargs["port"] = self.config.port
+            self.connection = self._connect_to_endpoint(**kwargs)
+            return self.connection
+
+    #--------------------------------------------------------------------------
+    def _convert_mapping_to_string(self, a_mapping):
+        self._stringify_dates_in_dict(a_mapping)
+        return json.dumps(a_mapping)
+
+    #--------------------------------------------------------------------------
+    def _convert_list_to_string(self, a_list):
+        return json.dumps(a_list)
+
+    #--------------------------------------------------------------------------
+    def _convert_string_to_list(self, a_string):
+        return json.loads(a_string)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _stringify_dates_in_dict(items):
+        for k, v in items.iteritems():
+            if isinstance(v, datetime.datetime):
+                items[k] = v.strftime("%Y-%m-%d %H:%M:%S.%f")
+        return items
+
+    # because this crashstorage class operates as its own connection class
+    # these function must be present.  The transaction executor will use them
+    # to coordinate retries
+    # essentially to function as a connection, this class must fullfill the
+    # API contract with connection objects recognized by the transaction
+    # manager. The following functions are required by that API.
+    #--------------------------------------------------------------------------
+    def commit(self):
+        """boto doesn't support transactions so this silently
+        does nothing"""
+
+    #--------------------------------------------------------------------------
+    def rollback(self):
+        """boto doesn't support transactions so this silently
+        does nothing"""
+
+    #--------------------------------------------------------------------------
+    @contextlib.contextmanager
+    def __call__(self):
+        """this class will serve as its own context manager.  That enables it
+        to use the transaction_executor class for retries"""
+        yield self
+
+    #--------------------------------------------------------------------------
+    def in_transaction(self, dummy):
+        """boto doesn't support transactions, so it is never in
+        a transaction."""
+        return False
+
+    #--------------------------------------------------------------------------
+    def force_reconnect(self):
+        try:
+            del self.connection
+        except AttributeError:
+            # already deleted, ignorable
+            pass
+
+

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -16,6 +16,10 @@ from socorro.external.crashstorage_base import (
     CrashIDNotFound,
     MemoryDumpsMapping,
 )
+from socorro.external.boto.connection_context import (
+    ConnectionContext,
+    BotoNotFound
+)
 from socorro.lib.util import DotDict
 from socorro.lib.converters import change_default
 
@@ -30,6 +34,13 @@ class BotoS3CrashStorage(CrashStorageBase):
     """
 
     required_config = Namespace()
+    required_config.add_option(
+        "resource_class",
+        default=ConnectionContext,
+        doc="fully qualified dotted Python classname to handle Boto connections",
+        from_string_converter=class_converter,
+        reference_value_from='resource.boto'
+    )
     required_config.add_option(
         'transaction_executor_class_for_get',
         default="socorro.database.transaction_executor."
@@ -47,24 +58,6 @@ class BotoS3CrashStorage(CrashStorageBase):
         reference_value_from='resource.boto',
     )
     required_config.add_option(
-        'host',
-        doc="The hostname (leave empty for AWS)",
-        default="",
-        reference_value_from='resource.boto',
-    )
-    required_config.add_option(
-        'port',
-        doc="The network port (leave at 0 for AWS)",
-        default=0,
-        reference_value_from='resource.boto',
-    )
-    required_config.add_option(
-        'access_key',
-        doc="access key",
-        default="",
-        reference_value_from='resource.boto',
-    )
-    required_config.add_option(
         'temporary_file_system_storage_path',
         doc='a local filesystem path where dumps temporarily '
             'during processing',
@@ -76,47 +69,6 @@ class BotoS3CrashStorage(CrashStorageBase):
         doc='the suffix used to identify a dump file (for use in temp files)',
         default='.dump',
         reference_value_from='resource.boto',
-    )
-    required_config.add_option(
-        'secret_access_key',
-        doc="secret access key",
-        default="",
-        secret=True,
-        reference_value_from='secrets.boto',
-    )
-    required_config.add_option(
-        'bucket_name',
-        doc="The name of the bucket.",
-        default='crashstats',
-        reference_value_from='resource.boto',
-        likely_to_be_changed=True,
-    )
-    required_config.add_option(
-        'prefix',
-        doc="a prefix to use inside the bucket",
-        default='',
-        reference_value_from='resource.boto',
-        likely_to_be_changed=True,
-    )
-    required_config.add_option(
-        'calling_format',
-        doc="fully qualified python path to the boto calling format function",
-        default='boto.s3.connection.SubdomainCallingFormat',
-        from_string_converter=class_converter,
-        reference_value_from='resource.boto',
-        likely_to_be_changed=True,
-    )
-
-    operational_exceptions = (
-        socket.timeout,
-        # wild guesses at retriable exceptions
-        boto.exception.PleaseRetryException,
-        boto.exception.ResumableTransferDisposition,
-        boto.exception.ResumableUploadException,
-    )
-
-    conditional_exceptions = (
-        boto.exception.StorageResponseError
     )
 
     #--------------------------------------------------------------------------
@@ -137,11 +89,11 @@ class BotoS3CrashStorage(CrashStorageBase):
             quit_check_callback
         )
 
-        self._bucket_name = config.bucket_name
-
+##        self._bucket_name = config.bucket_name
+        self.connection_source = config.resource_class(config)
         self.transaction = config.transaction_executor_class(
             config,
-            self,  # we are our own connection
+            self.connection_source,  # we are our own connection
             quit_check_callback
         )
         if config.transaction_executor_class_for_get.is_infinite:
@@ -154,45 +106,28 @@ class BotoS3CrashStorage(CrashStorageBase):
 
         self.transaction_for_get = config.transaction_executor_class_for_get(
             config,
-            self,  # we are our own connection
+            self.connection_source,  # we are our own connection
             quit_check_callback
         )
 
 
-        # short cuts to external resources - makes testing/mocking easier
-        self._connect_to_endpoint = boto.connect_s3
-        self._calling_format = config.calling_format
-        self._CreateError = boto.exception.S3CreateError
-        self._S3ResponseError = boto.exception.S3ResponseError
-        self._open = open
-
     #--------------------------------------------------------------------------
     @staticmethod
-    def build_s3_dirs(prefix, name_of_thing, crash_id):
-        """
-        Use S3 pseudo-directories to make it easier to list/expire later
-        {{prefix}}/{{version}}/{{name_of_thing}}/{{crash_id}}
-        """
-        version = 'v1'
-        return '%s/%s/%s/%s' % (prefix, version, name_of_thing, crash_id)
-
-    #--------------------------------------------------------------------------
-    @staticmethod
-    def do_save_raw_crash(boto_s3_store, raw_crash, dumps, crash_id):
+    def do_save_raw_crash(boto_connection, raw_crash, dumps, crash_id):
         if dumps is None:
             dumps = MemoryDumpsMapping()
-        raw_crash_as_string = boto_s3_store._convert_mapping_to_string(
+        raw_crash_as_string = boto_connection._convert_mapping_to_string(
             raw_crash
         )
-        boto_s3_store._submit_to_boto_s3(
+        boto_connection.submit_to_boto_s3(
             crash_id,
             "raw_crash",
             raw_crash_as_string
         )
-        dump_names_as_string = boto_s3_store._convert_list_to_string(
+        dump_names_as_string = boto_connection._convert_list_to_string(
             dumps.keys()
         )
-        boto_s3_store._submit_to_boto_s3(
+        boto_connection.submit_to_boto_s3(
             crash_id,
             "dump_names",
             dump_names_as_string
@@ -205,7 +140,7 @@ class BotoS3CrashStorage(CrashStorageBase):
         for dump_name, dump in dumps.iteritems():
             if dump_name in (None, '', 'upload_file_minidump'):
                 dump_name = 'dump'
-            boto_s3_store._submit_to_boto_s3(crash_id, dump_name, dump)
+            boto_connection.submit_to_boto_s3(crash_id, dump_name, dump)
 
     #--------------------------------------------------------------------------
     def save_raw_crash(self, raw_crash, dumps, crash_id):
@@ -213,12 +148,12 @@ class BotoS3CrashStorage(CrashStorageBase):
 
     #--------------------------------------------------------------------------
     @staticmethod
-    def _do_save_processed(boto_s3_store, processed_crash):
+    def _do_save_processed(boto_connection, processed_crash):
         crash_id = processed_crash['uuid']
-        processed_crash_as_string = boto_s3_store._convert_mapping_to_string(
+        processed_crash_as_string = boto_connection._convert_mapping_to_string(
             processed_crash
         )
-        boto_s3_store._submit_to_boto_s3(
+        boto_connection.submit_to_boto_s3(
             crash_id,
             "processed_crash",
             processed_crash_as_string
@@ -243,14 +178,14 @@ class BotoS3CrashStorage(CrashStorageBase):
 
     #--------------------------------------------------------------------------
     @staticmethod
-    def do_get_raw_crash(boto_s3_store, crash_id):
+    def do_get_raw_crash(boto_connection, crash_id):
         try:
-            raw_crash_as_string = boto_s3_store._fetch_from_boto_s3(
+            raw_crash_as_string = boto_connection.fetch_from_boto_s3(
                 crash_id,
                 "raw_crash"
             )
             return json.loads(raw_crash_as_string, object_hook=DotDict)
-        except boto.exception.StorageResponseError, x:
+        except (boto.exception.StorageResponseError, BotoNotFound), x:
             raise CrashIDNotFound(
                 '%s not found: %s' % (crash_id, x)
             )
@@ -261,11 +196,11 @@ class BotoS3CrashStorage(CrashStorageBase):
 
     #--------------------------------------------------------------------------
     @staticmethod
-    def do_get_raw_dump(boto_s3_store, crash_id, name=None):
+    def do_get_raw_dump(boto_connection, crash_id, name=None):
         try:
             if name in (None, '', 'upload_file_minidump'):
                 name = 'dump'
-            a_dump = boto_s3_store._fetch_from_boto_s3(crash_id, name)
+            a_dump = boto_connection.fetch_from_boto_s3(crash_id, name)
             return a_dump
         except boto.exception.StorageResponseError, x:
             raise CrashIDNotFound(
@@ -278,13 +213,13 @@ class BotoS3CrashStorage(CrashStorageBase):
 
     #--------------------------------------------------------------------------
     @staticmethod
-    def do_get_raw_dumps(boto_s3_store, crash_id):
+    def do_get_raw_dumps(boto_connection, crash_id):
         try:
-            dump_names_as_string = boto_s3_store._fetch_from_boto_s3(
+            dump_names_as_string = boto_connection.fetch_from_boto_s3(
                 crash_id,
                 "dump_names"
             )
-            dump_names = boto_s3_store._convert_string_to_list(
+            dump_names = boto_connection._convert_string_to_list(
                 dump_names_as_string
             )
             # when we fetch the dumps, they are by default in memory, so we'll
@@ -293,7 +228,7 @@ class BotoS3CrashStorage(CrashStorageBase):
             for dump_name in dump_names:
                 if dump_name in (None, '', 'upload_file_minidump'):
                     dump_name = 'dump'
-                dumps[dump_name] = boto_s3_store._fetch_from_boto_s3(
+                dumps[dump_name] = boto_connection.fetch_from_boto_s3(
                     crash_id,
                     dump_name
                 )
@@ -320,9 +255,9 @@ class BotoS3CrashStorage(CrashStorageBase):
 
     #--------------------------------------------------------------------------
     @staticmethod
-    def _do_get_unredacted_processed(boto_s3_store, crash_id):
+    def _do_get_unredacted_processed(boto_connection, crash_id):
         try:
-            processed_crash_as_string = boto_s3_store._fetch_from_boto_s3(
+            processed_crash_as_string = boto_connection.fetch_from_boto_s3(
                 crash_id,
                 "processed_crash"
             )
@@ -338,131 +273,6 @@ class BotoS3CrashStorage(CrashStorageBase):
     #--------------------------------------------------------------------------
     def get_unredacted_processed(self, crash_id):
         return self.transaction_for_get(self._do_get_unredacted_processed, crash_id)
-
-    #--------------------------------------------------------------------------
-    def _get_bucket(self, conn, bucket_name):
-        try:
-            return self._bucket_cache
-        except AttributeError:
-            self._bucket_cache = conn.get_bucket(bucket_name)
-            return self._bucket_cache
-
-    #--------------------------------------------------------------------------
-    def _get_or_create_bucket(self, conn, bucket_name):
-        try:
-            return self._bucket_cache
-        except AttributeError:
-            try:
-                self._bucket_cache = conn.get_bucket(bucket_name)
-            except self._S3ResponseError:
-                self._bucket_cache = conn.create_bucket(bucket_name)
-            return self._bucket_cache
-
-    #--------------------------------------------------------------------------
-    def _submit_to_boto_s3(self, crash_id, name_of_thing, thing):
-        """submit something to boto.
-        """
-        if not isinstance(thing, basestring):
-            raise Exception('can only submit strings to boto')
-
-        conn = self._connect()
-        bucket = self._get_or_create_bucket(conn, self.config.bucket_name)
-
-        key = self.build_s3_dirs(self.config.prefix, name_of_thing, crash_id)
-
-        storage_key = bucket.new_key(key)
-        storage_key.set_contents_from_string(thing)
-
-    #--------------------------------------------------------------------------
-    def _fetch_from_boto_s3(self, crash_id, name_of_thing):
-        """retrieve something from boto.
-        """
-        conn = self._connect()
-        bucket = self._get_bucket(conn, self.config.bucket_name)
-
-        key = self.build_s3_dirs(self.config.prefix, name_of_thing, crash_id)
-
-        storage_key = bucket.get_key(key)
-        if storage_key is None:
-            raise CrashIDNotFound('%s not found, no value returned' % crash_id)
-        return storage_key.get_contents_as_string()
-
-    #--------------------------------------------------------------------------
-    def _connect(self):
-        try:
-            return self.connection
-        except AttributeError:
-            kwargs = {
-                "aws_access_key_id": self.config.access_key,
-                "aws_secret_access_key": self.config.secret_access_key,
-                "is_secure": True,
-                "calling_format": self._calling_format(),
-            }
-            if self.config.host:
-                kwargs["host"] = self.config.host
-            if self.config.port:
-                kwargs["port"] = self.config.port
-            self.connection = self._connect_to_endpoint(**kwargs)
-            return self.connection
-
-    #--------------------------------------------------------------------------
-    def _convert_mapping_to_string(self, a_mapping):
-        self._stringify_dates_in_dict(a_mapping)
-        return json.dumps(a_mapping)
-
-    #--------------------------------------------------------------------------
-    def _convert_list_to_string(self, a_list):
-        return json.dumps(a_list)
-
-    #--------------------------------------------------------------------------
-    def _convert_string_to_list(self, a_string):
-        return json.loads(a_string)
-
-    #--------------------------------------------------------------------------
-    @staticmethod
-    def _stringify_dates_in_dict(items):
-        for k, v in items.iteritems():
-            if isinstance(v, datetime.datetime):
-                items[k] = v.strftime("%Y-%m-%d %H:%M:%S.%f")
-        return items
-
-    # because this crashstorage class operates as its own connection class
-    # these function must be present.  The transaction executor will use them
-    # to coordinate retries
-    # essentially to function as a connection, this class must fullfill the
-    # API contract with connection objects recognized by the transaction
-    # manager. The following functions are required by that API.
-    #--------------------------------------------------------------------------
-    def commit(self):
-        """boto doesn't support transactions so this silently
-        does nothing"""
-
-    #--------------------------------------------------------------------------
-    def rollback(self):
-        """boto doesn't support transactions so this silently
-        does nothing"""
-
-    #--------------------------------------------------------------------------
-    @contextlib.contextmanager
-    def __call__(self):
-        """this class will serve as its own context manager.  That enables it
-        to use the transaction_executor class for retries"""
-        yield self
-
-    #--------------------------------------------------------------------------
-    def in_transaction(self, dummy):
-        """boto doesn't support transactions, so it is never in
-        a transaction."""
-        return False
-
-    #--------------------------------------------------------------------------
-    def force_reconnect(self):
-        try:
-            del self.connection
-        except AttributeError:
-            # already deleted, ignorable
-            pass
-
 
 #==============================================================================
 class SupportReasonAPIStorage(BotoS3CrashStorage):
@@ -489,7 +299,7 @@ class SupportReasonAPIStorage(BotoS3CrashStorage):
 
     #--------------------------------------------------------------------------
     @staticmethod
-    def _do_save_processed(boto_s3_store, processed_crash):
+    def _do_save_processed(boto_connection, processed_crash):
         """Replaces the function of the same name in the parent class.
         """
         crash_id = processed_crash['uuid']
@@ -507,7 +317,7 @@ class SupportReasonAPIStorage(BotoS3CrashStorage):
             return
 
         # Submit the data chunk to S3.
-        boto_s3_store._submit_to_boto_s3(
+        boto_connection.submit_to_boto_s3(
             crash_id,
             'support_reason',
             json.dumps(content)

--- a/socorro/unittest/external/boto/test_connection_context.py
+++ b/socorro/unittest/external/boto/test_connection_context.py
@@ -1,0 +1,206 @@
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import mock
+import json
+import tempfile
+import shutil
+from os.path import join
+
+import boto.exception
+
+from socorro.lib.util import DotDict
+from socorro.external.crashstorage_base import (
+    Redactor,
+    MemoryDumpsMapping
+)
+from socorro.external.boto.connection_context import (
+    ConnectionContext
+)
+from socorro.external.boto.crashstorage import (
+    BotoS3CrashStorage,
+    SupportReasonAPIStorage
+)
+from socorro.database.transaction_executor import (
+    TransactionExecutor,
+    TransactionExecutorWithLimitedBackoff,
+)
+from socorro.external.crashstorage_base import CrashIDNotFound
+import socorro.unittest.testbase
+
+
+a_raw_crash = {
+    "submitted_timestamp": "2013-01-09T22:21:18.646733+00:00"
+}
+a_raw_crash_as_string = json.dumps(a_raw_crash)
+
+
+class ABadDeal(Exception):
+    pass
+
+
+class ConditionallyABadDeal(Exception):
+    pass
+
+ConnectionContext.operational_exceptions = (ABadDeal, )
+ConnectionContext.conditional_exceptions = (ConditionallyABadDeal, )
+
+a_thing = {
+    'a': 'some a',
+    'b': 'some b',
+    'c':  16,
+    'd': {
+        'da': 'some da',
+        'db': 'same db',
+    },
+}
+thing_as_str = json.dumps(a_thing)
+
+class TestCase(socorro.unittest.testbase.TestCase):
+
+    def setup_mocked_s3_storage(
+        self,
+        executor=TransactionExecutor,
+        executor_for_gets=TransactionExecutor,
+        storage_class='BotoS3CrashStorage',
+        host='',
+        port=0
+    ):
+        config = DotDict({
+            'resource_class': ConnectionContext,
+            'logger': mock.Mock(),
+            'host': host,
+            'port': port,
+            'access_key': 'this is the access key',
+            'secret_access_key': 'secrets',
+            'bucket_name': 'silliness',
+            'prefix': 'dev',
+            'calling_format': mock.Mock()
+        })
+        s3_conn = ConnectionContext(config)
+        s3_conn._connect_to_endpoint = mock.Mock()
+        s3_conn._mocked_connection = s3_conn._connect_to_endpoint.return_value
+        s3_conn._calling_format.return_value = mock.Mock()
+        s3_conn._CreateError = mock.Mock()
+        s3_conn._S3ResponseError = mock.Mock()
+        s3_conn._open = mock.MagicMock()
+
+        return s3_conn
+
+    def assert_s3_connection_parameters(self, connection_source, host='', port=0):
+        kwargs = {
+            "aws_access_key_id": connection_source.config.access_key,
+            "aws_secret_access_key": connection_source.config.secret_access_key,
+            "is_secure": True,
+            "calling_format": connection_source._calling_format.return_value
+        }
+        if host:
+            kwargs['host'] = host
+        if port:
+            kwargs['port'] = port
+        connection_source._connect_to_endpoint.assert_called_with(**kwargs)
+
+    def test_connect_with_host_port(self):
+        connection = self.setup_mocked_s3_storage(
+            host='somewhere.sometime.someone',
+            port=666,
+        )
+        c =  connection._connect()
+        self.assert_s3_connection_parameters(
+            connection,
+            host='somewhere.sometime.someone',
+            port=666,
+        )
+
+    def test_s3_dir_builder(self):
+        connection_source = self.setup_mocked_s3_storage()
+        prefix = 'dev'
+        name_of_thing = 'dump'
+        crash_id = 'fff13cf0-5671-4496-ab89-47a922141114'
+        good = connection_source.build_s3_dirs(prefix, name_of_thing, crash_id)
+        self.assertEqual("dev/v1/dump/fff13cf0-5671-4496-ab89-47a922141114", good)
+
+    def test_submit_to_boto_s3(self):
+        connection_source = self.setup_mocked_s3_storage()
+
+        # the call to be tested
+        connection_source.submit_to_boto_s3(
+            'this_is_an_id',
+            'name_of_thing',
+            thing_as_str
+        )
+
+        # this should have happened
+        self.assert_s3_connection_parameters(connection_source)
+        self.assertEqual(connection_source._calling_format.call_count, 1)
+        connection_source._calling_format.assert_called_with()
+
+        self.assertEqual(connection_source._connect_to_endpoint.call_count, 1)
+        self.assert_s3_connection_parameters(connection_source)
+
+        self.assertEqual(
+            connection_source._mocked_connection.get_bucket.call_count,
+            1
+        )
+        connection_source._mocked_connection.get_bucket.assert_called_with(
+            'silliness'
+        )
+
+        bucket_mock = connection_source._mocked_connection.get_bucket \
+            .return_value
+        self.assertEqual(bucket_mock.new_key.call_count, 1)
+        bucket_mock.new_key.called_once_with(
+            'dev/v1/name_of_thing/this_is_an_id'
+        )
+
+        storage_key_mock = bucket_mock.new_key.return_value
+        self.assertEqual(
+            storage_key_mock.set_contents_from_string.call_count,
+            1
+        )
+        storage_key_mock.set_contents_from_string.called_once_with(
+            '{"a": "some a", "c": 16, "b": "some b", "d": '
+            '{"db": "same db", "da": "some da"}}'
+        )
+
+    def test_get_fetch_from_boto(self):
+        # setup some internal behaviors and fake outs
+        connection_source = self.setup_mocked_s3_storage()
+        mocked_get_contents_as_string = (
+            connection_source._connect_to_endpoint.return_value
+            .get_bucket.return_value.get_key.return_value
+            .get_contents_as_string
+        )
+        mocked_get_contents_as_string.side_effect = [ thing_as_str ]
+
+        # the tested call
+        result = connection_source.fetch_from_boto_s3(
+            'name_of_thing',
+            'this_is_an_id'
+        )
+
+        # what should have happened internally
+        self.assertEqual(connection_source._calling_format.call_count, 1)
+        connection_source._calling_format.assert_called_with()
+
+        self.assertEqual(connection_source._connect_to_endpoint.call_count, 1)
+        self.assert_s3_connection_parameters(connection_source)
+
+        self.assertEqual(
+            connection_source._mocked_connection.get_bucket.call_count,
+            1
+        )
+        connection_source._mocked_connection.get_bucket.assert_called_with(
+            'silliness'
+        )
+
+        self.assertEqual(mocked_get_contents_as_string.call_count, 1)
+        mocked_get_contents_as_string.assert_has_calls(
+            [
+                mock.call(),
+            ],
+        )
+
+        self.assertEqual(result, thing_as_str)


### PR DESCRIPTION
we're gonna have to store correlation data in S3, it sure would be handy to have a nicely wrapped Boto connection class to use for this.  We've got one, but it is embedded within the BotoS3CrashStorage class. 

Split it out into a TransactionExecutor compatible ConnectionContext class.  That'll give us some nice code reuse.  At the same time, this action should in no way have any repercussions on existing uses the BotoS3CrashStorage class.  In other words, this action should not affect configuration of any existing App.