### PR TITLE
fixes bug 1223949 - New relic configuration to wsgi file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -184,3 +184,5 @@ datadog==0.5.0
 # sha256: x4ZXPEj73ejlDlVeXiWoNkQ-Zm1sz_bLDSAIYVNYsOM
 # sha256: 7lmy7t1AEe6q6Kle7DGql37DVd9_TsoQZ_QCy3lCngo
 freezegun==0.3.5
+# sha256: tYAUqlZA40Vup9vzPxUaHEud9HKJdocwwKAwYaRxOGU
+newrelic==2.56.0.42

--- a/webapp-django/wsgi/socorro-crashstats.py
+++ b/webapp-django/wsgi/socorro-crashstats.py
@@ -4,3 +4,16 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crashstats.settings')
 
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
+
+
+try:
+    import newrelic.agent
+except ImportError:
+    newrelic = False
+
+
+if newrelic:
+    newrelic_ini = os.getenv('NEWRELIC_PYTHON_INI_FILE', None)
+    if newrelic_ini:
+        newrelic.agent.initialize(newrelic_ini)
+        application = newrelic.agent.wsgi_application()(application)


### PR DESCRIPTION
Here's how I run the webapp locally WITH newrelic enabled 

```
NEWRELIC_PYTHON_INI_FILE=~/dev/MOZILLA/CORRO/newrelic.ini    \
DJANGO_SETTINGS_MODULE=crashstats.settings uwsgi --pythonpath   \
  ./webapp-django/ -w webapp-django.wsgi.socorro-crashstats   \
  --http :9090 -H ~/virtualenvs/socorro
```
I don't know how to check that bits are actually sent to newrelic.com but I put some print statements in to test and it did seem to configure without any problems. 