### PR TITLE
fixes bug 1227685 - CurrentProducts.get is called too much

### DIFF
--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -87,7 +87,6 @@ class ReportListForm(BaseForm):
     signature = form_fields.SignatureField(required=True)
     product = forms.MultipleChoiceField(required=False)
     version = forms.MultipleChoiceField(required=False)
-    platform = forms.MultipleChoiceField(required=False)
     date = forms.DateTimeField(required=False)
     range_value = forms.IntegerField(required=False)
     reason = forms.CharField(required=False)
@@ -115,12 +114,10 @@ class ReportListForm(BaseForm):
     )
     plugin_query = forms.CharField(required=False)
 
-    def __init__(self, current_products, current_versions, current_platforms,
-                 *args, **kwargs):
+    def __init__(self, current_products, current_versions, *args, **kwargs):
         super(ReportListForm, self).__init__(*args, **kwargs)
 
         # Default values
-        platforms = [(x['code'], x['name']) for x in current_platforms]
         products = [(x, x) for x in current_products]
         versions = [(self.all_param, self.all_param)]
         for version in current_versions:
@@ -129,7 +126,6 @@ class ReportListForm(BaseForm):
 
         self.fields['product'].choices = products
         self.fields['version'].choices = versions
-        self.fields['platform'].choices = platforms
 
     def clean_version(self):
         versions = self.cleaned_data['version']

--- a/webapp-django/crashstats/crashstats/tests/test_forms.py
+++ b/webapp-django/crashstats/crashstats/tests/test_forms.py
@@ -40,20 +40,6 @@ class TestForms(DjangoTestCase):
                 "release": "Beta"
             }
         ]
-        self.current_platforms = [
-            {
-                'code': 'windows',
-                'name': 'Windows'
-            },
-            {
-                'code': 'mac',
-                'name': 'Mac OS X'
-            },
-            {
-                'code': 'linux',
-                'name': 'Linux'
-            }
-        ]
         self.current_channels = (
             'release',
             'beta',
@@ -68,7 +54,6 @@ class TestForms(DjangoTestCase):
             return forms.ReportListForm(
                 self.current_products,
                 self.current_versions,
-                self.current_platforms,
                 data
             )
 
@@ -101,12 +86,6 @@ class TestForms(DjangoTestCase):
 
         form = get_new_form({
             'signature': 'sig',
-            'platform': ['winux']
-        })
-        ok_(not form.is_valid())  # invalid platform
-
-        form = get_new_form({
-            'signature': 'sig',
             'plugin_query_type': 'invalid'
         })
         ok_(not form.is_valid())  # invalid query type
@@ -123,7 +102,6 @@ class TestForms(DjangoTestCase):
             'signature': 'sig',
             'product': ['WaterWolf', 'SeaMonkey', 'NightTrain'],
             'version': ['WaterWolf:20.0'],
-            'platform': ['linux', 'mac'],
             'date': '01/02/2012 12:23:34',
             'range_unit': 'weeks',
             'range_value': 12,
@@ -142,7 +120,6 @@ class TestForms(DjangoTestCase):
         ok_(isinstance(form.cleaned_data['range_value'], int))
         ok_(isinstance(form.cleaned_data['product'], list))
         ok_(isinstance(form.cleaned_data['version'], list))
-        ok_(isinstance(form.cleaned_data['platform'], list))
 
         # Test default values
         form = get_new_form({'signature': 'sig',
@@ -154,7 +131,6 @@ class TestForms(DjangoTestCase):
 
         eq_(form.cleaned_data['product'], [])
         eq_(form.cleaned_data['version'], [])
-        eq_(form.cleaned_data['platform'], [])
         eq_(form.cleaned_data['range_unit'], 'weeks')
         eq_(form.cleaned_data['process_type'], 'any')
         eq_(form.cleaned_data['hang_type'], 'any')
@@ -166,7 +142,6 @@ class TestForms(DjangoTestCase):
             return forms.ReportListForm(
                 self.current_products,
                 self.current_versions,
-                self.current_platforms,
                 data
             )
 

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1828,11 +1828,9 @@ def report_pending(request, crash_id):
 @pass_default_context
 def report_list(request, partial=None, default_context=None):
     context = default_context or {}
-
     form = forms.ReportListForm(
-        models.ProductsVersions().get(),
-        models.CurrentVersions().get(),
-        models.Platforms().get(),
+        context['currentproducts']['hits'],
+        context['currentversions'],
         request.GET
     )
     if not form.is_valid():
@@ -2005,7 +2003,6 @@ def report_list(request, partial=None, default_context=None):
             signature=context['signature'],
             products=context['selected_products'],
             versions=context['product_versions'],
-            os=form.cleaned_data['platform'],
             start_date=start_date,
             end_date=end_date,
             build_ids=form.cleaned_data['build_id'],
@@ -2177,7 +2174,6 @@ def report_list(request, partial=None, default_context=None):
             signature=context['signature'],
             products=form.cleaned_data['product'],
             versions=context['product_versions'],
-            os=form.cleaned_data['platform'],
             start_date=start_date,
             end_date=end_date,
             build_ids=form.cleaned_data['build_id'],
@@ -2262,12 +2258,10 @@ def report_list(request, partial=None, default_context=None):
             {'value': x[0], 'label': x[1], 'default': x[2]}
             for x in ALL_REPORTS_COLUMNS
         ]
-
         super_search_params = get_super_search_style_params(
             signature=context['signature'],
             product=context['selected_products'],
             version=context['product_versions'],
-            platform=form.cleaned_data['platform'],
             start_date=start_date,
             end_date=end_date,
         )
@@ -2478,11 +2472,12 @@ def plot_signature(request, product, versions, start_date, end_date,
     return graph_data
 
 
-def signature_summary(request):
-
+@pass_default_context
+def signature_summary(request, default_context=None):
+    context = default_context or {}
     form = forms.SignatureSummaryForm(
-        models.ProductsVersions().get(),
-        models.CurrentVersions().get(),
+        context['currentproducts']['hits'],
+        context['currentversions'],
         request.GET
     )
 
@@ -2737,11 +2732,13 @@ def raw_data(request, crash_id, extension, name=None):
 
 
 @utils.json_view
-def correlations_json(request):
+@pass_default_context
+def correlations_json(request, default_context=None):
+    context = default_context or {}
 
     form = forms.CorrelationsJSONForm(
-        models.ProductsVersions().get(),
-        models.CurrentVersions().get(),
+        context['currentproducts']['hits'],
+        context['currentversions'],
         models.Platforms().get(),
         request.GET
     )
@@ -2776,11 +2773,13 @@ def correlations_json(request):
 
 
 @utils.json_view
-def correlations_signatures_json(request):
+@pass_default_context
+def correlations_signatures_json(request, default_context=None):
+    context = default_context or {}
 
     form = forms.CorrelationsSignaturesJSONForm(
-        models.ProductsVersions().get(),
-        models.CurrentVersions().get(),
+        context['currentproducts']['hits'],
+        context['currentversions'],
         models.Platforms().get(),
         request.GET
     )


### PR DESCRIPTION
It's still bad, but it's a LOT better now. 

Before:
<img width="1372" alt="before" src="https://cloud.githubusercontent.com/assets/26739/11399748/44c27836-9357-11e5-9a20-05122487357e.png">
**53 `memcache.get` calls**

After:
<img width="1375" alt="after" src="https://cloud.githubusercontent.com/assets/26739/11399750/495322ce-9357-11e5-9376-844785d0b1e3.png">
**30 `memcache.get` calls**

What this is, is the metric for rendering 1 Report list page of a randomly picked signature. 

So why does it still need 13 calls just render 1 page? It loads one AJAX call for every tab (which is a good thing) and each time it needs to verify that the product and version supplied in the AJAX URL's query string is sane. 

This is going to make for much less memcache IO and it's going to make the Report list page faster.
There's still more "deeper" work that can be done but considering that the Report list a slowly dying feature it's not worth going further at the moment. 