### PR TITLE
nobug -- fixup breakpad bucket name

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -27,7 +27,7 @@ fi
 
 if [ "`uname -sm`" == "Linux x86_64" ]; then
   # pull pre-built, known version of breakpad
-  wget -N --quiet 'https://s3-us-west-2.amazonaws.com/org.mozilla.breakpad/breakpad.tar.gz'
+  wget -N --quiet 'https://org-mozilla-breakpad.s3-us-west-2.amazonaws.com/breakpad.tar.gz'
   tar -zxf breakpad.tar.gz
   rm -rf stackwalk
   mv breakpad stackwalk


### PR DESCRIPTION
switch breakpad to using a non-dot bucket name.

I made a hyphenated bucket with the same contents to satisfy the wildcard cert. This will prevent the build from failing on systems that actually validate the cert.