### PR TITLE
Bug 1238595 syntaxerror in compressed jquery ui

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -597,8 +597,14 @@ STATICFILES_FINDERS = (
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
 # You have to run `npm install` for this to be installed in `./node_modules`
-PIPELINE_YUGLIFY_BINARY = path('node_modules/.bin/yuglify')
+
 PIPELINE_LESS_BINARY = path('node_modules/.bin/lessc')
+PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
+PIPELINE_UGLIFYJS_BINARY = path('node_modules/.bin/uglifyjs')
+PIPELINE_UGLIFYJS_ARGUMENTS = '--mangle'
+PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.cssmin.CSSMinCompressor'
+PIPELINE_CSSMIN_BINARY = path('node_modules/.bin/cssmin')
+
 
 # Don't wrap javascript code in... `(...code...)();`
 # because possibly much code has been built with the assumption that things

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -260,7 +260,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'crashstats/js/socorro/exploitability.js',
         ),
-        'output_filename': 'js/.min.js',
+        'output_filename': 'js/exploitability.min.js',
     },
     'gccrashes': {
         'source_filenames': (
@@ -442,6 +442,7 @@ for config in PIPELINE_JS, PIPELINE_CSS:  # NOQA
         out = v['output_filename']
         assert isinstance(v['source_filenames'], tuple), v
         assert isinstance(out, basestring), v
+        assert not out.split('/')[-1].startswith('.'), k
         assert '_' not in out
         assert out.endswith('.min.css') or out.endswith('.min.js')
         for asset_file in v['source_filenames']:

--- a/webapp-django/package.json
+++ b/webapp-django/package.json
@@ -8,7 +8,8 @@
   "author": "Mozilla",
   "license": "MPL-2.0",
   "dependencies": {
+    "cssmin": "0.4.3",
     "less": "2.5.3",
-    "yuglify": "0.1.4"
+    "uglify-js": "2.6.1"
   }
 }


### PR DESCRIPTION
@adngdb So yuglify has [a bug that can't handle certain jquery files](https://github.com/yui/yuglify/issues/19).  And sadly yuglify uses the old UglifyJS and not UglifyJS2. Switched fixed the problem. 

What `yuglify` was was a wrapper over `cssmin` and (the old) `uglifyjs`. So instead of keeping it, I decided it's better we just use explicitly `cssmin` and (the new) `uglifyjs`. 

Yeah, it's confusing. Compare: [uglify-js](https://www.npmjs.com/package/uglify-js) and [uglify](https://www.npmjs.com/package/uglifyjs). 

Also, [this was confusing](https://twitter.com/peterbe/status/686607276254298113)