### PR TITLE
fixes bug 1226359 - Fail more gracefully if the NEWRELIC_PYTHON_INI_FILE doesn't exist

### DIFF
--- a/webapp-django/wsgi/socorro-crashstats.py
+++ b/webapp-django/wsgi/socorro-crashstats.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'crashstats.settings')
 
@@ -15,5 +16,11 @@ except ImportError:
 if newrelic:
     newrelic_ini = os.getenv('NEWRELIC_PYTHON_INI_FILE', None)
     if newrelic_ini:
-        newrelic.agent.initialize(newrelic_ini)
-        application = newrelic.agent.wsgi_application()(application)
+        if os.path.isfile(newrelic_ini):
+            newrelic.agent.initialize(newrelic_ini)
+            application = newrelic.agent.wsgi_application()(application)
+        else:
+            print >>sys.stderr, (
+                "NEWRELIC_PYTHON_INI_FILE set but file does not exist. "
+                "Skipping to initialize newrelic agent."
+            )


### PR DESCRIPTION
I checked that this worked by running:

```
NEWRELIC_PYTHON_INI_FILE=xxxxxxewrelic.ini \
 DJANGO_SETTINGS_MODULE=crashstats.settings uwsgi --pythonpath   \
  ./webapp-django/ -w webapp-django.wsgi.socorro-crashstats     --http :8000\
 -H ~/virtualenvs/socorro -M --need-app --workers 3
```

And it spat this out:
```
...
mapped 291040 bytes (284 KB) for 3 cores
*** Operational MODE: preforking ***
added ./webapp-django/ to pythonpath.
NEWRELIC_PYTHON_INI_FILE set but file does not exist. Skipping to initialize newrelic agent.
WSGI app 0 (mountpoint='') ready in 1 seconds on interpreter 0x7f7f6a600830 pid: 67248 (default app)
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 67248)
spawned uWSGI worker 1 (pid: 67249, cores: 1)
spawned uWSGI worker 2 (pid: 67250, cores: 1)
spawned uWSGI worker 3 (pid: 67251, cores: 1)
spawned uWSGI http 1 (pid: 67252)
```
