### PR TITLE
fixes bug 1237666 - Break out pyinotify install for non-linux

### DIFF
--- a/linux-requirements.txt
+++ b/linux-requirements.txt
@@ -1,0 +1,6 @@
+# These are requirements that you can only install if you're on Linux.
+# Basically, all the other requirements in `requirements.txt` should
+# work on all platforms.
+
+# sha256: nJmKXXYGyoNQZc2rwBOubGbrnqdqAKHjvG4M_itPcfQ
+pyinotify==0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,10 +121,6 @@ pyflakes==0.8.1
 pyhs2==0.6.0
 # sha256: TzJCJuHuhaxBUgV5up3nAylAEmAuU2IX_Q50VuFH2IY
 sasl==0.1.3
-# this is a temporary fork until https://github.com/seb-m/pyinotify/pull/92
-# is merged and a new pyinotify release is available
-# sha256: nRcVzSXV8H7KWbh-30BOtW37kRIs9HZQTN52I0LPN0c
-https://github.com/rhelmer/pyinotify/archive/208583041a.zip#egg=pyinotify
 # sha256: EAFkVWiXwSGfM3BuY6ZWuISNM9CbAWHi3u_MUJeM9i0
 # sha256: IDkUT86PG2A9A_paVkNXjfGtAHxO1BphfwKjlD9wWaE
 Django==1.7.11

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,6 +15,11 @@ source "$VIRTUAL_ENV/bin/activate"
 ${VIRTUAL_ENV}/bin/pip install tools/peep-2.*tar.gz
 ${VIRTUAL_ENV}/bin/peep install --download-cache=./pip-cache -r requirements.txt
 
+# only install `linux-requirements.txt` if you're on linux
+if [[ `uname` == 'Linux' ]]; then
+  ${VIRTUAL_ENV}/bin/peep install --download-cache=./pip-cache -r linux-requirements.txt
+fi
+
 if [ -n "${SOCORRO_DEVELOPMENT_ENV+1}" ]; then
     # install development egg in local virtualenv
     ${VIRTUAL_ENV}/bin/python setup.py develop


### PR DESCRIPTION
This solves two things. 

1. Now you can do `peep install -r requirements.txt` on non-Linux without having to rely on rhelmer's fork on github (which is not on pypi). 
2. rhelmer's fork made it installable on OSX but once installed it would cause problems with Django because Django tries to use it (based on it being import'able) but will of course fail. That's why we can do add [this hack](https://github.com/rhelmer/pyinotify/pull/2) to rhelmer's fork. 