### PR TITLE
fixes bug 1219776 - Remove beta hack on crashes per user

### DIFF
--- a/socorro/unittest/external/postgresql/test_adi.py
+++ b/socorro/unittest/external/postgresql/test_adi.py
@@ -25,7 +25,7 @@ class IntegrationTestADI(PostgreSQLTestCase):
         yesterday = self.date - datetime.timedelta(hours=24)
         products = ('Firefox', 'Thunderbird')
 
-        versions = ('39.0', '40.0')
+        versions = ('39.0b1', '40.0')
         platforms = ('Linux', 'Windows')
         channels = ('release', 'beta')
 
@@ -178,3 +178,28 @@ class IntegrationTestADI(PostgreSQLTestCase):
             'version': '40.0',
             'build_type': 'release'
         })
+
+        stats = impl.get(
+            start_date=start,
+            end_date=end,
+            product='Firefox',
+            versions=['39.0b'],
+            platforms=['Linux', 'Windows'],
+        )
+        eq_(stats['total'], 1)
+        hit, = stats['hits']
+        eq_(hit, {
+            'adi_count': 4 + 1L,
+            'date': start_formatted,
+            'version': '39.0b1',
+            'build_type': 'release'
+        })
+
+        stats = impl.get(
+            start_date=start,
+            end_date=end,
+            product='Firefox',
+            versions=['39.0b', '40.0'],
+            platforms=['Linux', 'Windows'],
+        )
+        eq_(stats['total'], 2)


### PR DESCRIPTION
Wow! I can't believe we let the new `Crashes per User` be landed without tests. 

So there's two big changes here. 

1. Test coverage of the `crashes_per_user`. One when everything is normal. And one when one of the requested versions is one of those "beta" releases. I.e. it ends with a "b". 

2. "Explosion and compression". Basically, when the user requests to see the data for version "XX.b", before doing the ADI query *and* the SuperSearch query, I look into the known list of current releases for all other versions that start with "XX.b" but is not "XX.b". So basically, if the request is `?p=Firefox&version=19.0&version=18.0b` instead of doing the queries on `versions=['19.0', '18.0b']` I convert that to `versions=['19.0', '18.0b1', '18.0b2', '18.0bn', ...]`. And when the results come back, I compress them back all under the version "18.0b". E.g. instead of `[{'count': 20, 'term': '18.0b1'}, {'count': 30, 'term': '18.0b2'}]` it becomes `[{'count': 20 + 30, 'term': '18.0b'}]`. 

I'm sorry that the PR looks big and scary. Be sure to run it locally and compare the numbers for 42.0b on the old and the new daily reports. It adds up on my screen. 
![screenshot 2015-10-29 13 36 57](https://cloud.githubusercontent.com/assets/26739/10833825/15a36cd2-7e52-11e5-9999-abbcb8340ca3.png)
