### PR TITLE
fixes bug 1230925 - Switch from django-compressor to django-pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ services:
   - memcached
 
 before_install:
-  - npm install -g less
   - gem install puppet puppet-lint
   - ./scripts/start-travis-elasticsearch.sh
 

--- a/docs/development/dev-services.rst
+++ b/docs/development/dev-services.rst
@@ -203,10 +203,6 @@ Install dependencies
   sudo pip-2.7 install docutils
   brew install mercurial
 
-Install lessc
-::
-  sudo npm install -g less
-
 Set your PATH
 ::
   export PATH=/usr/local/bin:/usr/local/sbin:$PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,9 +144,6 @@ https://github.com/jsocol/commonware/archive/b554418.zip#egg=commonware
 cef==0.5
 # sha256: aLzPfWX4LppstFym1qD3o35lVH9HUNrrmjq9wcvd9hI
 https://github.com/mozilla/nuggets/archive/ce50688.zip#egg=nuggets
-# sha256: uhN1-xAk6OkVR1BNQ5IyF5XJif3lALluvHyTiE94bmA
-# sha256: PZvJY9gAiuFR1sZk-f1VRCcF6puebXznfN1Av5LZHzo
-django-appconf==1.0.1
 # sha256: UE5EGWeseGBKs18DABj8mm-icOam6YRx0jEf139wZ0s
 # sha256: smA0Iw78731g5SZ4kO2mVt_EnFZ_JxJdkH7uT-f5puw
 django-compressor==1.4
@@ -189,3 +186,9 @@ freezegun==0.3.5
 newrelic==2.56.0.42
 # sha256: VaXcePenQqDnVmRRNP-zm74R2g_qK8D3Bw1A2sIItzI
 contextlib2==0.4.0
+# sha256: xxHohhXvN7I1nOMJeOrnxl5UkkrrBDIpZWxeI5Bl5ZY
+# sha256: pakJ9APQ6lbyEWGJSf9ON48W5amWvegZvStbDnqbuP4
+django-pipeline==1.5.4
+# sha256: BK-ioGq33MqdgXF7Qgp6FIJgYemyYUpcd90kx1zPl-Q
+# sha256: L-I0K7T-i44hfw0htZIcvlQIv5Ztn5ICXnB-iBsZi-0
+futures==3.0.3

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,10 +6,6 @@ source scripts/defaults
 
 git submodule update --init --recursive
 
-if [[ ! "$(type -p lessc)" ]]; then
-    printf "\e[0;32mlessc not found! less must be installed and lessc on your path to build socorro.\e[0m\n" && exit 1
-fi
-
 if [ ! -d "$VIRTUAL_ENV" ]; then
     virtualenv -p $PYTHON ${VIRTUAL_ENV}
 fi

--- a/webapp-django/bin/bootstrap.sh
+++ b/webapp-django/bin/bootstrap.sh
@@ -18,7 +18,9 @@ then
     export COMPRESS_OFFLINE=True
 fi
 
+echo "Install the node packages"
+npm install
+
+echo "Running collectstatic"
+# XXX Should this do something like `rm -fr static; mkdir static`?
 ./manage.py collectstatic --noinput
-# even though COMPRESS_OFFLINE=True COMPRESS becomes (!DEBUG) which
-# will become False so that's why we need to use --force here.
-./manage.py compress --force --engine=jinja2

--- a/webapp-django/crashstats/api/templates/api/documentation.html
+++ b/webapp-django/crashstats/api/templates/api/documentation.html
@@ -6,17 +6,12 @@
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" href="{{ static('api/css/documentation.css') }}" type="text/css">
-{% endcompress %}
+{% stylesheet 'api_documentation' %}
 {% endblock %}
 
 {% block site_js %}
 {{ super() }}
-<script type="text/javascript" src="{{ static('api/js/lib/filesize.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('api/js/testdrive.js') }}"></script>
-{% endcompress %}
+{% javascript 'api_documentation' %}
 {% endblock %}
 
 {% block content %}

--- a/webapp-django/crashstats/base/monkeypatches.py
+++ b/webapp-django/crashstats/base/monkeypatches.py
@@ -6,7 +6,3 @@ def patch():
 
     import session_csrf
     session_csrf.monkeypatch()
-
-    import jingo
-    from compressor.contrib.jinja2ext import CompressorExtension
-    jingo.env.add_extension(CompressorExtension)

--- a/webapp-django/crashstats/base/templates/crashstats_base.html
+++ b/webapp-django/crashstats/base/templates/crashstats_base.html
@@ -6,9 +6,7 @@
         <title>{% block page_title %}Crash Data for {{ product }}{% endblock %}</title>
 
         {% block site_css %}
-            {% compress css %}
-            <link href="{{ static('crashstats/css/screen.less') }}" type="text/less" rel="stylesheet">
-            {% endcompress %}
+            {% stylesheet 'crashstats_base' %}
             {{ browserid_css() }}
         {% endblock %}
     {% if GOOGLE_ANALYTICS_ID %}
@@ -187,12 +185,7 @@
         <br class="clear" />
     </div>
     {% block site_js %}
-    {% compress js %}
-    <script src="{{ static('crashstats/js/jquery/jquery-2.0.3.min.js') }}"></script>
-    <script src="{{ static('crashstats/js/jquery/plugins/jquery.cookies.2.2.0.js') }}"></script>
-    <script src="{{ static('crashstats/js/socorro/nav.js') }}"></script>
-    <script src="{{ static('crashstats/js/socorro/analytics.js') }}"></script>
-    {% endcompress %}
+    {% javascript 'crashstats_base' %}
     {{ browserid_js() }}
     {% endblock %}
   </body>

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/report_index.css
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/report_index.css
@@ -1,0 +1,4 @@
+#details th,
+#metadata th {
+    width: 15%;
+}

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -430,17 +430,9 @@ html.production {
             }
             th.sortable {
                 padding-right: 17px;
-                background: url(../../img/2.0/sort-none.png) no-repeat right center;
             }
             th.sortable:hover {
                 cursor: pointer;
-                background-image: url(../../img/2.0/sort-none-hover.png);
-            }
-            th.sortable.sort-desc {
-                background-image: url(../../img/2.0/sort-desc.png);
-            }
-            th.sortable.sort-asc {
-                background-image: url(../../img/2.0/sort-asc.png);
             }
         }
         tbody {
@@ -717,7 +709,7 @@ div.admin {
 }
 #close_simplebox {
     position:absolute;
-    background:transparent url(/img/icons/close_round.png) 0 0 no-repeat;
+    background:transparent url(../../img/icons/close_round.png) 0 0 no-repeat;
     margin-top:-20px;
     border:0;
     width:30px;
@@ -977,7 +969,7 @@ a.correlation-toggler {
     width: 40px
 }
 a.open-external {
-    background: url(/img/icons/external.png) no-repeat scroll left top transparent;
+    background: url(../../img/icons/external.png) no-repeat scroll left top transparent;
     color: #0A2533;
     margin-left: 20px;
     padding: 2px 0 2px 20px;

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/exploitability.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/exploitability.js
@@ -1,0 +1,4 @@
+$(function () {
+    // Enhance bug links.
+    BugLinks.enhance();
+});

--- a/webapp-django/crashstats/crashstats/templates/crashstats/crashes_per_user.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/crashes_per_user.html
@@ -1,16 +1,9 @@
 {% extends "crashstats_base.html" %}
 {% block site_css %}
     {{ super() }}
-    {% compress css %}
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
-    {% endcompress %}
-    {% compress css %}
-    <link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/crashes_per_user.less') }}">
-    {% endcompress %}
+    {% stylesheet 'jquery_ui' %}
+    {% stylesheet 'metricsgraphics' %}
+    {% stylesheet 'crashes_per_user' %}
 {% endblock %}
 
 {% block page_title %}
@@ -256,15 +249,10 @@ Crashes per User for {{ product }}
 {% block site_js %}
     {{ super() }}
 
-    {% compress js %}
-    <script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-    {% endcompress %}
-
-    {% compress js %}
-    <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-    <script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
-    <script src="{{ static('crashstats/js/socorro/crashes_per_user.js') }}"></script>
-    {% endcompress %}
+    {% javascript 'd3' %}
+    {% javascript 'jquery_ui' %}
+    {% javascript 'metricsgraphics' %}
+    {% javascript 'crashes_per_user' %}
     <script>
     var DATA = {{ graph_data | json_dumps }};
     window.socGraphByReportType = false;

--- a/webapp-django/crashstats/crashstats/templates/crashstats/crontabber_state.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/crontabber_state.html
@@ -6,16 +6,8 @@
 
 {% block site_css %}
   {{ super() }}
-
-  {% compress css %}
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-  {% endcompress %}
-
-  {% compress css %}
-  <link media="screen" href="{{ static('crashstats/css/crontabber_state.css') }}" type="text/css" rel="stylesheet">
-  {% endcompress %}
+  {% stylesheet 'jquery_ui' %}
+  {% stylesheet 'crontabber_state' %}
 {% endblock %}
 
 
@@ -59,12 +51,8 @@
 
 {% block site_js %}
   {{ super() }}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-  <script src="{{ static('crashstats/js/moment.min.js') }}"></script>
-  <script src="{{ static('crashstats/js/underscore-min.js') }}"></script>
-  <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-  {% compress js %}
-  <script src="{{ static('crashstats/js/lib/sankey.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/crontabber_state.js') }}"></script>
-  {% endcompress %}
+  {% javascript 'd3' %}
+  {% javascript 'moment' %}
+  {% javascript 'jquery_tablesorter' %}
+  {% javascript 'crontabber_state' %}
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/daily.html
@@ -2,16 +2,9 @@
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
-{% endcompress %}
-{% compress css %}
-<link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/daily.less') }}">
-{% endcompress %}
+{% stylesheet 'jquery_ui' %}
+{% stylesheet 'metricsgraphics' %}
+{% stylesheet 'daily' %}
 {% endblock %}
 
 {% block page_title %}Crashes per Active Daily Install for {{ product }}{% endblock %}
@@ -232,14 +225,10 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-<script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
-<script src="{{ static('crashstats/js/socorro/daily.js') }}"></script>
-{% endcompress %}
+{% javascript 'd3' %}
+{% javascript 'metricsgraphics' %}
+{% javascript 'jquery_ui' %}
+{% javascript 'daily' %}
 <script>
     var data = {{ graph_data | json_dumps }};
     window.socGraphByReportType = false;

--- a/webapp-django/crashstats/crashstats/templates/crashstats/exploitability.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/exploitability.html
@@ -3,17 +3,9 @@
 {% block page_title %}Exploitable crashes{% endblock %}
 
 {% block site_js %}
-  {{ super() }}
-  {% compress js %}
-  <script src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-  {% endcompress %}
-
-  <script type="text/javascript">
-$(function () {
-    // Enhance bug links.
-    BugLinks.enhance();
-});
-  </script>
+    {{ super() }}
+    {% javascript 'bugzilla' %}
+    {% javascript 'exploitability' %}
 {% endblock %}
 
 {% block content %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/exploitability_report.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/exploitability_report.html
@@ -4,12 +4,8 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script src="{{ static('crashstats/js/socorro/exploitability_report.js') }}"></script>
-{% endcompress %}
+{% javascript 'bugzilla' %}
+{% javascript 'exploitability_report' %}
 {% endblock %}
 
 

--- a/webapp-django/crashstats/crashstats/templates/crashstats/gccrashes.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/gccrashes.html
@@ -1,18 +1,9 @@
 {% extends "crashstats_base.html" %}
 {% block site_css %}
   {{ super() }}
-
-  {% compress css %}
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
-  <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
-  {% endcompress %}
-
-  {% compress css %}
-    <link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/gccrashes.less') }}" media="screen" />
-  {% endcompress %}
+  {% stylesheet 'jquery_ui' %}
+  {% stylesheet 'metricsgraphics' %}
+  {% stylesheet 'gccrashes' %}
 {% endblock %}
 
 {% block page_title %}
@@ -71,15 +62,9 @@ Total Volume of GC Crashes for {{ product }} {{ selected_version }}
 
 {% block site_js %}
   {{ super() }}
-  <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-  <script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
-
-  {% compress js %}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-  {% endcompress %}
-
-  {% compress js %}
-  <script src="{{ static('crashstats/js/socorro/utils.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/gccrashes.js') }}"></script>
-  {% endcompress %}
+  {% javascript 'd3' %}
+  {% javascript 'jquery_ui' %}
+  {% javascript 'metricsgraphics' %}
+  {% javascript 'socorro_utils' %}
+  {% javascript 'gccrashes' %}
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/home.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/home.html
@@ -2,11 +2,7 @@
 
 {% block site_css %}
     {{ super() }}
-
-    {% compress css %}
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/metricsgraphics.css') }}">
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/metricsgraphics_custom.css') }}">
-    {% endcompress %}
+    {% stylesheet 'metricsgraphics' %}
 {% endblock %}
 
 {% block page_title %}
@@ -78,14 +74,9 @@ Crash Data for {{ product }} {% if version %}{{ version }}{% endif %}
 {% endblock %}
 {% block site_js %}
     {{ super() }}
-    {% compress js %}
-    <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-    <script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
-    {% endcompress %}
-
-    {% compress js %}
-    <script src="{{ static('crashstats/js/socorro/utils.js') }}"></script>
-    <script src="{{ static('crashstats/js/socorro/dashboard_graph.js') }}"></script>
-    <script src="{{ static('crashstats/js/socorro/daily.js') }}"></script>
-    {% endcompress %}
+    {% javascript 'd3' %}
+    {% javascript 'metricsgraphics' %}
+    {% javascript 'daily' %}
+    {% javascript 'socorro_utils' %}
+    {% javascript 'home' %}
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_index.html
@@ -2,32 +2,17 @@
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-{% endcompress %}
-{% compress css %}
-<style type="text/css">
-    #details th,
-    #metadata th {
-        width: 15%;
-    }
-</style>
-{% endcompress %}
+{% stylesheet 'jquery_ui' %}
+{% stylesheet 'report_index' %}
 {% endblock %}
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-<script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/correlation.js') }}"></script>
-{% endcompress %}
+{% javascript 'jquery_ui' %}
+{% javascript 'jquery_tablesorter' %}
+{% javascript 'bugzilla' %}
+{% javascript 'correlation' %}
+{% javascript 'report_index' %}
 {% endblock %}
 
 {% block page_title %}[@ {{ report.signature }}] - {{ report.product }} {{ report.version }} Crash Report - Report ID: {{ report.uuid }}{% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/report_list.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/report_list.html
@@ -2,15 +2,8 @@
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-<link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-{% endcompress %}
-{% compress css %}
-<link media="screen" href="{{ static('crashstats/css/report_list.less') }}" type="text/less" rel="stylesheet" />
-<link media="screen" href="{{ static('crashstats/css/accordion.less') }}" type="text/less" rel="stylesheet" />
-{% endcompress %}
+{% stylesheet 'jquery_ui' %}
+{% stylesheet 'report_list' %}
 {% endblock %}
 
 {% block report %}
@@ -182,29 +175,13 @@
 
 {% block site_js %}
 {{ super() }}
-<script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-
-{% compress js %}
-<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-<script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script type="text/javascript" src="{{ static('crashstats/js/jquery/plugins/jquery.cookie.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/correlation.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/lib/awty.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/lib/accordions.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/utils.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_signature_summary.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_graph.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_reports.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_comments.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_correlations.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_sigurls.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_bugzilla.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/report_list_table.js') }}"></script>
-<script type="text/javascript" src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-{% endcompress %}
+{% javascript 'd3' %}
+{% javascript 'jquery_ui' %}
+{% javascript 'jquery_tablesorter' %}
+{% javascript 'correlation' %}
+{% javascript 'bugzilla' %}
+{% javascript 'socorro_utils' %}
+{% javascript 'report_list' %}
 
 <script type="text/javascript">
     var SocReport = {

--- a/webapp-django/crashstats/crashstats/templates/crashstats/status.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/status.html
@@ -102,19 +102,9 @@
 
 {% block site_js %}
   {{ super() }}
-  <!--[if IE]><script type="text/javascript" src="{{ static('crashstats/js/flot-0.7/excanvas.pack.js') }}"></script><![endif]-->
-  <script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-
-  {% compress js %}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-  {% endcompress %}
-
-  {% compress js %}
-  <script src="{{ static('crashstats/js/lib/filesize.min.js') }}"></script>
-  <script src="{{ static('crashstats/js/flot-0.7/jquery.flot.pack.js') }}"></script>
-  <script src="{{ static('crashstats/js/timeago/jquery.timeago.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/server_status.js') }}"></script>
-  {% endcompress %}
+  {% javascript 'd3' %}
+  {% javascript 'jquery_tablesorter' %}
+  {% javascript 'status' %}
   <script>
     var waiting_job_count = {{ plot_data.waiting_job_count | json_dumps }};
     var processors_count = {{ plot_data.processors_count | json_dumps }};

--- a/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher.html
@@ -1,10 +1,7 @@
 {% extends "crashstats_base.html" %}
 {% block site_css %}
-  {{ super() }}
-
-  {% compress css %}
-  <link href="{{ static('crashstats/css/topcrashers.less') }}" rel="stylesheet" type="text/less" media="screen" />
-  {% endcompress %}
+    {{ super() }}
+    {% stylesheet 'topcrashers' %}
 {% endblock %}
 
 {% block page_title %}
@@ -216,16 +213,9 @@ Top Crashers for {{ product }} {{ version }}
         };
 //]]>
 </script>
-  {{ super() }}
-  {% compress js %}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-  {% endcompress %}
-  <!--[if IE]><script type="text/javascript" src="{{ static('crashstats/js/flot-0.7/excanvas.pack.js') }}f"></script><![endif]-->
-  {% compress js %}
-  <script src="{{ static('crashstats/js/flot-0.7/jquery.flot.pack.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/topcrash.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/correlation.js') }}"></script>
-  {% endcompress %}
-
+    {{ super() }}
+    {% javascript 'jquery_tablesorter' %}
+    {% javascript 'bugzilla' %}
+    {% javascript 'correlation' %}
+    {% javascript 'topcrash' %}
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher_ranks_bybug.html
+++ b/webapp-django/crashstats/crashstats/templates/crashstats/topcrasher_ranks_bybug.html
@@ -1,9 +1,7 @@
 {% extends "crashstats_base.html" %}
 {% block site_css %}
   {{ super() }}
-  {% compress css %}
-    <link rel="stylesheet" type="text/less" href="{{ static('crashstats/css/tcr_bybug.less') }}" media="screen" />
-  {% endcompress %}
+  {% stylesheet 'tcr_bybug' %}
 {% endblock %}
 
 {% block page_title %}
@@ -78,8 +76,6 @@ Top Crashing Signatures {% if bug_number %}For Bug {{ bug_number }} {% endif %}
 
 {% block site_js %}
   {{ super() }}
-  {% compress js %}
-  <script src="{{ static('crashstats/js/socorro/utils.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/tcr_bybug.js') }}"></script>
-  {% endcompress %}
+  {% javascript 'socorro_utils' %}
+  {% javascript 'tcr_bybug' %}
 {% endblock %}

--- a/webapp-django/crashstats/manage/static/manage/js/groups.js
+++ b/webapp-django/crashstats/manage/static/manage/js/groups.js
@@ -1,0 +1,5 @@
+$(function() {
+    $('button[name="edit"]').click(function() {
+        location.href = location.pathname + $(this).val() + '/';
+    });
+});

--- a/webapp-django/crashstats/manage/static/manage/js/supersearch_fields.js
+++ b/webapp-django/crashstats/manage/static/manage/js/supersearch_fields.js
@@ -1,0 +1,7 @@
+$(function () {
+    $('.tablesorter').tablesorter();
+    $('.delete').click(function (e) {
+        var field_name = $(this).data('field-name');
+        return confirm('Do you really want to delete the "'+ field_name +'" field?');
+    });
+});

--- a/webapp-django/crashstats/manage/templates/manage/api_tokens.html
+++ b/webapp-django/crashstats/manage/templates/manage/api_tokens.html
@@ -4,20 +4,14 @@
 
 {% block site_js %}
 {{ super() }}
-<script src="{{ static('crashstats/js/moment.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/pagination_utils.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/api_tokens.js') }}"></script>
-{% endcompress %}
+{% javascript 'moment' %}
+{% javascript 'pagination' %}
+{% javascript 'api_tokens' %}
 {% endblock %}
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" type="text/css" href="{{ static('manage/css/api_tokens.css') }}">
-{% endcompress %}
+{% stylesheet 'api_tokens' %}
 {% endblock %}
 
 {% block admin_title %}{{ super() }} - API Tokens{% endblock %}

--- a/webapp-django/crashstats/manage/templates/manage/events.html
+++ b/webapp-django/crashstats/manage/templates/manage/events.html
@@ -4,13 +4,9 @@
 
 {% block site_js %}
 {{ super() }}
-<script src="{{ static('crashstats/js/moment.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/pagination_utils.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/events.js') }}"></script>
-{% endcompress %}
+{% javascript 'moment' %}
+{% javascript 'pagination' %}
+{% javascript 'manage:events' %}
 {% endblock %}
 
 {% block site_css %}

--- a/webapp-django/crashstats/manage/templates/manage/featured_versions.html
+++ b/webapp-django/crashstats/manage/templates/manage/featured_versions.html
@@ -4,9 +4,7 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/featured-versions.js') }}"></script>
-{% endcompress %}
+{% javascript 'manage:featured_versions' %}
 {% endblock %}
 
 {% block site_css %}

--- a/webapp-django/crashstats/manage/templates/manage/fields.html
+++ b/webapp-django/crashstats/manage/templates/manage/fields.html
@@ -4,9 +4,7 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/fields.js') }}"></script>
-{% endcompress %}
+{% javascript 'manage:fields' %}
 {% endblock %}
 
 {% block site_css %}

--- a/webapp-django/crashstats/manage/templates/manage/graphics_devices.html
+++ b/webapp-django/crashstats/manage/templates/manage/graphics_devices.html
@@ -14,9 +14,7 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/graphics_devices.js') }}"></script>
-{% endcompress %}
+{% javascript 'manage:graphics_devices' %}
 {% endblock %}
 
 {% block mainbody %}

--- a/webapp-django/crashstats/manage/templates/manage/groups.html
+++ b/webapp-django/crashstats/manage/templates/manage/groups.html
@@ -2,7 +2,8 @@
 
 {% block page_title %}{{ super() }} - Groups{% endblock %}
 
-{% block site_css %} {{ super() }}
+{% block site_css %}
+{{ super() }}
 <style type="text/css">
     td {
         vertical-align: top
@@ -14,15 +15,7 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script type="text/javascript">
-    $(function() {
-        $('button[name="edit"]').click(function() {
-            location.href = location.pathname + $(this).val() + '/';
-        });
-    });
-</script>
-{% endcompress %}
+{% javascript 'manage:groups' %}
 {% endblock %}
 
 {% block mainbody %}

--- a/webapp-django/crashstats/manage/templates/manage/skiplist.html
+++ b/webapp-django/crashstats/manage/templates/manage/skiplist.html
@@ -4,9 +4,7 @@
 
 {% block site_js %}
 {{ super() }}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/skiplist.js') }}"></script>
-{% endcompress %}
+{% javascript 'manage:skiplist' %}
 {% endblock %}
 
 {% block site_css %}

--- a/webapp-django/crashstats/manage/templates/manage/supersearch_field.html
+++ b/webapp-django/crashstats/manage/templates/manage/supersearch_field.html
@@ -6,12 +6,8 @@
 
 {% block site_js %}
     {{ super() }}
-
-    {% compress js %}
-<script src="{{ static('crashstats/js/lib/select2/select2.js') }}"></script>
-<script src="{{ static('manage/js/supersearch_field.js') }}"></script>
-    {% endcompress %}
-
+    {% javascript 'select2' %}
+    {% javascript 'manage:supersearch_field' %}
 <script>
 var ALL_PERMISSIONS = {{ all_permissions | json_dumps }};
 </script>
@@ -19,13 +15,8 @@ var ALL_PERMISSIONS = {{ all_permissions | json_dumps }};
 
 {% block site_css %}
     {{ super() }}
-
-    {% compress css %}
-<link href="{{ static('crashstats/js/lib/select2/select2.css') }}" type="text/css" rel="stylesheet">
-    {% endcompress %}
-    {% compress css %}
-<link href="{{ static('manage/css/supersearch_fields.less') }}" type="text/less" rel="stylesheet">
-    {% endcompress %}
+    {% stylesheet 'select2' %}
+    {% stylesheet 'manage:supersearch_fields' %}
 {% endblock %}
 
 {% block mainbody %}

--- a/webapp-django/crashstats/manage/templates/manage/supersearch_fields.html
+++ b/webapp-django/crashstats/manage/templates/manage/supersearch_fields.html
@@ -5,11 +5,8 @@
 {% block admin_title %}{{ super() }} - Super Search Fields{% endblock %}
 
 {% block site_css %}
-  {{ super() }}
-
-    {% compress css %}
-<link href="{{ static('manage/css/supersearch_fields.less') }}" type="text/less" rel="stylesheet">
-    {% endcompress %}
+    {{ super() }}
+    {% stylesheet 'manage:supersearch_fields' %}
 {% endblock %}
 
 {% block mainbody %}
@@ -93,7 +90,8 @@
 
 {% block site_js %}
   {{ super() }}
-
+  {% javascript 'jquery_tablesorter' %}
+  {% javascript 'manage:supersearch_fields' %}
 <script type="text/javascript" src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
 <script>
 $(function () {

--- a/webapp-django/crashstats/manage/templates/manage/symbols_uploads.html
+++ b/webapp-django/crashstats/manage/templates/manage/symbols_uploads.html
@@ -34,13 +34,9 @@
 
 {% block site_js %}
 {{ super() }}
-<script type="text/javascript" src="{{ static('crashstats/js/moment.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/pagination_utils.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/symbols-uploads.js') }}"></script>
-{% endcompress %}
+{% javascript 'moment' %}
+{% javascript 'pagination' %}
+{% javascript 'manage:symbols_uploads' %}
 {% endblock %}
 
 {% block admin_title %}{{ super() }} - {{ page_title }}{% endblock %}

--- a/webapp-django/crashstats/manage/templates/manage/users.html
+++ b/webapp-django/crashstats/manage/templates/manage/users.html
@@ -4,13 +4,9 @@
 
 {% block site_js %}
 {{ super() }}
-<script src="{{ static('crashstats/js/moment.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/pagination_utils.js') }}"></script>
-{% endcompress %}
-{% compress js %}
-<script type="text/javascript" src="{{ static('manage/js/users.js') }}"></script>
-{% endcompress %}
+{% javascript 'moment' %}
+{% javascript 'pagination' %}
+{% javascript 'manage:users' %}
 {% endblock %}
 
 {% block site_css %}

--- a/webapp-django/crashstats/profile/templates/profile/profile.html
+++ b/webapp-django/crashstats/profile/templates/profile/profile.html
@@ -4,22 +4,13 @@
 
 {% block site_css %}
     {{ super() }}
-
-    {% compress css %}
-<link type="text/css" rel="stylesheet" href="{{ static('profile/css/profile.css') }}">
-    {% endcompress %}
-
+    {% stylesheet 'profile' %}
 {% endblock %}
 
 {% block site_js %}
     {{ super() }}
-
-<script src="{{ static('crashstats/js/moment.min.js') }}"></script>
-
-    {% compress js %}
-<script type="text/javascript" src="{{ static('profile/js/profile.js') }}"></script>
-    {% endcompress %}
-
+    {% javascript 'moment' %}
+    {% javascript 'profile' %}
 {% endblock %}
 
 {% block content %}

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -1,0 +1,468 @@
+#
+# CSS
+#
+
+PIPELINE_CSS = {
+    'search': {
+        'source_filenames': (
+            'supersearch/css/search.less',
+        ),
+        'output_filename': 'css/search.min.css',
+    },
+    'select2': {
+        'source_filenames': (
+            'crashstats/js/lib/select2/select2.css',
+        ),
+        'output_filename': 'css/select2.min.css',
+    },
+    'jquery_ui': {
+        'source_filenames': (
+            'crashstats/css/lib/jquery-ui.css',
+            'crashstats/css/lib/jquery-ui.structure.css',
+            'crashstats/css/lib/jquery-ui.theme.css',
+        ),
+        'output_filename': 'css/jquery-ui.min.css',
+    },
+    'metricsgraphics': {
+        'source_filenames': (
+            'crashstats/css/lib/metricsgraphics.css',
+            'crashstats/css/metricsgraphics_custom.css',
+        ),
+        'output_filename': 'css/metricsgraphics.min.css',
+    },
+    'crashstats_base': {
+        'source_filenames': (
+            'crashstats/css/screen.less',
+        ),
+        'output_filename': 'css/crashstats-base.min.css',
+    },
+    'api_documentation': {
+        'source_filenames': (
+            'api/css/documentation.css',
+        ),
+        'output_filename': 'css/api-documentation.min.css',
+    },
+    'crashes_per_user': {
+        'source_filenames': (
+            'crashstats/css/crashes_per_user.less',
+        ),
+        'output_filename': 'css/crashes-per-user.min.css',
+    },
+    'crontabber_state': {
+        'source_filenames': (
+            'crashstats/css/crontabber_state.css',
+        ),
+        'output_filename': 'css/crontabber-state.min.css',
+    },
+    'daily': {
+        'source_filenames': (
+            'crashstats/css/daily.less',
+        ),
+        'output_filename': 'css/daily.min.css',
+    },
+    'gccrashes': {
+        'source_filenames': (
+            'crashstats/css/gccrashes.less',
+        ),
+        'output_filename': 'css/gccrashes.min.css',
+    },
+    'report_index': {
+        'source_filenames': (
+            'crashstats/css/report_index.css',
+        ),
+        'output_filename': 'css/report-index.min.css',
+    },
+    'report_list': {
+        'source_filenames': (
+            'crashstats/css/report_list.less',
+            'crashstats/css/accordion.less',
+        ),
+        'output_filename': 'css/report-list.min.css',
+    },
+    'tcr_bybug': {
+        'source_filenames': (
+            'crashstats/css/tcr_bybug.less',
+        ),
+        'output_filename': 'css/tcr-bybug.min.css',
+    },
+    'api_tokens': {
+        'source_filenames': (
+            'manage/css/api_tokens.css',
+        ),
+        'output_filename': 'css/api-tokens.min.css',
+    },
+    'manage:supersearch_fields': {
+        'source_filenames': (
+            'manage/css/supersearch_fields.less',
+        ),
+        'output_filename': 'css/manage-supersearch-fields.min.css',
+    },
+    'profile': {
+        'source_filenames': (
+            'profile/css/profile.css',
+        ),
+        'output_filename': 'css/profile.min.css',
+    },
+    'signature_report': {
+        'source_filenames': (
+            'signature/css/signature_report.less',
+        ),
+        'output_filename': 'css/signature-report.min.css',
+    },
+    'symbols': {
+        'source_filenames': (
+            'symbols/css/home.css',
+        ),
+        'output_filename': 'css/symbols.min.css',
+    },
+    'tokens': {
+        'source_filenames': (
+            'tokens/css/home.css',
+        ),
+        'output_filename': 'css/tokens.min.css',
+    },
+    'topcrashers': {
+        'source_filenames': (
+            'crashstats/css/topcrashers.less',
+        ),
+        'output_filename': 'css/topcrashers.min.css',
+    },
+
+}
+
+#
+# JavaScript
+#
+
+
+PIPELINE_JS = {
+    'moment': {
+        'source_filenames': (
+            'crashstats/js/moment.min.js',
+        ),
+        'output_filename': 'js/moment.min.js',
+    },
+    'pagination': {
+        'source_filenames': (
+            'manage/js/pagination_utils.js',
+        ),
+        'output_filename': 'js/pagination.min.js',
+    },
+    'dynamic_form': {
+        'source_filenames': (
+            'supersearch/js/lib/dynamic_form.js',
+        ),
+        'output_filename': 'js/dynamic-form.min.js',
+    },
+    'bugzilla': {
+        'source_filenames': (
+            'crashstats/js/socorro/bugzilla.js',
+        ),
+        'output_filename': 'js/bugzilla.min.js',
+    },
+    'd3': {
+        'source_filenames': (
+            'crashstats/js/lib/d3.min.js',
+        ),
+        'output_filename': 'js/d3.min.js',
+    },
+    'jquery_ui': {
+        'source_filenames': (
+            'crashstats/js/jquery/plugins/jquery-ui.js',
+        ),
+        'output_filename': 'js/jquery-ui.min.js',
+    },
+    'correlation': {
+        'source_filenames': (
+            'crashstats/js/socorro/correlation.js',
+        ),
+        'output_filename': 'js/correlation.min.js',
+    },
+    'metricsgraphics': {
+        'source_filenames': (
+            'crashstats/js/lib/metricsgraphics.min.js',
+        ),
+        'output_filename': 'js/metricsgraphics.min.js',
+    },
+    'select2': {
+        'source_filenames': (
+            'crashstats/js/lib/select2/select2.js',
+        ),
+        'output_filename': 'js/select2.min.js',
+    },
+    'jquery_tablesorter': {
+        'source_filenames': (
+            'crashstats/js/jquery/plugins/jquery.tablesorter.js',
+        ),
+        'output_filename': 'js/jquery-tablesorter.min.js',
+    },
+    'timeutils': {
+        'source_filenames': (
+            'crashstats/js/timeutils.js',
+        ),
+        'output_filename': 'js/timeutils.min.js',
+    },
+    'socorro_utils': {
+        'source_filenames': (
+            'crashstats/js/socorro/utils.js',
+        ),
+        'output_filename': 'js/socorro-utils.min.js',
+    },
+    'topcrash': {
+        'source_filenames': (
+            'crashstats/js/socorro/topcrash.js',
+        ),
+        'output_filename': 'js/topcrash.min.js',
+    },
+    'crashstats_base': {
+        'source_filenames': (
+            'crashstats/js/jquery/jquery-2.0.3.min.js',
+            'crashstats/js/jquery/plugins/jquery.cookies.2.2.0.js',
+            'crashstats/js/socorro/nav.js',
+            'crashstats/js/socorro/analytics.js',
+        ),
+        'output_filename': 'js/crashstats-base.min.js',
+    },
+    'api_documentation': {
+        'source_filenames': (
+            'api/js/lib/filesize.min.js',
+            'api/js/testdrive.js'
+        ),
+        'output_filename': 'js/api-documentation.min.js',
+    },
+    'crashes_per_user': {
+        'source_filenames': (
+            'crashstats/js/socorro/crashes_per_user.js',
+        ),
+        'output_filename': 'js/crashes-per-user.min.js',
+    },
+    'crontabber_state': {
+        'source_filenames': (
+            'crashstats/js/underscore-min.js',
+            'crashstats/js/lib/sankey.js',
+            'crashstats/js/socorro/crontabber_state.js',
+        ),
+        'output_filename': 'js/crontabber-state.min.js',
+    },
+    'daily': {  # deprecated
+        'source_filenames': (
+            'crashstats/js/socorro/daily.js',
+        ),
+        'output_filename': 'js/daily.min.js',
+    },
+    'exploitability_report': {  # deprecated
+        'source_filenames': (
+            'crashstats/js/socorro/exploitability_report.js',
+        ),
+        'output_filename': 'js/exploitability-report.min.js',
+    },
+    'exploitability': {
+        'source_filenames': (
+            'crashstats/js/socorro/exploitability.js',
+        ),
+        'output_filename': 'js/.min.js',
+    },
+    'gccrashes': {
+        'source_filenames': (
+            'crashstats/js/socorro/gccrashes.js',
+        ),
+        'output_filename': 'js/gccrashes.min.js',
+    },
+    'daily': {
+        'source_filenames': (
+            'crashstats/js/socorro/daily.js',
+        ),
+        'output_filename': 'js/daily.min.js',
+    },
+    'home': {
+        'source_filenames': (
+            'crashstats/js/socorro/dashboard_graph.js',
+        ),
+        'output_filename': 'js/home.min.js',
+    },
+    'report_index': {
+        'source_filenames': (
+            'crashstats/js/socorro/report.js',
+        ),
+        'output_filename': 'js/report-index.min.js',
+    },
+    'report_list': {
+        'source_filenames': (
+            'crashstats/js/jquery/plugins/jquery.cookie.js',
+            'crashstats/js/lib/awty.js',
+            'crashstats/js/lib/accordions.js',
+            'crashstats/js/socorro/report_list.js',
+            'crashstats/js/socorro/report_list_signature_summary.js',
+            'crashstats/js/socorro/report_list_graph.js',
+            'crashstats/js/socorro/report_list_reports.js',
+            'crashstats/js/socorro/report_list_comments.js',
+            'crashstats/js/socorro/report_list_correlations.js',
+            'crashstats/js/socorro/report_list_sigurls.js',
+            'crashstats/js/socorro/report_list_bugzilla.js',
+            'crashstats/js/socorro/report_list_table.js',
+        ),
+        'output_filename': 'js/report-list.min.js',
+    },
+    'status': {
+        'source_filenames': (
+            'crashstats/js/lib/filesize.min.js',
+            'crashstats/js/flot-0.7/jquery.flot.pack.js',
+            'crashstats/js/timeago/jquery.timeago.js',
+            'crashstats/js/socorro/server_status.js',
+        ),
+        'output_filename': 'js/status.min.js',
+    },
+    'tcr_bybug': {
+        'source_filenames': (
+            'crashstats/js/socorro/tcr_bybug.js',
+        ),
+        'output_filename': 'js/tcr-bybug.min.js',
+    },
+    'api_tokens': {
+        'source_filenames': (
+            'manage/js/api_tokens.js',
+        ),
+        'output_filename': 'js/api-tokens.min.js',
+    },
+    'manage:events': {
+        'source_filenames': (
+            'manage/js/events.js',
+        ),
+        'output_filename': 'js/manage-events.min.js',
+    },
+    'manage:featured_versions': {
+        'source_filenames': (
+            'manage/js/featured-versions.js',
+        ),
+        'output_filename': 'js/manage-featured-versions.min.js',
+    },
+    'manage:fields': {
+        'source_filenames': (
+            'manage/js/fields.js',
+        ),
+        'output_filename': 'js/manage-fields.min.js',
+    },
+    'manage:graphics_devices': {
+        'source_filenames': (
+            'manage/js/graphics_devices.js',
+        ),
+        'output_filename': 'js/manage-graphics-devices.min.js',
+    },
+    'manage:groups': {
+        'source_filenames': (
+            'manage/js/groups.js',
+        ),
+        'output_filename': 'js/manage-groups.min.js',
+    },
+    'manage:skiplist': {
+        'source_filenames': (
+            'manage/js/skiplist.js',
+        ),
+        'output_filename': 'js/manage-skiplist.min.js',
+    },
+    'manage:supersearch_field': {
+        'source_filenames': (
+            'manage/js/supersearch_field.js',
+        ),
+        'output_filename': 'js/manage-supersearch-field.min.js',
+    },
+    'manage:supersearch_fields': {
+        'source_filenames': (
+            'manage/js/supersearch_fields.js',
+        ),
+        'output_filename': 'js/manage-supersearch-fields.min.js',
+    },
+    'manage:symbols_uploads': {
+        'source_filenames': (
+            'manage/js/symbols-uploads.js',
+        ),
+        'output_filename': 'js/manage-symbols-uploads.min.js',
+    },
+    'manage:users': {
+        'source_filenames': (
+            'manage/js/users.js',
+        ),
+        'output_filename': 'js/manage-users.min.js',
+    },
+    'profile': {
+        'source_filenames': (
+            'profile/js/profile.js',
+        ),
+        'output_filename': 'js/profile.min.js',
+    },
+    'signature_report': {
+        'source_filenames': (
+            'signature/js/signature_report.js',
+            'signature/js/signature_tab.js',
+            'signature/js/signature_tab_summary.js',
+            'signature/js/signature_tab_graphs.js',
+            'signature/js/signature_tab_reports.js',
+            'signature/js/signature_tab_aggregations.js',
+            'signature/js/signature_tab_comments.js',
+            'signature/js/signature_tab_graph.js',
+            'signature/js/signature_panel.js',
+        ),
+        'output_filename': 'js/signature-report.min.js',
+    },
+    'search_custom': {
+        'source_filenames': (
+            'supersearch/js/lib/ace/ace.js',
+            'supersearch/js/lib/ace/theme-monokai.js',
+            'supersearch/js/lib/ace/mode-json.js',
+            'supersearch/js/socorro/search_custom.js',
+        ),
+        'output_filename': 'js/search-custom.min.js',
+    },
+    'search': {
+        'source_filenames': (
+            'supersearch/js/socorro/search.js',
+        ),
+        'output_filename': 'js/search.min.js',
+    },
+    'tokens': {
+        'source_filenames': (
+            'tokens/js/home.js',
+        ),
+        'output_filename': 'js/tokens.min.js',
+    },
+}
+
+# This is sanity checks, primarily for developers. It checks that
+# you haven't haven't accidentally make a string a tuple with an
+# excess comma, no underscores in the bundle name and that the
+# bundle file extension is either .js or .css.
+# We also check, but only warn, if a file is re-used in a different bundle.
+# That's because you might want to consider not including that file in the
+# bundle and instead break it out so it can be re-used on its own.
+_used = {}
+for config in PIPELINE_JS, PIPELINE_CSS:  # NOQA
+    _trouble = set()
+    for k, v in config.items():
+        assert isinstance(k, basestring), k
+        out = v['output_filename']
+        assert isinstance(v['source_filenames'], tuple), v
+        assert isinstance(out, basestring), v
+        assert '_' not in out
+        assert out.endswith('.min.css') or out.endswith('.min.js')
+        for asset_file in v['source_filenames']:
+            if asset_file in _used:
+                # Consider using warnings.warn here instead
+                print '{:<52} in {:<20} already in {}'.format(
+                    asset_file,
+                    k,
+                    _used[asset_file]
+                )
+                _trouble.add(asset_file)
+            _used[asset_file] = k
+
+    for asset_file in _trouble:
+        print "REPEATED", asset_file
+        found_in = []
+        sets = []
+        for k, v in config.items():
+            if asset_file in v['source_filenames']:
+                found_in.append(k)
+                sets.append(set(list(v['source_filenames'])))
+        print "FOUND IN", found_in
+        print "ALWAYS TOGETHER WITH", set.intersection(*sets)
+        break

--- a/webapp-django/crashstats/signature/templates/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/templates/signature/signature_report.html
@@ -3,16 +3,10 @@
 
 {% block site_css %}
     {{ super() }}
-    {% compress css %}
-<link href="{{ static('crashstats/js/lib/select2/select2.css') }}" type="text/css" rel="stylesheet">
-<link href="{{ static('crashstats/css/lib/metricsgraphics.css') }}" type="text/css" rel="stylesheet">
-<link href="{{ static('crashstats/css/metricsgraphics_custom.css') }}" type="text/css" rel="stylesheet">
-    {% endcompress %}
-
-    {% compress css %}
-<link href="{{ static('supersearch/css/search.less') }}" type="text/less" rel="stylesheet">
-<link href="{{ static('signature/css/signature_report.less') }}" type="text/less" rel="stylesheet">
-    {% endcompress %}
+    {% stylesheet 'select2' %}
+    {% stylesheet 'metricsgraphics' %}
+    {% stylesheet 'search' %}
+    {% stylesheet 'signature_report' %}
 {% endblock %}
 
 {% block content %}
@@ -90,30 +84,12 @@ var COLUMNS = {{ columns | join(', ') | json_dumps }};
 var DEFAULT_CHANNEL = '{{ channel }}';
 </script>
 
-<script src="{{ static('crashstats/js/lib/d3.min.js') }}"></script>
-<script src="{{ static('crashstats/js/lib/metricsgraphics.min.js') }}"></script>
-
-{% compress js %}
-<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-<script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-{% endcompress %}
-
-    {% compress js %}
-<script src="{{ static('crashstats/js/lib/select2/select2.js') }}"></script>
-<script src="{{ static('supersearch/js/lib/dynamic_form.js') }}"></script>
-<script src="{{ static('crashstats/js/socorro/utils.js') }}"></script>
-    {% endcompress %}
-
-    {% compress js %}
-<script src="{{ static('signature/js/signature_report.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab_summary.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab_graphs.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab_reports.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab_aggregations.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab_comments.js') }}"></script>
-<script src="{{ static('signature/js/signature_tab_graph.js') }}"></script>
-<script src="{{ static('signature/js/signature_panel.js') }}"></script>
-    {% endcompress %}
-
+{% javascript 'd3' %}
+{% javascript 'jquery_ui' %}
+{% javascript 'jquery_tablesorter' %}
+{% javascript 'select2' %}
+{% javascript 'dynamic_form' %}
+{% javascript 'socorro_utils' %}
+{% javascript 'metricsgraphics' %}
+{% javascript 'signature_report' %}
 {% endblock %}

--- a/webapp-django/crashstats/supersearch/templates/supersearch/search.html
+++ b/webapp-django/crashstats/supersearch/templates/supersearch/search.html
@@ -3,19 +3,9 @@
 
 {% block site_css %}
     {{ super() }}
-    {% compress css %}
-<link href="{{ static('crashstats/js/lib/select2/select2.css') }}" type="text/css" rel="stylesheet">
-    {% endcompress %}
-
-    {% compress css %}
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.css') }}" media="screen" />
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.structure.css') }}" media="screen" />
-    <link rel="stylesheet" type="text/css" href="{{ static('crashstats/css/lib/jquery-ui.theme.css') }}" media="screen" />
-    {% endcompress %}
-
-    {% compress css %}
-<link href="{{ static('supersearch/css/search.less') }}" type="text/less" rel="stylesheet">
-    {% endcompress %}
+    {% stylesheet 'select2' %}
+    {% stylesheet 'jquery_ui' %}
+    {% stylesheet 'search' %}
 {% endblock %}
 
 {% block content %}
@@ -122,21 +112,11 @@ var COLUMNS = {{ possible_columns | json_dumps }};
 var FACETS = {{ possible_facets | json_dumps }};
 var BASE_URL = location.protocol + '//' + location.host;
 </script>
-
-{% compress js %}
-<script src="{{ static('crashstats/js/jquery/plugins/jquery-ui.js') }}"></script>
-<script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-{% endcompress %}
-
-    {% compress js %}
-<script src="{{ static('crashstats/js/lib/select2/select2.js') }}"></script>
-<script src="{{ static('supersearch/js/lib/dynamic_form.js') }}"></script>
-<script src="{{ static('crashstats/js/socorro/utils.js') }}"></script>
-    {% endcompress %}
-
-    {% compress js %}
-<script src="{{ static('supersearch/js/socorro/search.js') }}"></script>
-<script src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-    {% endcompress %}
-
+    {% javascript 'select2' %}
+    {% javascript 'jquery_ui' %}
+    {% javascript 'jquery_tablesorter' %}
+    {% javascript 'dynamic_form' %}
+    {% javascript 'socorro_utils' %}
+    {% javascript 'bugzilla' %}
+    {% javascript 'search' %}
 {% endblock %}

--- a/webapp-django/crashstats/supersearch/templates/supersearch/search_custom.html
+++ b/webapp-django/crashstats/supersearch/templates/supersearch/search_custom.html
@@ -42,12 +42,8 @@
 
 {% block site_css %}
     {{ super() }}
-    {% compress css %}
-<link href="{{ static('crashstats/js/lib/select2/select2.css') }}" type="text/css" rel="stylesheet">
-    {% endcompress %}
-    {% compress css %}
-<link href="{{ static('supersearch/css/search.less') }}" type="text/less" rel="stylesheet">
-    {% endcompress %}
+    {% stylesheet 'select2' %}
+    {% stylesheet 'search' %}
 {% endblock %}
 
 
@@ -58,12 +54,6 @@
 var ELASTICSEARCH_INDICES = {{ elasticsearch_indices | json_dumps }};
 </script>
 
-    {% compress js %}
-<script src="{{ static('crashstats/js/lib/select2/select2.js') }}"></script>
-<script src="{{ static('supersearch/js/lib/ace/ace.js') }}"></script>
-<script src="{{ static('supersearch/js/lib/ace/theme-monokai.js') }}"></script>
-<script src="{{ static('supersearch/js/lib/ace/mode-json.js') }}"></script>
-<script src="{{ static('supersearch/js/socorro/search_custom.js') }}"></script>
-    {% endcompress %}
-
+    {% javascript 'select2' %}
+    {% javascript 'search_custom' %}
 {% endblock %}

--- a/webapp-django/crashstats/symbols/templates/symbols/home.html
+++ b/webapp-django/crashstats/symbols/templates/symbols/home.html
@@ -2,17 +2,13 @@
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" href="{{ static('symbols/css/home.css') }}" type="text/css">
-{% endcompress %}
+{% stylesheet 'symbols' %}
 {% endblock %}
 
 {% block site_js %}
 {{ super() }}
-<script type="text/javascript" src="{{ static('crashstats/js/moment.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('crashstats/js/timeutils.js') }}"></script>
-{% endcompress %}
+{% javascript 'moment' %}
+{% javascript 'timeutils' %}
 {% endblock %}
 
 {% block content_inner %}

--- a/webapp-django/crashstats/tokens/templates/tokens/home.html
+++ b/webapp-django/crashstats/tokens/templates/tokens/home.html
@@ -6,18 +6,14 @@
 
 {% block site_css %}
 {{ super() }}
-{% compress css %}
-<link rel="stylesheet" href="{{ static('tokens/css/home.css') }}" type="text/css">
-{% endcompress %}
+{% stylesheet 'tokens' %}
 {% endblock %}
 
 {% block site_js %}
 {{ super() }}
-<script type="text/javascript" src="{{ static('crashstats/js/moment.min.js') }}"></script>
-{% compress js %}
-<script type="text/javascript" src="{{ static('crashstats/js/timeutils.js') }}"></script>
-<script type="text/javascript" src="{{ static('tokens/js/home.js') }}"></script>
-{% endcompress %}
+{% javascript 'moment' %}
+{% javascript 'timeutils' %}
+{% javascript 'tokens' %}
 {% endblock %}
 
 {% block content %}

--- a/webapp-django/crashstats/topcrashers/templates/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/templates/topcrashers/topcrashers.html
@@ -1,10 +1,8 @@
 {% extends "crashstats_base.html" %}
 {% block site_css %}
-  {{ super() }}
+    {{ super() }}
 
-  {% compress css %}
-  <link href="{{ static('crashstats/css/topcrashers.less') }}" rel="stylesheet" type="text/less" media="screen" />
-  {% endcompress %}
+    {% stylesheet 'topcrashers' %}
 {% endblock %}
 
 {% block page_title %}
@@ -234,14 +232,9 @@ Top Crashers for {{ product }} {{ version }}
         };
 //]]>
 </script>
-  {{ super() }}
-  {% compress js %}
-  <script src="{{ static('crashstats/js/jquery/plugins/jquery.tablesorter.js') }}"></script>
-  {% endcompress %}
-  {% compress js %}
-  <script src="{{ static('crashstats/js/socorro/topcrash.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/bugzilla.js') }}"></script>
-  <script src="{{ static('crashstats/js/socorro/correlation.js') }}"></script>
-  {% endcompress %}
-
+    {{ super() }}
+    {% javascript 'jquery_tablesorter' %}
+    {% javascript 'bugzilla' %}
+    {% javascript 'correlation' %}
+    {% javascript 'topcrash' %}
 {% endblock %}

--- a/webapp-django/package.json
+++ b/webapp-django/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "socorro-webapp-django",
+  "description": "webapp for crash-stats",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mozilla/socorro.git"
+  },
+  "author": "Mozilla",
+  "license": "MPL-2.0",
+  "dependencies": {
+    "less": "2.5.3",
+    "yuglify": "0.1.4"
+  }
+}


### PR DESCRIPTION
It works on my laptop at least. 

If you set `DEBUG=false` you need to have run `./manage.py collectstatic`. When you do, you'll notice that it successfully bundles and compresses assets and give them cool names like `/static/css/crashstats-base.min.949336cd20ab.css`.