### PR TITLE
fixes bug 1237715 - API SuperSearch without a full date parameter

### DIFF
--- a/socorro/lib/search_common.py
+++ b/socorro/lib/search_common.py
@@ -267,6 +267,9 @@ class SearchBase(object):
             lower_than = None
             greater_than = None
             for param in parameters['date']:
+                if not param.operator:
+                    # dates can't be a specific date
+                    raise BadArgumentError('date must have a prefix operator')
                 if (
                     '<' in param.operator and (
                         not lower_than or

--- a/socorro/unittest/lib/test_search_common.py
+++ b/socorro/unittest/lib/test_search_common.py
@@ -210,6 +210,19 @@ class TestSearchBase(TestCase):
         eq_(params['user_comments'][0].operator, '__null__')
         ok_(params['user_comments'][0].operator_not)
 
+    def test_get_parameters_date_no_operator(self):
+        with _get_config_manager().context() as config:
+            search = SearchBaseWithFields(
+                config=config,
+            )
+
+        # the date parameter must always have a prefix operator
+        assert_raises(
+            BadArgumentError,
+            search.get_parameters,
+            date='2016-01-01'
+        )
+
     def test_get_parameters_date_defaults(self):
         with _get_config_manager().context() as config:
             search = SearchBaseWithFields(


### PR DESCRIPTION
Is this right?

It's easy to reproduce. If you go to the /api page and just fill in a single date on the `date` key, you get a 500 error. 