### PR TITLE
fixes bug 1237671 - Refactor out funfactory python dependencies we longer needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,10 +28,11 @@ sqlalchemy-citext==1.0-2
 mercurial==2.7.1
 # sha256: Yj_jJZOSGfYbQathJMV_SWDOT0hlFoRqqvfUd10qLto
 honcho==0.5.0
-# sha256: th84eGr2uNZEtTBVIBLWacdBX89YUt4yDykIANuXmD0
-gunicorn==18.0
-# sha256: wLOB1sItqTHoXj7-YSYp_jOgGsJbDwKKpjG4XYbVAos
-uWSGI==2.0.10
+# sha256: xX8bAFpLkJMzA8je7Zvt61CTMapqCpkAI6V5blK9iYg
+# sha256: U7WARHZK151zKvGMWAsaVLckrfTSkOwZxMp4qyKh7g0
+gunicorn==19.4.5
+# sha256: MGtR25dkjW0ju36s125aQTQ0V18iDawd4jHIwm0z5Ak
+uWSGI==2.0.12
 # sha256: RsjrEON7PfBBeJVwaZ6bRgyiLm39JWyiDkIE2wz7K8U
 # sha256: FnmOimdGf1D4-bCAyOcKQfD_fS3QYedEI-U7x-2S-40
 configman==1.2.11
@@ -136,17 +137,6 @@ fancy-tag==0.2.0
 https://github.com/mozilla/django-session-csrf/archive/f00ad91.zip#egg=django-session-csrf
 # sha256: xJWo39CpwdPY7QISG7sotsnTTU2jCqk6fmOcDz17Bjk
 jingo==0.7.1
-# sha256: fjEbGTXZzUaSH2AmQWeicWQX00adBDuSIR7AwpQiKO8
-https://github.com/fwenzel/django-sha2/archive/3ba2b47.zip#egg=django-sha2
-# sha256: o2HP2_WwSljbspF8fp7FRyWPZqltTE5THiIoh7GFuxE
-https://github.com/jsocol/commonware/archive/b554418.zip#egg=commonware
-# sha256: LRy1WDkWc99RCaP-XoT95hYO3IskGz6xmrPTq-m43zE
-cef==0.5
-# sha256: aLzPfWX4LppstFym1qD3o35lVH9HUNrrmjq9wcvd9hI
-https://github.com/mozilla/nuggets/archive/ce50688.zip#egg=nuggets
-# sha256: UE5EGWeseGBKs18DABj8mm-icOam6YRx0jEf139wZ0s
-# sha256: smA0Iw78731g5SZ4kO2mVt_EnFZ_JxJdkH7uT-f5puw
-django-compressor==1.4
 # sha256: Eq491FQ_jcXMX0vdf2_RaPTRYkQU11OkQVc8zBh6jkM
 django-jsonfield==0.9.13
 # sha256: iTXjRYmmVJstzm7v-uQNInOetVtqmUow9mpCjW-YuBM

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -68,7 +68,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
-    'commonware.response.cookies',
     'django_nose',
     'session_csrf',
 
@@ -124,7 +123,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'session_csrf.CsrfMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'commonware.middleware.FrameOptionsHeader',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     'waffle.middleware.WaffleMiddleware',
     'ratelimit.middleware.RatelimitMiddleware',
@@ -625,6 +624,15 @@ CEF_VENDOR = config('CEF_VENDOR', 'Mozilla')
 # If you intend to run WITHOUT HTTPS, such as local development,
 # then set this to False
 SESSION_COOKIE_SECURE = config('SESSION_COOKIE_SECURE', True, cast=bool)
+
+# By default, use HTTPONLY cookies
+SESSION_COOKIE_HTTPONLY = config('SESSION_COOKIE_HTTPONLY', True, cast=bool)
+
+# By default, we don't want to be inside a frame.
+# If you need to override this you can use the
+# `django.views.decorators.clickjacking.xframe_options_sameorigin`
+# decorator on specific views that can be in a frame.
+X_FRAME_OPTIONS = config('X_FRAME_OPTIONS', 'DENY')
 
 # When socorro is installed (python setup.py install), it will create
 # a file in site-packages for socorro called "socorro/socorro_revision.txt".


### PR DESCRIPTION
Yes, I did upgrade uWSGI and gunicorn. That's because if I didn't they wouldn't compile any more on my machine. 

What `commonware` did for us is...:

* Made sure all cookies are httponly and secure by default. We manage that with `SESSION_SECURE_COOKIE = True` and there's now a new `SESSION_COOKIE_HTTPONLY` setting which Django respects.
* It sets a `X-Frame-Options: DENY` header. (see `curl -v https://crash-stats.mozilla.com >/dev/null`) We can do that with stock Django now. 