### PR TITLE
fixes Bug 1218579  -removed logger reference at the end that might not exist

### DIFF
--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -287,7 +287,6 @@ class SocorroApp(RequiredConfig):
             # whew, finally run the app that we wanted
 
             return_code = fix_exit_code(app_to_run.main())
-            config.logger.debug('returning errorcode %d',  return_code)
             return return_code
 
 


### PR DESCRIPTION
there was a debug line in the socorro app hierarchy that was inadvertently left in.  in some edge cases it causes an exception during a shut down.  fix it.