### PR TITLE
Fixes Bug 1219265 - iterator for products & versions for correlation reports + consolidation

### DIFF
--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -423,7 +423,8 @@ class FetchTransformSaveWithSeparateNewCrashSourceApp(FetchTransformSaveApp):
             self.new_crash_source = \
                 self.config.new_crash_source.new_crash_source_class(
                     self.config.new_crash_source,
-                    self.app_instance_name
+                    name=self.app_instance_name,
+                    quit_check_callback=self.quit_check
                 )
         else:
             # the configuration failed to provide a "new_crash_source", fall

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -13,7 +13,7 @@ import datetime
 
 from socorro.lib.util import DotDict as SocorroDotDict
 
-from configman import Namespace,  RequiredConfig
+from configman import Namespace, RequiredConfig
 from configman.converters import classes_in_namespaces_converter, \
                                  class_converter
 from configman.dotdict import DotDict as ConfigmanDotDict
@@ -132,7 +132,6 @@ class Redactor(RequiredConfig):
         reference_value_from='resource.redactor',
     )
 
-
     #--------------------------------------------------------------------------
     def __init__(self, config):
         self.config = config
@@ -238,7 +237,8 @@ class CrashStorageBase(RequiredConfig):
     def save_raw_crash_with_file_dumps(self, raw_crash, dumps, crash_id):
         """this method that saves  both the raw_crash and the dump and must be
         overridden in any implementation that wants a different behavior.  It
-        assumes that the crashes are in the form of paths to files.
+        assumes that the dumps are in the form of paths to files and need to
+        be converted to memory_dumps
 
         parameters:
             raw_crash - a mapping containing the raw crash meta data.  It is
@@ -247,11 +247,11 @@ class CrashStorageBase(RequiredConfig):
             dumps - a dict of dump name keys and paths to file system locations
                     for the dump data
             crash_id - the crash key to use for this crash"""
-        in_memory_dumps = {}
-        for dump_key, dump_path in dumps.iteritems():
-            with open(dump_path) as f:
-                in_memory_dumps[dump_key] = f.read()
-        self.save_raw_crash(raw_crash, in_memory_dumps, crash_id)
+        self.save_raw_crash(
+            raw_crash,
+            dumps.as_memory_dumps_mapping(),
+            crash_id
+        )
 
     #--------------------------------------------------------------------------
     def save_processed(self, processed_crash):
@@ -365,7 +365,6 @@ class CrashStorageBase(RequiredConfig):
         """overridden by subclasses that must acknowledge a successful use of
         an item pulled from the 'new_crashes' generator. """
         return crash_id
-
 
 
 #==============================================================================
@@ -1084,7 +1083,6 @@ class PrimaryDeferredProcessedStorage(PrimaryDeferredStorage):
         """fetch an unredacted processed crash from the underlying
         storage implementation"""
         return self.processed_store.get_unredacted_processed(crash_id)
-
 
 
 #==============================================================================

--- a/socorro/external/fs/fs_new_crash_source.py
+++ b/socorro/external/fs/fs_new_crash_source.py
@@ -22,7 +22,7 @@ class FSNewCrashSource(RequiredConfig):
     )
 
     #--------------------------------------------------------------------------
-    def __init__(self, config, processor_name, quit_check_callback=None):
+    def __init__(self, config, name=None, quit_check_callback=None):
         self.crash_store = config.crashstorage_class(
             config,
             quit_check_callback

--- a/socorro/external/postgresql/new_crash_source.py
+++ b/socorro/external/postgresql/new_crash_source.py
@@ -1,0 +1,158 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from datetime import timedelta
+from collections import Sequence
+
+from configman import Namespace, RequiredConfig, class_converter
+
+from socorro.lib.converters import (
+    change_default,
+)
+from socorro.lib.datetimeutil import (
+    utc_now,
+    string_to_datetime,
+)
+from socorro.external.postgresql.dbapi2_util import execute_query_fetchall
+
+
+#==============================================================================
+class PGQueryNewCrashSource(RequiredConfig):
+    """This class is an iterator that will yield a stream of crash_ids based
+    on a query to the PG database."""
+    required_config = Namespace()
+    required_config.add_option(
+        'transaction_executor_class',
+        default="socorro.database.transaction_executor."
+        "TransactionExecutorWithInfiniteBackoff",
+        doc='a class that will manage transactions',
+        from_string_converter=class_converter,
+        reference_value_from='resource.postgresql',
+    )
+    required_config.add_option(
+        'database_class',
+        default='socorro.external.postgresql.connection_context'
+            '.ConnectionContext',
+        doc='the class responsible for connecting to Postgres',
+        from_string_converter=class_converter,
+        reference_value_from='resource.postgresql',
+    )
+    required_config.add_option(
+        'crash_id_query',
+        doc='sql to get a list of crash_ids',
+        default="select 'some_id'",
+        likely_to_be_changed=True,
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, name, quit_check_callback=None):
+
+        self.database = config.database_class(
+            config
+        )
+        self.transaction = config.transaction_executor_class(
+            config,
+            self.database,
+            quit_check_callback=quit_check_callback
+        )
+        self.config = config
+        self.name = name
+        self.data = ()
+        self.crash_id_query = config.crash_id_query
+
+    #--------------------------------------------------------------------------
+    def __iter__(self):
+        crash_ids = self.transaction(
+            execute_query_fetchall,
+            self.crash_id_query,
+            self.data
+        )
+
+        for a_crash_id in crash_ids:
+            yield a_crash_id
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        self.database.close()
+
+    #--------------------------------------------------------------------------
+    new_crashes = __iter__
+
+    #--------------------------------------------------------------------------
+    def __call__(self):
+        return self.__iter__()
+
+
+#==============================================================================
+class PGPVNewCrashSource(PGQueryNewCrashSource):
+    required_config = Namespace()
+    required_config.crash_id_query = change_default(
+        PGQueryNewCrashSource,
+        'crash_id_query',
+        "select uuid "
+        "from reports_clean rc join product_versions pv "
+        "    on rc.product_version_id = pv.product_version_id "
+        "where "
+        "%s <= date_processed and date_processed < %s"
+        "and %s between pv.build_date and pv.sunset_date"
+    )
+    required_config.add_option(
+        'date',
+        doc="a date in the form YYYY-MM-DD",
+        default=(utc_now() - timedelta(1)).date(),
+        from_string_converter=string_to_datetime
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, name, quit_check_callback=None):
+        super(PGPVNewCrashSource, self).__init__(
+            config,
+            name,
+            quit_check_callback
+        )
+        self.data = (
+            config.date,
+            config.date + timedelta(1),  # add a day
+            config.date
+        )
+
+
+#==============================================================================
+class DBCrashStorageWrapperNewCrashSource(PGQueryNewCrashSource):
+    """This class is both a crashstorage system and a new_crash_source
+    iterator.  The base FTSApp classes ties the iteration of new crashes
+    to the crashstorage system designed as the 'source'.  This class is
+    appropriate for use in that case as a 'source'."""
+
+    required_config = Namespace()
+    required_config.namespace('implementation')
+    required_config.implementation.add_option(
+        'crashstorage_class',
+        default='socorro.external.boto.crashstorage.BotoS3CrashStorage',
+        doc='a class for a source of raw crashes',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, name=None, quit_check_callback=None):
+        super(DBCrashStorageWrapperNewCrashSource, self).__init__(
+            config,
+            name=name,
+            quit_check_callback=quit_check_callback
+        )
+        self._implementation = config.implementation.crashstorage_class(
+            config.implementation,
+            quit_check_callback
+        )
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        super(DBCrashStorageWrapperNewCrashSource, self).close()
+        self._implementation.close()
+
+    #--------------------------------------------------------------------------
+    def __getattr__(self, method):
+        def inner(*args, **kwargs):
+            return getattr(self._implementation, method)(*args, **kwargs)
+        return inner

--- a/socorro/external/rabbitmq/rmq_new_crash_source.py
+++ b/socorro/external/rabbitmq/rmq_new_crash_source.py
@@ -21,7 +21,7 @@ class RMQNewCrashSource(RequiredConfig):
     )
 
     #--------------------------------------------------------------------------
-    def __init__(self, config, processor_name, quit_check_callback=None):
+    def __init__(self, config, name=None, quit_check_callback=None):
         self.crash_store = config.crashstorage_class(
             config,
             quit_check_callback

--- a/socorro/processor/timemachine.py
+++ b/socorro/processor/timemachine.py
@@ -62,51 +62,7 @@ class DateProcessedTimeMachine(Rule):
         )
         return True
 
-
 #==============================================================================
-class PGQueryNewCrashSource(RequiredConfig):
-    required_config = Namespace()
-    required_config.add_option(
-        'crashstorage_class',
-        doc='the source storage class',
-        default='socorro.external.postgresql.crashstorage.PostgreSQLCrashStorage',
-        from_string_converter=class_converter,
-        reference_value_from='resource.postgresql'
-    )
-    required_config.add_option(
-        'crash_id_query',
-        doc='sql to get a list of crash_ids',
-        default="select uuid from reports_20141020 where uuid like '%142022' and date_processed > '2014-10-23'",
-    )
-
-    #--------------------------------------------------------------------------
-    def __init__(self, config, processor_name, quit_check_callback=None):
-        self.crash_store = config.crashstorage_class(
-            config,
-            quit_check_callback
-        )
-        self.config = config
-
-    #--------------------------------------------------------------------------
-    def close(self):
-        pass
-
-    #--------------------------------------------------------------------------
-    def __iter__(self):
-        crash_ids = self.crash_store.transaction(
-            execute_query_fetchall,
-            self.config.crash_id_query
-        )
-
-        for a_crash_id in crash_ids:
-            yield a_crash_id
-
-        while True:
-            yield None
-
-    #--------------------------------------------------------------------------
-    new_crashes =  __iter__
-
-    #--------------------------------------------------------------------------
-    def __call__(self):
-        return self.__iter__()
+# this class was relocated to a more appropriate module.  This import is
+# offered for backwards compatibility
+from socorro.external.postgresql.new_crash_source import PGQueryNewCrashSource

--- a/socorro/unittest/external/fs/test_fs_new_crash_source.py
+++ b/socorro/unittest/external/fs/test_fs_new_crash_source.py
@@ -39,14 +39,14 @@ class TestConnection(TestCase):
     #--------------------------------------------------------------------------
     def test_constructor(self):
         config = self._setup_config()
-        ncs = FSNewCrashSource(config, "ignored_processor_name")
+        ncs = FSNewCrashSource(config, name="ignored_processor_name")
         ok_(isinstance(ncs.crash_store, FakeCrashStore))
         ok_(ncs.crash_store.config is config)
 
     #--------------------------------------------------------------------------
     def test__iter__(self):
         config = self._setup_config()
-        ncs = FSNewCrashSource(config, "ignored_processor_name")
+        ncs = FSNewCrashSource(config)
         for i, (args, kwargs) in zip(range(10), ncs()):
             crash_id = args[0]
             eq_(str(i), crash_id)

--- a/socorro/unittest/external/postgresql/test_new_crash_source.py
+++ b/socorro/unittest/external/postgresql/test_new_crash_source.py
@@ -1,0 +1,455 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from itertools import izip_longest
+from datetime import date
+
+from mock import Mock
+from nose.tools import eq_, ok_
+
+from configman.dotdict import DotDict as ConfigmanDotDict
+
+from socorro.unittest.testbase import TestCase
+from socorro.external.postgresql.new_crash_source import (
+    PGQueryNewCrashSource,
+    DBCrashStorageWrapperNewCrashSource,
+    PGPVNewCrashSource
+)
+from socorro.lib.util import DotDict as SocorroDotDict
+from socorro.external.crashstorage_base import (
+    FileDumpsMapping,
+    MemoryDumpsMapping
+)
+
+
+#==============================================================================
+class NewCrashSourceTestBase(TestCase):
+    #--------------------------------------------------------------------------
+    def get_standard_config(self):
+        self.expected_sequence = ['one', 'two', 'three', 'four', 'five']
+        config = ConfigmanDotDict()
+        config.transaction_executor_class = Mock()
+        config.transaction_executor_class.return_value.return_value = (
+            self.expected_sequence
+        )
+        config.database_class = Mock()
+
+        config.crash_id_query = (
+            'select uuid from jobs order by '
+            'queueddatetime DESC limit 1000'
+        )
+
+        config.logger = Mock()
+        return config
+
+
+#==============================================================================
+class TestPGQueryNewCrashSource(NewCrashSourceTestBase):
+
+    #--------------------------------------------------------------------------
+    def test_init_and_close(self):
+        config = self.get_standard_config()
+
+        # the calls to be tested
+        crash_source = PGQueryNewCrashSource(config, name='fred')
+        crash_source.close()
+
+        # this is what should have happened
+        ok_(crash_source.config is config)
+        eq_(crash_source.name, 'fred')
+        config.database_class.assert_called_once_with(config)
+        config.transaction_executor_class.assert_called_once_with(
+            config,
+            crash_source.database,
+            quit_check_callback=None
+        )
+        crash_source.database.close.assert_called_once_with()
+
+    #--------------------------------------------------------------------------
+    def test_iter(self):
+        config = self.get_standard_config()
+        crash_source = PGQueryNewCrashSource(config, name='fred')
+        crash_source.close()
+
+        # the call to be tested & what should have happened
+        for i, (exp, actual) in enumerate(izip_longest(
+            self.expected_sequence,
+            crash_source())
+        ):
+            eq_(exp, actual)
+
+        eq_(
+            i,
+            4,
+            'there should have been exactly 5 iterations, instead: %d'
+            % (i + 1)
+        )
+
+
+#==============================================================================
+class TestDBSamplingCrashStorageWrapper(NewCrashSourceTestBase):
+
+    #--------------------------------------------------------------------------
+    def get_standard_config(self):
+        config = super(
+            TestDBSamplingCrashStorageWrapper,
+            self
+        ).get_standard_config()
+        config.implementation = ConfigmanDotDict()
+        config.implementation.crashstorage_class = Mock()
+
+        return config
+
+    #--------------------------------------------------------------------------
+    def test_init_and_close(self):
+        config = self.get_standard_config()
+
+        # the calls to be tested
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+        db_sampling.close()
+
+        # this is what should have happened
+        ok_(db_sampling.config is config)
+        config.database_class.assert_called_once_with(config)
+        config.transaction_executor_class.assert_called_once_with(
+            config,
+            db_sampling.database,
+            quit_check_callback=None
+        )
+        config.implementation.crashstorage_class.assert_called_once_with(
+            config.implementation,
+            None
+        )
+        db_sampling.database.close.assert_called_once_with()
+        db_sampling._implementation.close.assert_called_once_with()
+
+    #--------------------------------------------------------------------------
+    def test_new_crashes(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        # the call to be tested & what should have happened
+        for i, (exp, actual) in enumerate(izip_longest(
+            self.expected_sequence,
+            db_sampling.new_crashes())
+        ):
+            eq_(exp, actual)
+
+        eq_(
+            i,
+            4,
+            'there should have been exactly 5 iterations, instead: %d'
+            % (i + 1)
+        )
+
+    #--------------------------------------------------------------------------
+    def test_get_raw_crash(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+        fake_raw_crash = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+
+        mocked_get_raw_crash = Mock(return_value=fake_raw_crash)
+        db_sampling._implementation.get_raw_crash = mocked_get_raw_crash
+
+        # the call to be tested
+        raw_crash = db_sampling.get_raw_crash(crash_id)
+
+        # this is what should have happened
+        ok_(fake_raw_crash is raw_crash)
+        db_sampling._implementation.get_raw_crash.assert_called_with(crash_id)
+
+    #--------------------------------------------------------------------------
+    def test_get_raw_dump(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+        fake_dump = 'contents of dump 86b58ff2-9708-487d-bfc4-9dac32121214'
+        mocked_get_raw_dump = Mock(return_value=fake_dump)
+        db_sampling._implementation.get_raw_dump = mocked_get_raw_dump
+
+        # the call to be tested
+        raw_dump = db_sampling.get_raw_dump(
+            crash_id,
+            'fred'
+        )
+
+        # this is what should have happened
+        ok_(fake_dump is raw_dump)
+        db_sampling._implementation.get_raw_dump.assert_called_with(
+            crash_id,
+            'fred'
+        )
+
+    #--------------------------------------------------------------------------
+    def test_get_raw_dumps(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+        fake_raw_dumps = MemoryDumpsMapping({
+            'upload_file_minidump':
+                'contents of dump 86b58ff2-9708-487d-bfc4-9dac32121214'
+        })
+        mocked_get_raw_dumps = Mock(return_value=fake_raw_dumps)
+        db_sampling._implementation.get_raw_dumps = mocked_get_raw_dumps
+
+        # the call to be tested
+        raw_dumps = db_sampling.get_raw_dumps(crash_id)
+
+        # this is what should have happened
+        ok_(fake_raw_dumps is raw_dumps)
+        db_sampling._implementation.get_raw_dumps.assert_called_with(crash_id)
+
+    #--------------------------------------------------------------------------
+    def test_get_raw_dumps_as_files(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+        fake_dumps_as_files = FileDumpsMapping({
+            'upload_file_minidump':
+                '86b58ff2-9708-487d-bfc4-9dac32121214'
+                '.upload_file_minidump.TEMPORARY.dump'
+        })
+        mocked_get_raw_dumps_as_files = Mock(return_value=fake_dumps_as_files)
+        db_sampling._implementation.get_raw_dumps_as_files = \
+            mocked_get_raw_dumps_as_files
+
+        # the call to be tested
+        raw_dumps_as_files = db_sampling.get_raw_dumps_as_files(crash_id)
+
+        # this is what should have happened
+        ok_(fake_dumps_as_files is raw_dumps_as_files)
+        db_sampling._implementation.get_raw_dumps_as_files \
+            .assert_called_with(crash_id)
+
+    #--------------------------------------------------------------------------
+    def test_get_processed(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+        fake_processed = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+
+        mocked_get_processed = Mock(return_value=fake_processed)
+        db_sampling._implementation.get_processed = mocked_get_processed
+
+        # the call to be tested
+        processed = db_sampling.get_processed(crash_id)
+
+        # this is what should have happened
+        ok_(fake_processed is processed)
+        db_sampling._implementation.get_processed.assert_called_with(crash_id)
+
+    #--------------------------------------------------------------------------
+    def test_get_unredacted_processed(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+        fake_processed = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+
+        mocked_get_processed = Mock(return_value=fake_processed)
+        db_sampling._implementation.get_unredacted_processed = \
+            mocked_get_processed
+
+        # the call to be tested
+        processed = db_sampling.get_unredacted_processed(crash_id)
+
+        # this is what should have happened
+        ok_(fake_processed is processed)
+        db_sampling._implementation.get_unredacted_processed \
+            .assert_called_with(crash_id)
+
+    #--------------------------------------------------------------------------
+    def test_remove(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+
+        # the call to be tested
+        db_sampling.remove(crash_id)
+
+        # this is what should have happened
+        db_sampling._implementation.remove \
+            .assert_called_with(crash_id)
+
+    #--------------------------------------------------------------------------
+    def test_save_raw_crash(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+
+        fake_raw_crash = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+        fake_dumps = MemoryDumpsMapping({
+            'upload_file_minidump':
+                '86b58ff2-9708-487d-bfc4-9dac32121214'
+                '.upload_file_minidump.TEMPORARY.dump'
+        })
+
+        # the call to be tested
+        db_sampling.save_raw_crash(
+            fake_raw_crash,
+            fake_dumps,
+            crash_id
+        )
+
+        # this is what should have happened
+        db_sampling._implementation.save_raw_crash.assert_called_once_with(
+            fake_raw_crash,
+            fake_dumps,
+            crash_id
+        )
+
+    #--------------------------------------------------------------------------
+    def test_save_raw_crash_with_file_dumps(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+
+        fake_raw_crash = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+        fake_dumps_as_files = FileDumpsMapping({
+            'upload_file_minidump':
+                '86b58ff2-9708-487d-bfc4-9dac32121214'
+                '.upload_file_minidump.TEMPORARY.dump'
+        })
+
+        # the call to be tested
+        db_sampling.save_raw_crash_with_file_dumps(
+            fake_raw_crash,
+            fake_dumps_as_files,
+            crash_id
+        )
+
+        # this is what should have happened
+        db_sampling._implementation.save_raw_crash_with_file_dumps \
+            .assert_called_once_with(
+                fake_raw_crash,
+                fake_dumps_as_files,
+                crash_id
+            )
+
+    #--------------------------------------------------------------------------
+    def test_save_processed(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+
+        fake_processed = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+
+        # the call to be tested
+        db_sampling.save_processed(fake_processed)
+
+        # this is what should have happened
+        db_sampling._implementation.save_processed.assert_called_once_with(
+            fake_processed
+        )
+
+    #--------------------------------------------------------------------------
+    def test_save_raw_and_processed(self):
+        config = self.get_standard_config()
+        db_sampling = DBCrashStorageWrapperNewCrashSource(config)
+        crash_id = '86b58ff2-9708-487d-bfc4-9dac32121214'
+
+        fake_raw_crash = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+        fake_dumps_as_files = FileDumpsMapping({
+            'upload_file_minidump':
+                '86b58ff2-9708-487d-bfc4-9dac32121214'
+                '.upload_file_minidump.TEMPORARY.dump'
+        })
+        fake_processed = SocorroDotDict({
+            "name": "Gabi",
+            "submitted_timestamp": "2012-12-14T00:00:00"
+        })
+
+        # the call to be tested
+        db_sampling.save_raw_and_processed(
+            fake_raw_crash,
+            fake_dumps_as_files,
+            fake_processed,
+            crash_id
+        )
+
+        # this is what should have happened
+        db_sampling._implementation.save_raw_and_processed \
+            .assert_called_once_with(
+                fake_raw_crash,
+                fake_dumps_as_files,
+                fake_processed,
+                crash_id
+            )
+
+
+#==============================================================================
+class TestPGPVNewCrashSource(NewCrashSourceTestBase):
+
+    #--------------------------------------------------------------------------
+    def get_standard_config(self):
+        config = super(
+            TestPGPVNewCrashSource,
+            self
+        ).get_standard_config()
+        config.crash_id_query = (
+            "select uuid "
+            "from reports_clean rc join product_versions pv "
+            "    on rc.product_version_id = pv.product_version_id "
+            "where "
+            "%s <= date_processed and date_processed < %s"
+            "and %s between pv.build_date and pv.sunset_date"
+        )
+        config.date = date(2015, 10, 18)
+        return config
+
+    #--------------------------------------------------------------------------
+    def test_init_and_close(self):
+        config = self.get_standard_config()
+
+        # the calls to be tested
+        a_new_crash_source = PGPVNewCrashSource(config, name='fred')
+        a_new_crash_source.close()
+
+        # this is what should have happened
+        ok_(a_new_crash_source.config is config)
+        config.database_class.assert_called_once_with(config)
+        config.transaction_executor_class.assert_called_once_with(
+            config,
+            a_new_crash_source.database,
+            quit_check_callback=None
+        )
+        a_new_crash_source.database.close.assert_called_once_with()
+        eq_(
+            a_new_crash_source.data,
+            (
+                date(2015, 10, 18),
+                date(2015, 10, 19),
+                date(2015, 10, 18),
+            )
+        )
+        eq_(
+            a_new_crash_source.crash_id_query,
+            config.crash_id_query
+        )

--- a/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
+++ b/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
@@ -39,14 +39,14 @@ class TestConnection(TestCase):
     #--------------------------------------------------------------------------
     def test_constructor(self):
         config = self._setup_config()
-        ncs = RMQNewCrashSource(config, "ignored_processor_name")
+        ncs = RMQNewCrashSource(config, name="ignored_processor_name")
         ok_(isinstance(ncs.crash_store, FakeCrashStore))
         ok_(ncs.crash_store.config is config)
 
     #--------------------------------------------------------------------------
     def test__iter__(self):
         config = self._setup_config()
-        ncs = RMQNewCrashSource(config, "ignored_processor_name")
+        ncs = RMQNewCrashSource(config)
         for i, (args, kwargs) in zip(range(10), ncs()):
             crash_id = args[0]
             eq_(str(i), crash_id)

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -123,11 +123,11 @@ class TestBase(TestCase):
                    .side_effect = open_function
                 crashstorage.save_raw_crash_with_file_dumps(
                     "fake raw crash",
-                    {
+                    FileDumpsMapping({
                         'one': 'eins',
                         'two': 'zwei',
                         'three': 'drei'
-                    },
+                    }),
                     'fake_id'
                 )
 

--- a/socorro/unittest/lib/test_converters.py
+++ b/socorro/unittest/lib/test_converters.py
@@ -1,7 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from nose.tools import eq_, ok_
 
 from configman import ConfigurationManager, RequiredConfig, Namespace
-from configman.converters import to_str, str_to_python_object
+from configman.converters import to_str
 
 from socorro.lib.converters import (
     str_to_classes_in_namespaces_converter,
@@ -218,6 +222,7 @@ class TestConverters(TestCase):
             self.assertEqual(a_class_name, a_class.__name__)
             self.assertEqual(ns_name, "%s_%02d" % (a_class_name, i))
 
+    #--------------------------------------------------------------------------
     def test_change_default(self):
         class Alpha(RequiredConfig):
             required_config = Namespace()
@@ -246,6 +251,7 @@ class TestConverters(TestCase):
             19
         )
 
+    #--------------------------------------------------------------------------
     def test_web_services_from_str(self):
         some_services_as_string = """[
             {


### PR DESCRIPTION
The correlation reports feed on data about specific Product/Versions.  In their original form, they read from a tar file of all the day's processed crashes.  Since in their new form they are in an FTS app, they can use a crash_iter that is more targeted.

Create a new_crash_source module for Postgres that accepts a list of Products/Versions in this form:  "Firefox, 41.0.1, 42.0, 43.0a3; Thunderbird, 38.1.0, 38.2.0; ...".  From that, create a query that will target just those crashes and then offer the stream of crash_ids as an iterator for an FTS app.  

There are at least two other new_crash_source iterators floating around in the Socorro source code.  Consolidate all of these into one module called socorro.external.postgresql.new_crash_source