### PR TITLE
unify close behavior for FTS source/destination & TransformRules

### DIFF
--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -284,6 +284,9 @@ class TransformRule(Rule):
         else:
             return False
 
+    #--------------------------------------------------------------------------
+    def close(self):
+        pass
 
 #==============================================================================
 class TransformRuleSystem(RequiredConfig):
@@ -470,6 +473,15 @@ class TransformRuleSystem(RequiredConfig):
             if not predicate_result:
                 return False
         return None
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        for a_rule in self.rules:
+            try:
+                a_rule.close()
+            except AttributeError:
+                # no close method mean no need to close
+                pass
 
 
 #------------------------------------------------------------------------------

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -285,3 +285,15 @@ class Processor2015(RequiredConfig):
             'successful' if success else 'failed',
             crash_id
         )
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        for a_rule_set_name, a_rule_set in self.rule_system.iteritems():
+            self.config.logger.debug('closing %s', a_rule_set_name)
+            try:
+                a_rule_set.close()
+            except AttributeError:
+                # guess we don't need to close that rule
+                pass
+        self.config.logger.debug('done closing rules')
+

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -171,10 +171,20 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         )
 
     #--------------------------------------------------------------------------
-    def _cleanup(self):
+    def close(self):
         """when  the processor shutsdown, this function cleans up"""
-        if self.companion_process:
+        try:
             self.companion_process.close()
+        except AttributeError:
+            # there is either no companion or it doesn't have a close method
+            # we can skip on
+            pass
+        try:
+            self.processor.close()
+        except AttributeError:
+            # the processor implementation does not have a close method
+            # we can blithely skip on
+            pass
 
 
 if __name__ == '__main__':

--- a/socorro/unittest/collector/test_crash_mover_app.py
+++ b/socorro/unittest/collector/test_crash_mover_app.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from nose.tools import eq_, ok_, assert_raises
+from mock import Mock
 
 from socorro.collector.crashmover_app import CrashMoverApp
 from socorro.lib.threaded_task_manager import ThreadedTaskManager
@@ -19,6 +20,8 @@ class TestCrashMoverApp(TestCase):
                 self.the_list = []
 
             def _setup_source_and_destination(self):
+                self.source = Mock()
+                self.destination = Mock()
                 pass
 
             def _basic_iterator(self):
@@ -74,6 +77,10 @@ class TestCrashMoverApp(TestCase):
                                                        'Product': 'Fennicky',
                                                        'Version': '1.0'}),
                                      })
+                self.number_of_close_calls = 0
+
+            def close():
+                self.number_of_close_calls += 1
 
             def get_raw_crash(self, ooid):
                 return self.store[ooid]
@@ -86,15 +93,23 @@ class TestCrashMoverApp(TestCase):
                 for k in self.store.keys():
                     yield k
 
+            def close(self):
+                self.number_of_close_calls += 1
+                pass
+
         class FakeStorageDestination(object):
 
             def __init__(self, config, quit_check_callback):
                 self.store = DotDict()
                 self.dumps = DotDict()
+                self.number_of_close_calls = 0
 
             def save_raw_crash(self, raw_crash, dumps, crash_id):
                 self.store[crash_id] = raw_crash
                 self.dumps[crash_id] = dumps
+
+            def close(self):
+                self.number_of_close_calls += 1
 
         logger = SilentFakeLogger()
         config = DotDict({
@@ -124,6 +139,10 @@ class TestCrashMoverApp(TestCase):
         eq_(len(destination.dumps), 4)
         eq_(destination.dumps['1237'],
                          source.get_raw_dumps('1237'))
+
+        # ensure that each storage system had its close called
+        eq_(source.number_of_close_calls, 1)
+        eq_(destination.number_of_close_calls, 1)
 
     def test_source_iterator(self):
 


### PR DESCRIPTION
three inheritance trees, FTS Apps, Crashstorge and Transform classes all have their own ways to shut themselves down.  Unify them all to use a simple 'close' method.  This makes them more compatible with each other, predictable and helps them move toward being contextmanager compatible.
