### PR TITLE
fixes bug 1233194 - 6 uwsgi workers for webheads

### DIFF
--- a/config/package/usr/lib/systemd/system/socorro-webapp.service
+++ b/config/package/usr/lib/systemd/system/socorro-webapp.service
@@ -3,7 +3,7 @@ Description=Socorro Webapp
 
 [Service]
 Environment=VENV=/data/socorro/socorro-virtualenv
-ExecStart=/bin/bash -c "envconsul -upcase=false -prefix socorro/common -prefix socorro/webapp-django $VENV/bin/uwsgi --pythonpath /data/socorro/webapp-django/ -M --need-app -w webapp-django.wsgi.socorro-crashstats -s /var/run/uwsgi/socorro/socorro-webapp.sock --chmod-socket=664 --uid=socorro --gid=nginx"
+ExecStart=/bin/bash -c "envconsul -upcase=false -prefix socorro/common -prefix socorro/webapp-django $VENV/bin/uwsgi --pythonpath /data/socorro/webapp-django/ -M --need-app -w webapp-django.wsgi.socorro-crashstats -s /var/run/uwsgi/socorro/socorro-webapp.sock --chmod-socket=664 --uid=socorro --gid=nginx -p 6"
 Restart=always
 
 [Install]


### PR DESCRIPTION
Perhaps now's not the time but I'm going to see about [uwsgitop](https://github.com/xrmx/uwsgitop)
You need to start uwsgi with `--stats`.

I noticed that our memory usage on all three webheads hovers steadily around 1Gb at the time of writing. Our m3.xlarge instances have [15Gb of ram](https://aws.amazon.com/ec2/instance-types/) and I noticed that at the time of writing free tells me we have 14Gb total and we use 1Gb. 
So let's see what those numbers are when we go to a higher number of processes (aka. workers).