### PR TITLE
Fixes bug 1221048 - Fixed link to Plugin Topcrashers in home page.

### DIFF
--- a/webapp-django/crashstats/crashstats/templates/crashstats/home.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/home.html
@@ -61,7 +61,7 @@ Crash Data for {{ product }} {% if version %}{{ version }}{% endif %}
                             </a>
                         </li>
                         <li>
-                            <a href="{{ url('topcrashers:topcrashers') }}?product={{ product }}&amp;versions={{ version }}&amp;crash_type=plugin&amp;days={{days}}">
+                            <a href="{{ url('topcrashers:topcrashers') }}?product={{ product }}&amp;versions={{ version }}&amp;process_type=plugin&amp;days={{days}}">
                                 Top Plugin Crashers
                             </a>
                         </li>


### PR DESCRIPTION
@peterbe somehow I missed that during my local tests and found only on stage just now. r?