### PR TITLE
fixes bug 1227237 - Upgrade raven and track releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,8 +60,9 @@ elasticsearch-dsl==0.0.8
 urllib3==1.9.1
 # sha256: cHay6ATFKumO3svU3B-8qBMYb-f1_dYlR4OgClWntEI
 elasticutils==0.7
-# sha256: wn5AqzzPN_MKn3estJFzcNk0HiWr2o6Uub1IxxJ_fUg
-raven==3.4.1
+# sha256: NizKbyluEUlgRjuihg4eXXDEGmc3OJ6zE73mFBcTcao
+# sha256: xUXIu2A70Kc3PpdgxvsWuwZX1vNW7RIQy7lM5Bjzc74
+raven==5.9.0
 # sha256: KjGJ950ce4ohSaDng8C0IX-tmzCm59YEUPJVPcLA5X4
 simplejson==3.6.5
 # sha256: HwRtz17HEu076GhLnzPJW3bijNHIJdsPXhVXv9h7N0U
@@ -186,3 +187,5 @@ datadog==0.5.0
 freezegun==0.3.5
 # sha256: tYAUqlZA40Vup9vzPxUaHEud9HKJdocwwKAwYaRxOGU
 newrelic==2.56.0.42
+# sha256: VaXcePenQqDnVmRRNP-zm74R2g_qK8D3Bw1A2sIItzI
+contextlib2==0.4.0

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -4,6 +4,7 @@
 
 import os
 import logging
+from pkg_resources import resource_string
 
 import dj_database_url
 from decouple import config, Csv
@@ -643,11 +644,22 @@ CEF_VENDOR = config('CEF_VENDOR', 'Mozilla')
 # then set this to False
 SESSION_COOKIE_SECURE = config('SESSION_COOKIE_SECURE', True, cast=bool)
 
-# To get your Sentry key, go to https://errormill.mozilla.org/
-RAVEN_CONFIG = {
-    'dsn': config('RAVEN_DSN', '')  # see https://errormill.mozilla.org/
-}
+# When socorro is installed (python setup.py install), it will create
+# a file in site-packages for socorro called "socorro/socorro_revision.txt".
+# If this socorro was installed like that, let's pick it up and use it.
+try:
+    SOCORRO_REVISION = resource_string('socorro', 'socorro_revision.txt')
+except IOError:
+    SOCORRO_REVISION = None
 
+# Raven sends errors to Sentry.
+# The release is optional.
+raven_dsn = config('RAVEN_DSN', '')
+if raven_dsn:
+    RAVEN_CONFIG = {
+        'dsn': raven_dsn,
+        'release': SOCORRO_REVISION,
+    }
 
 # Specify the middleware implementation to use in the middleware
 SEARCH_MIDDLEWARE_IMPL = config('SEARCH_MIDDLEWARE_IMPL', 'elasticsearch')


### PR DESCRIPTION
The reason I'm confident this'll work is because I managed to send [this in](https://sentry.prod.mozaws.net/operations/socorro-stage/group/155635/) 
That's from my laptop using the socorro stage project. Scroll down to the bottom and you can see that I clearly used raven 5.9.0. 

As of this version of raven we'd now be able to append a version for all crashes. Look at [the second code example here](https://docs.getsentry.com/hosted/clients/python/advanced/). [Here](https://docs.getsentry.com/hosted/clients/python/integrations/django/)'s how you do it in Django. The problem is that can only get that version out of the middleware at runtime. Not when the uwsgi workers are starting up. I'll ask @jdotpz if he has some good ideas. 