### PR TITLE
Bug 1242024 - Use a regional S3 connection context

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -267,7 +267,7 @@ class BotoS3CrashStorage(BotoCrashStorage):
     required_config.resource_class = change_default(
         BotoCrashStorage,
         'resource_class',
-        'socorro.external.boto.connection_context.S3ConnectionContext'
+        'socorro.external.boto.connection_context.RegionalS3ConnectionContext'
     )
 
 

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -327,4 +327,3 @@ class SupportReasonAPIStorage(BotoS3CrashStorage):
         nothing; however it is necessary for compatibility purposes.
         """
         pass
-

--- a/socorro/external/postgresql/new_crash_source.py
+++ b/socorro/external/postgresql/new_crash_source.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from datetime import timedelta
-from collections import Sequence
 
 from configman import Namespace, RequiredConfig, class_converter
 
@@ -32,8 +31,10 @@ class PGQueryNewCrashSource(RequiredConfig):
     )
     required_config.add_option(
         'database_class',
-        default='socorro.external.postgresql.connection_context'
-            '.ConnectionContext',
+        default=(
+            'socorro.external.postgresql.connection_context'
+            '.ConnectionContext'
+        ),
         doc='the class responsible for connecting to Postgres',
         from_string_converter=class_converter,
         reference_value_from='resource.postgresql',
@@ -47,7 +48,6 @@ class PGQueryNewCrashSource(RequiredConfig):
 
     #--------------------------------------------------------------------------
     def __init__(self, config, name, quit_check_callback=None):
-
         self.database = config.database_class(
             config
         )


### PR DESCRIPTION
CC @twobraids 

Lars, you are the ideal reviewer for this PR but I don't want to assign you out of principle. 
However, the change is small but quite significant. 

The most important change is on line 270 in `socorro/external/boto/crashstorage.py`.
It changes the default to use this new regional connection context class. I don't know if we've specified an override in consul for this but even if we have it's not a huge concern since the old class is still there. 

Another important "trick" is that the default region is `us-west-2` which is what I know we Mozilla use. By setting it as a default we can pursue this new code into prod without having to config change anything. 

By the way, I was able to now get my report index page (using `org.allizom.crash-stats.rhelmer-test.crashes`) to work in my local middleware server. All I had to do was edit the `hbase.calling_format` to `boto.s3.connection.OrdinaryCallingFormat` and it just work. (Why oh why do we still refer to this as hbase?! I hope that can die when we fully deprecate the middleware)

This little PR is approximately a weeks worth of work. With actual real coding just in the last 2 hours of that week. 