### PR TITLE
Fixes Bug 1218366  fixed missing import in the SocorroLiteProcessor class + a test

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -350,7 +350,7 @@ function start_minimal_socorro_apps() {
   echo "INFO: starting up *** start_minimal_socorro_apps *** "
   echo "      * in this test we're using the older collector capable of accepting only breakpad crashes"
   echo "      * the collector writes to only the filesystem using FSTemporaryStorage"
-  echo "      * the processor used Processor2015 with the MozillaProcessorAlgorithm2015"
+  echo "      * the processor used Processor2015 with the SocorroLiteProcessorAlgorithm2015"
   echo "      * the processor sources from FSTemporaryStorage"
   echo "      * the processor writes only to FSPermanentStorage"
   socorro collector \
@@ -362,7 +362,7 @@ function start_minimal_socorro_apps() {
       --source.crashstorage_class=socorro.external.fs.crashstorage.FSTemporaryStorage \
       --new_crash_source.new_crash_source_class=socorro.external.fs.fs_new_crash_source.FSNewCrashSource \
       --new_crash_source.crashstorage_class=socorro.external.fs.crashstorage.FSTemporaryStorage \
-      --processor.processor_class=socorro.processor.mozilla_processor_2015.MozillaProcessorAlgorithm2015 \
+      --processor.processor_class=socorro.processor.socorrolite_processor_2015.SocorroLiteProcessorAlgorithm2015 \
       --destination.crashstorage_class=socorro.external.fs.crashstorage.FSPermanentStorage \
       --destination.fs_root=./processedCrashStore \
       > processor.log 2>&1 &

--- a/socorro/processor/socorrolite_processor_2015.py
+++ b/socorro/processor/socorrolite_processor_2015.py
@@ -1,6 +1,9 @@
 import ujson
+
 from socorro.processor.processor_2015 import Processor2015
 from socorro.lib.converters import change_default
+
+from configman import Namespace
 
 #------------------------------------------------------------------------------
 # these are the steps that define minimal processing of a crash.


### PR DESCRIPTION
We don't use the ScorroLiteProcessor at Mozilla, but our docs lead new users to start with it.  We ought to ensure that it works.  

Fix the missing symbol in the SocorroLiteProcessor and add it to the integration tests to make sure it works.