### PR TITLE
Bug 1231796 - Update forced versions for correlations for Firefox cycle starting 2015-12-14

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="42.0b99 43.0b1 43.0b2 43.0b3 43.0b4 43.0b5 43.0b6 43.0b7 43.0b8 43.0b9 43.0b99 44.0a2 45.0a1"
+MANUAL_VERSION_OVERRIDE="44.0b1 44.0b2 44.0b3 44.0b4 44.0b5 44.0b6 44.0b7 44.0b8 44.0b9 44.0b99 45.0a2 46.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This adds current aurora and nightly versions as well as all planned beta versions for this cycle, and should land on prod early next week (2015-12-14 or closely after).

Note that need to update the crashanalysis node with that code (and make sure this version of the script is actually being run) to actually make it live.
