### PR TITLE
Bug 1246253 one productversions api to rule them all

### DIFF
--- a/socorro/external/postgresql/adi.py
+++ b/socorro/external/postgresql/adi.py
@@ -89,8 +89,8 @@ class ADI(PostgreSQLBase):
 
         rows = []
         for row in results.zipped():
-            row.date = row.date.strftime('%Y-%m-%d')
+            row['date'] = row['date'].strftime('%Y-%m-%d')
             # BIGINTs become Decimal which becomes floating point in JSON
-            row.adi_count = long(row.adi_count)
+            row['adi_count'] = long(row['adi_count'])
             rows.append(row)
         return {'hits': rows, 'total': len(rows)}

--- a/socorro/external/postgresql/crashes.py
+++ b/socorro/external/postgresql/crashes.py
@@ -136,8 +136,8 @@ class Crashes(PostgreSQLBase):
 
             # Transforming the results into what we want
             for comment in results.zipped():
-                comment.date_processed = datetimeutil.date_to_string(
-                    comment.date_processed
+                comment['date_processed'] = datetimeutil.date_to_string(
+                    comment['date_processed']
                 )
                 comments.append(comment)
 
@@ -527,7 +527,7 @@ class Crashes(PostgreSQLBase):
         # Transforming the results into what we want
         history = []
         for dot in results.zipped():
-            dot.date = datetimeutil.date_to_string(dot.date)
+            dot['date'] = datetimeutil.date_to_string(dot['date'])
             history.append(dot)
 
         return {

--- a/socorro/external/postgresql/dbapi2_util.py
+++ b/socorro/external/postgresql/dbapi2_util.py
@@ -6,8 +6,6 @@
 
 from collections import Sequence
 
-from socorro.lib.util import DotDict
-
 
 #==============================================================================
 class SQLDidNotReturnSingleValue (Exception):
@@ -59,7 +57,7 @@ class FetchAllSequence(Sequence):
 
     def zipped(self):
         names = [x.name for x in self.description]
-        return [DotDict(zip(names, x)) for x in self.rows]
+        return [dict(zip(names, x)) for x in self.rows]
 
 
 #------------------------------------------------------------------------------

--- a/socorro/external/postgresql/product_build_types.py
+++ b/socorro/external/postgresql/product_build_types.py
@@ -37,7 +37,7 @@ class ProductBuildTypes(PostgreSQLBase):
 
         build_types = {}
         for row in results.zipped():
-            build_types[row.build_type] = row.throttle
+            build_types[row['build_type']] = row['throttle']
 
         return {
             'hits': build_types,

--- a/socorro/external/postgresql/raw_sql/views/001_product_info_view.sql
+++ b/socorro/external/postgresql/raw_sql/views/001_product_info_view.sql
@@ -1,2 +1,22 @@
 CREATE VIEW product_info AS
-    SELECT product_versions.product_version_id, product_versions.product_name, product_versions.version_string, 'new'::text AS which_table, product_versions.build_date AS start_date, product_versions.sunset_date AS end_date, product_versions.featured_version AS is_featured, product_versions.build_type, ((product_release_channels.throttle * (100)::numeric))::numeric(5,2) AS throttle, product_versions.version_sort, products.sort AS product_sort, release_channels.sort AS channel_sort, product_versions.has_builds, product_versions.is_rapid_beta FROM (((product_versions JOIN product_release_channels ON (((product_versions.product_name = product_release_channels.product_name) AND (product_versions.build_type = product_release_channels.release_channel)))) JOIN products ON ((product_versions.product_name = products.product_name))) JOIN release_channels ON ((product_versions.build_type = release_channels.release_channel))) ORDER BY product_versions.product_name, product_versions.version_string;
+SELECT product_versions.product_version_id,
+       product_versions.product_name,
+       product_versions.version_string,
+       'new'::text AS which_table,
+       product_versions.build_date AS start_date,
+       product_versions.sunset_date AS end_date,
+       product_versions.featured_version AS is_featured,
+       product_versions.build_type,
+       ((product_release_channels.throttle * (100)::numeric))::numeric(5,2) AS throttle,
+       product_versions.version_sort,
+       products.sort AS product_sort,
+       release_channels.sort AS channel_sort,
+       product_versions.has_builds,
+       product_versions.is_rapid_beta
+FROM ( ( ( product_versions
+          JOIN product_release_channels ON ( ( ( product_versions.product_name = product_release_channels.product_name )
+                                              AND ( product_versions.build_type = product_release_channels.release_channel ) ) ) )
+        JOIN products ON ( ( product_versions.product_name = products.product_name ) ) )
+      JOIN release_channels ON ( ( product_versions.build_type = release_channels.release_channel ) ) )
+ORDER BY product_versions.product_name,
+         product_versions.version_string;

--- a/socorro/external/postgresql/releases.py
+++ b/socorro/external/postgresql/releases.py
@@ -45,10 +45,10 @@ class Releases(PostgreSQLBase):
 
         channels = {}
         for res in sql_results.zipped():
-            if res.product not in channels:
-                channels[res.product] = [res.channel]
+            if res['product'] not in channels:
+                channels[res['product']] = [res['channel']]
             else:
-                channels[res.product].append(res.channel)
+                channels[res['product']].append(res['channel'])
 
         return channels
 
@@ -81,10 +81,10 @@ class Releases(PostgreSQLBase):
 
         for version in sql_results.zipped():
             total += 1
-            if version.product not in hits:
-                hits[version.product] = [version.version]
+            if version['product'] not in hits:
+                hits[version['product']] = [version['version']]
             else:
-                hits[version.product].append(version.version)
+                hits[version['product']].append(version['version'])
 
         return {
             "total": total,

--- a/socorro/external/postgresql/report.py
+++ b/socorro/external/postgresql/report.py
@@ -84,7 +84,7 @@ class Report(PostgreSQLBase):
                     '%s is not a recognized sort order key' % sort_order['key']
                 )
             sort_order['direction'] = 'ASC'
-            if 'reverse' in kwargs:
+            if str(kwargs.get('reverse', '')).lower() == 'true':
                 if kwargs.pop('reverse'):
                     sort_order['direction'] = 'DESC'
 
@@ -293,7 +293,7 @@ class Report(PostgreSQLBase):
         else:
             # old middleware
             context = self.context
-        ## Adding count for each OS
+        # Adding count for each OS
         for i in context.platforms:
             sql_select.append("".join(("count(CASE WHEN (r.os_name = %(os_",
                                        i["id"], ")s) THEN 1 END) AS is_",
@@ -304,7 +304,7 @@ class Report(PostgreSQLBase):
         sql_select.append(("SUM (CASE WHEN r.process_type IS NULL THEN 0  "
                            "ELSE 1 END) AS numplugin"))
 
-        ## Searching through plugins
+        # Searching through plugins
         if params["report_process"] == "plugin":
             sql_select.append(("plugins.name AS pluginName, "
                                "plugins_reports.version AS pluginVersion, "
@@ -318,7 +318,7 @@ class Report(PostgreSQLBase):
         """
         sql_from = ["FROM reports r"]
 
-        ## Searching through plugins
+        # Searching through plugins
         if params["report_process"] == "plugin":
             sql_from.append(("plugins_reports ON "
                              "plugins_reports.report_id = r.id"))

--- a/socorro/external/postgresql/signature_first_date.py
+++ b/socorro/external/postgresql/signature_first_date.py
@@ -33,7 +33,7 @@ class SignatureFirstDate(PostgreSQLBase):
 
         signatures = []
         for sig in results.zipped():
-            sig.first_date = datetimeutil.date_to_string(sig.first_date)
+            sig['first_date'] = datetimeutil.date_to_string(sig['first_date'])
             signatures.append(sig)
 
         return {

--- a/socorro/lib/external_common.py
+++ b/socorro/lib/external_common.py
@@ -7,21 +7,49 @@ Common functions for external modules.
 """
 
 import json
+import datetime
 
-from datetime import datetime, timedelta, date
+from socorro.external import BadArgumentError
 from socorro.lib.util import DotDict
-
 import socorro.lib.datetimeutil as dtutil
 
 
-def parse_arguments(filters, arguments):
+def parse_arguments(filters, arguments, modern=False):
     """
     Return a dict of parameters.
 
     Take a list of filters and for each try to get the corresponding
     value in arguments or a default value. Then check that value's type.
 
-    Example:
+    The @modern parameter indicates how the arguments should be
+    interpreted. The old way is that you always specify a list and in
+    the list you write the names of types as strings. I.e. instad of
+    `str` you write `'str'`.
+
+    The modern way allows you to specify arguments by real Python types
+    and entering it as a list means you accept and expect it to be a list.
+
+    For example, using the modern way:
+
+        filters = [
+            ("param1", "default", [str]),
+            ("param2", None, int),
+            ("param3", ["list", "of", 4, "values"], [str])
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345
+        }
+        =>
+        {
+            "param1": ["value1"],
+            "param2": 0,
+            "param3": ["list", "of", "4", "values"]
+        }
+
+
+    And an example for the old way:
+
         filters = [
             ("param1", "default", ["list", "str"]),
             ("param2", None, "int"),
@@ -37,6 +65,9 @@ def parse_arguments(filters, arguments):
             "param2": 0,
             "param3": ["list", "of", "4", "values"]
         }
+
+    The reason for having the modern and the non-modern way is
+    transition of legacy code. One day it will all be the modern way.
     """
     params = DotDict()
 
@@ -49,26 +80,37 @@ def parse_arguments(filters, arguments):
         else:
             param = arguments.get(i[0], i[1])
 
+        # proceed and do the type checking
         if count >= 3:
             types = i[2]
-            if not isinstance(types, list):
-                types = [types]
 
-            for t in reversed(types):
-                if t == "list" and not isinstance(param, list):
-                    if param is None or param == '':
-                        param = []
-                    else:
+            if modern:
+                if isinstance(types, list) and param is not None:
+                    assert len(types) == 1
+                    if not isinstance(param, list):
                         param = [param]
-                elif t == "list" and isinstance(param, list):
-                    continue
-                elif isinstance(param, list) and "list" not in types:
-                    param = " ".join(param)
-                    param = check_type(param, t)
-                elif isinstance(param, list):
-                    param = [check_type(x, t) for x in param]
+                    param = [check_type(x, types[0]) for x in param]
                 else:
-                    param = check_type(param, t)
+                    param = check_type(param, types)
+            else:
+                if not isinstance(types, list):
+                    types = [types]
+
+                for t in reversed(types):
+                    if t == "list" and not isinstance(param, list):
+                        if param is None or param == '':
+                            param = []
+                        else:
+                            param = [param]
+                    elif t == "list" and isinstance(param, list):
+                        continue
+                    elif isinstance(param, list) and "list" not in types:
+                        param = " ".join(param)
+                        param = check_type(param, t)
+                    elif isinstance(param, list):
+                        param = [check_type(x, t) for x in param]
+                    else:
+                        param = check_type(param, t)
 
         params[i[0]] = param
     return params
@@ -86,34 +128,60 @@ def check_type(param, datatype):
     if param is None:
         return param
 
-    if datatype == "str" and not isinstance(param, basestring):
+    if getattr(datatype, 'clean', None) and callable(datatype.clean):
+        try:
+            return datatype.clean(param)
+        except ValueError:
+            raise BadArgumentError(param)
+
+    elif isinstance(datatype, str):
+        # You've given it something like `'bool'` as a string.
+        # This is the legacy way of doing it.
+        datatype = {
+            'str': str,
+            'bool': bool,
+            'float': float,
+            'date': datetime.date,
+            'datetime': datetime.datetime,
+            'timedelta': datetime.timedelta,
+            'json': 'json',  # exception
+            'int': int,
+        }[datatype]
+
+    if datatype is str and not isinstance(param, basestring):
         try:
             param = str(param)
         except ValueError:
             param = str()
 
-    elif datatype == "int" and not isinstance(param, int):
+    elif datatype is int and not isinstance(param, int):
         try:
             param = int(param)
         except ValueError:
             param = int()
 
-    elif datatype == "bool" and not isinstance(param, bool):
+    elif datatype is bool and not isinstance(param, bool):
         param = str(param).lower() in ("true", "t", "1", "y", "yes")
 
-    elif datatype == "datetime" and not isinstance(param, datetime):
+    elif (
+        datatype is datetime.datetime and
+        not isinstance(param, datetime.datetime)
+    ):
         try:
             param = dtutil.string_to_datetime(param)
         except ValueError:
             param = None
 
-    elif datatype == "date" and not isinstance(param, date):
+    elif datatype is datetime.date and not isinstance(param, datetime.date):
         try:
             param = dtutil.string_to_datetime(param).date()
         except ValueError:
             param = None
 
-    elif datatype == "timedelta" and not isinstance(param, timedelta):
+    elif (
+        datatype is datetime.timedelta and
+        not isinstance(param, datetime.timedelta)
+    ):
         try:
             param = dtutil.strHoursToTimeDelta(param)
         except ValueError:

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -58,7 +58,7 @@ SERVICES_LIST = (
     (r'/platforms/(.*)', 'platforms.Platforms'),
     (r'/priorityjobs/(.*)', 'priorityjobs.Priorityjobs'),
     (r'/products/build_types/(.*)', 'product_build_types.ProductBuildTypes'),
-    (r'/products/(.*)', 'products.Products'),
+    (r'/products/(.*)', 'products.Products'),  # deprecated
     (r'/query/', 'query.Query'),
     (r'/releases/(channels|featured|release)/(.*)', 'releases.Releases'),
     (r'/report/(list)/(.*)', 'report.Report'),

--- a/socorro/unittest/external/postgresql/test_dbapi2_util.py
+++ b/socorro/unittest/external/postgresql/test_dbapi2_util.py
@@ -200,11 +200,6 @@ class TestDBAPI2Helper(TestCase):
         eq_(zipped[0], {'first_name': 'Peter', 'last_name': 'Bengtsson'})
         eq_(zipped[1], {'first_name': 'Lars', 'last_name': 'Lohn'})
 
-        # Also, because the zipped list actually is made up for DotDict
-        # instances you can access this like a proper ORM thing.
-        eq_(zipped[0].first_name, 'Peter')
-        eq_(zipped[0]['first_name'], 'Peter')
-
         # __len__
         eq_(len(zipped), 2)
 

--- a/socorro/unittest/external/postgresql/test_graphics_report.py
+++ b/socorro/unittest/external/postgresql/test_graphics_report.py
@@ -108,15 +108,15 @@ class IntegrationTestGraphicsReport(PostgreSQLTestCase):
         assert res['hits']
         assert len(res['hits']) == res['total']
         ok_(isinstance(res['hits'], list))
-        crash_ids = [x.crash_id for x in res['hits']]
+        crash_ids = [x['crash_id'] for x in res['hits']]
         eq_(crash_ids, ['1', '2'])
-        release_channels = [x.release_channel for x in res['hits']]
+        release_channels = [x['release_channel'] for x in res['hits']]
         eq_(release_channels, ['alpha', 'beta'])
-        signatures = [x.signature for x in res['hits']]
+        signatures = [x['signature'] for x in res['hits']]
         eq_(signatures, ['signature', 'my signature'])
-        date_processed = [x.date_processed for x in res['hits']]
+        date_processed = [x['date_processed'] for x in res['hits']]
         # should be ordered ascending
         first, second = date_processed
         ok_(first < second)
-        bug_associations = [x.bug_list for x in res['hits']]
+        bug_associations = [x['bug_list'] for x in res['hits']]
         eq_(bug_associations, [[], []])

--- a/socorro/unittest/external/postgresql/test_products.py
+++ b/socorro/unittest/external/postgresql/test_products.py
@@ -5,21 +5,22 @@
 import datetime
 from nose.tools import eq_, ok_
 
-from socorro.external.postgresql.products import Products
+from socorro.external.postgresql.products import ProductVersions, Products
 from socorro.lib import datetimeutil
 
 from .unittestbase import PostgreSQLTestCase
 
 
 #==============================================================================
-class IntegrationTestProducts(PostgreSQLTestCase):
-    """Test socorro.external.postgresql.products.Products class. """
+class IntegrationTestProductVersionsBase(PostgreSQLTestCase):
 
     #--------------------------------------------------------------------------
     @classmethod
     def setUpClass(cls):
         """ Populate product_info table with fake data """
-        super(IntegrationTestProducts, cls).setUpClass()
+        super(IntegrationTestProductVersionsBase, cls).setUpClass()
+
+        cls.truncate()
 
         cursor = cls.connection.cursor()
 
@@ -27,6 +28,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
         cls.now = datetimeutil.utc_now()
         now = cls.now.date()
         lastweek = now - datetime.timedelta(days=7)
+        nextweek = now + datetime.timedelta(days=7)
 
         cursor.execute("""
             INSERT INTO products
@@ -57,7 +59,10 @@ class IntegrationTestProducts(PostgreSQLTestCase):
             (release_channel, sort)
             VALUES
             (
-                'Release', 1
+                'Nightly', 1
+            ),
+            (
+                'Release', 3
             ),
             (
                 'Beta', 2
@@ -70,6 +75,9 @@ class IntegrationTestProducts(PostgreSQLTestCase):
             VALUES
             (
                 'Firefox', 'Release', '0.1'
+            ),
+            (
+                'Firefox', 'Nightly', '1.0'
             ),
             (
                 'Fennec', 'Release', '0.1'
@@ -87,29 +95,33 @@ class IntegrationTestProducts(PostgreSQLTestCase):
             INSERT INTO product_versions
             (product_name, major_version, release_version, version_string,
              build_date, sunset_date, featured_version, build_type,
-             version_sort)
+             version_sort, has_builds, is_rapid_beta)
             VALUES
             (
                 'Firefox',
                 '8.0',
                 '8.0',
                 '8.0',
-                '%(now)s',
-                '%(now)s',
+                '%(lastweek)s',
+                '%(lastweek)s',
                 False,
                 'Release',
-                '0008000'
+                '0008000',
+                false,
+                false
             ),
             (
                 'Firefox',
                 '9.0',
                 '9.0',
                 '9.0',
-                '%(lastweek)s',
-                '%(lastweek)s',
-                False,
+                '%(now)s',
+                '%(nextweek)s',
+                True,
                 'Nightly',
-                '0009000'
+                '0009000',
+                true,
+                false
             ),
             (
                 'Fennec',
@@ -120,7 +132,9 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                 '%(now)s',
                 False,
                 'Release',
-                '0011001'
+                '0011001',
+                false,
+                false
             ),
             (
                 'Fennec',
@@ -128,10 +142,12 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                 '12.0',
                 '12.0b1',
                 '%(now)s',
-                '%(now)s',
+                '%(nextweek)s',
                 False,
                 'Beta',
-                '00120b1'
+                '00120b1',
+                true,
+                false
             ),
             (
                 'Thunderbird',
@@ -139,12 +155,14 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                 '10.0',
                 '10.0.2b',
                 '%(now)s',
-                '%(now)s',
+                '%(nextweek)s',
                 False,
                 'Release',
-                '001002b'
+                '001002b',
+                false,
+                true
             );
-        """ % {'now': now, 'lastweek': lastweek})
+        """ % {'now': now, 'lastweek': lastweek, 'nextweek': nextweek})
 
         cls.connection.commit()
 
@@ -152,6 +170,12 @@ class IntegrationTestProducts(PostgreSQLTestCase):
     @classmethod
     def tearDownClass(cls):
         """ Cleanup the database, delete tables and functions """
+        cls.truncate()
+        super(IntegrationTestProductVersionsBase, cls).tearDownClass()
+
+    #--------------------------------------------------------------------------
+    @classmethod
+    def truncate(cls):
         cursor = cls.connection.cursor()
         cursor.execute("""
             TRUNCATE products, product_version_builds, product_versions,
@@ -160,13 +184,351 @@ class IntegrationTestProducts(PostgreSQLTestCase):
             CASCADE
         """)
         cls.connection.commit()
-        super(IntegrationTestProducts, cls).tearDownClass()
 
+
+#==============================================================================
+class IntegrationTestProductVersions(IntegrationTestProductVersionsBase):
+    """Test socorro.external.postgresql.products.ProductVersions class. """
+
+    #--------------------------------------------------------------------------
+    def test_get_basic(self):
+        productversions = ProductVersions(config=self.config)
+        now = self.now.date()
+        lastweek = now - datetime.timedelta(days=7)
+
+        # Find one exact match for one product and one version
+        params = {
+            "product": "Firefox",
+            "version": "8.0",
+        }
+        res = productversions.get(**params)
+        res_expected = {
+            "hits": [{
+                "is_featured": False,
+                "version": "8.0",
+                "throttle": 10.0,
+                "start_date": lastweek,
+                "end_date": lastweek,
+                "has_builds": False,
+                "product": "Firefox",
+                "build_type": "Release",
+                "is_rapid_beta": False,
+            }],
+            "total": 1
+        }
+
+        eq_(res['total'], res_expected['total'])
+        eq_(
+            sorted(res['hits'][0]),
+            sorted(res_expected['hits'][0])
+        )
+        eq_(res['hits'], res_expected['hits'])
+
+    #--------------------------------------------------------------------------
+    def test_get_with_one_product_multiple_versions(self):
+        productversions = ProductVersions(config=self.config)
+        now = self.now.date()
+        nextweek = now + datetime.timedelta(days=7)
+
+        params = {
+            "product": "Fennec",
+            "version": ["11.0.1", "12.0b1"],
+        }
+        res = productversions.get(**params)
+        res_expected = {
+            "hits": [
+                {
+                    "is_featured": False,
+                    "version": "12.0b1",
+                    "throttle": 100.0,
+                    "start_date": now,
+                    "end_date": nextweek,
+                    "has_builds": True,
+                    "product": "Fennec",
+                    "build_type": "Beta",
+                    "is_rapid_beta": False,
+                },
+                {
+                    "is_featured": False,
+                    "version": "11.0.1",
+                    "throttle": 10.0,
+                    "start_date": now,
+                    "end_date": now,
+                    "has_builds": False,
+                    "product": "Fennec",
+                    "build_type": "Release",
+                    "is_rapid_beta": False,
+                }
+            ],
+            "total": 2
+        }
+
+        eq_(res['total'], res_expected['total'])
+        eq_(
+            sorted(res['hits'][0]),
+            sorted(res_expected['hits'][0])
+        )
+        eq_(res['hits'][0], res_expected['hits'][0])
+        eq_(res['hits'][1], res_expected['hits'][1])
+
+    #--------------------------------------------------------------------------
+    def test_get_no_parameter_returning_all(self):
+        productversions = ProductVersions(config=self.config)
+        now = self.now.date()
+        lastweek = now - datetime.timedelta(days=7)
+        nextweek = now + datetime.timedelta(days=7)
+
+        # Test products list is returned with no parameters
+        # Note that the expired version is not returned
+        res = productversions.get()
+        res_expected = {
+            "hits":
+                [
+                    {
+                        "product": "Firefox",
+                        "version": "9.0",
+                        "start_date": now,
+                        "end_date": nextweek,
+                        "throttle": 100.00,
+                        "is_featured": True,
+                        "build_type": "Nightly",
+                        "has_builds": True,
+                        "is_rapid_beta": False,
+                    },
+                    {
+                        "product": "Firefox",
+                        "version": "8.0",
+                        "start_date": lastweek,
+                        "end_date": lastweek,
+                        "throttle": 10.00,
+                        "is_featured": False,
+                        "build_type": "Release",
+                        "has_builds": False,
+                        "is_rapid_beta": False,
+                    },
+                    {
+                        "product": "Thunderbird",
+                        "version": "10.0.2b",
+                        "start_date": now,
+                        "end_date": nextweek,
+                        "throttle": 10.00,
+                        "is_featured": False,
+                        "build_type": "Release",
+                        "has_builds": False,
+                        "is_rapid_beta": True,
+                    },
+                    {
+                        "product": "Fennec",
+                        "version": "12.0b1",
+                        "start_date": now,
+                        "end_date": nextweek,
+                        "throttle": 100.00,
+                        "is_featured": False,
+                        "build_type": "Beta",
+                        "has_builds": True,
+                        "is_rapid_beta": False,
+                    },
+                    {
+                        "product": "Fennec",
+                        "version": "11.0.1",
+                        "start_date": now,
+                        "end_date": now,
+                        "throttle": 10.00,
+                        "is_featured": False,
+                        "build_type": "Release",
+                        "has_builds": False,
+                        "is_rapid_beta": False,
+
+                    }
+                ],
+            "total": 5
+        }
+
+        eq_(res['total'], res_expected['total'])
+        assert res['total'] == len(res['hits'])
+        # same keys
+        keys = set(res['hits'][0].keys())
+        expected_keys = set(res_expected['hits'][0].keys())
+        eq_(keys, expected_keys)
+        eq_(len(res['hits']), len(res_expected['hits']))
+        eq_(res['hits'], res_expected['hits'])
+
+    #--------------------------------------------------------------------------
+    def test_filter_by_featured(self):
+        productversions = ProductVersions(config=self.config)
+
+        res = productversions.get(is_featured=True)
+        eq_(len(res['hits']), 1)
+        eq_(res['total'], 1)
+        ok_(all(x['is_featured'] for x in res['hits']))
+        res = productversions.get(is_featured=False)
+        eq_(res['total'], 4)
+        eq_(len(res['hits']), 4)
+        ok_(all(not x['is_featured'] for x in res['hits']))
+
+    #--------------------------------------------------------------------------
+    def test_filter_by_start_date(self):
+        productversions = ProductVersions(config=self.config)
+        now = self.now.date()
+
+        res = productversions.get(start_date='>=' + now.isoformat())
+        eq_(res['total'], 4)
+        res = productversions.get(start_date='<' + now.isoformat())
+        eq_(res['total'], 1)
+
+    #--------------------------------------------------------------------------
+    def test_filter_by_end_date(self):
+        productversions = ProductVersions(config=self.config)
+        now = self.now.date()
+        nextweek = now + datetime.timedelta(days=7)
+
+        res = productversions.get(end_date='=' + nextweek.isoformat())
+        eq_(res['total'], 3)
+        for hit in res['hits']:
+            eq_(hit['end_date'], nextweek)
+
+    #--------------------------------------------------------------------------
+    def test_filter_by_active(self):
+        productversions = ProductVersions(config=self.config)
+        now = self.now.date()
+        nextweek = now + datetime.timedelta(days=7)
+
+        res = active_results = productversions.get(active=True)
+        eq_(res['total'], 4)
+        res_expected = {
+            "hits":
+                [
+                    {
+                        "product": "Firefox",
+                        "version": "9.0",
+                        "start_date": now,
+                        "end_date": nextweek,
+                        "throttle": 100.00,
+                        "is_featured": True,
+                        "build_type": "Nightly",
+                        "has_builds": True,
+                        "is_rapid_beta": False,
+                    },
+                    {
+                        "product": "Thunderbird",
+                        "version": "10.0.2b",
+                        "start_date": now,
+                        "end_date": nextweek,
+                        "throttle": 10.00,
+                        "is_featured": False,
+                        "build_type": "Release",
+                        "has_builds": False,
+                        "is_rapid_beta": True,
+                    },
+                    {
+                        "product": "Fennec",
+                        "version": "12.0b1",
+                        "start_date": now,
+                        "end_date": nextweek,
+                        "throttle": 100.00,
+                        "is_featured": False,
+                        "build_type": "Beta",
+                        "has_builds": True,
+                        "is_rapid_beta": False,
+                    },
+                    {
+                        "product": "Fennec",
+                        "version": "11.0.1",
+                        "start_date": now,
+                        "end_date": now,
+                        "throttle": 10.00,
+                        "is_featured": False,
+                        "build_type": "Release",
+                        "has_builds": False,
+                        "is_rapid_beta": False,
+                    },
+                ],
+            "total": 3
+        }
+        eq_(res['hits'][0], res_expected['hits'][0])
+        eq_(res['hits'][1], res_expected['hits'][1])
+        eq_(res['hits'][2], res_expected['hits'][2])
+        eq_(res['hits'][3], res_expected['hits'][3])
+        for hit in res['hits']:
+            ok_(hit['end_date'] >= now, hit)
+
+        res = not_active_results = productversions.get(active=False)
+        eq_(res['total'], 1)
+
+        both_results = productversions.get()
+        eq_(
+            both_results['total'],
+            active_results['total'] + not_active_results['total']
+        )
+
+    #--------------------------------------------------------------------------
+    def test_filter_by_is_rapid_beta(self):
+        productversions = ProductVersions(config=self.config)
+
+        res = true_results = productversions.get(is_rapid_beta=True)
+        eq_(res['total'], 1)
+        for hit in res['hits']:
+            ok_(hit['is_rapid_beta'])
+
+        res = false_results = productversions.get(is_rapid_beta=False)
+        eq_(res['total'], 4)
+        for hit in res['hits']:
+            ok_(not hit['is_rapid_beta'])
+
+        both_results = productversions.get()
+        eq_(
+            both_results['total'],
+            true_results['total'] + false_results['total']
+        )
+
+    #--------------------------------------------------------------------------
+    def test_post(self):
+        products = ProductVersions(config=self.config)
+
+        ok_(products.post(
+            product='KillerApp',
+            version='1.0',
+        ))
+
+        # let's check certain things got written to certain tables
+        cursor = self.connection.cursor()
+        try:
+            # expect there to be a new product
+            cursor.execute(
+                'select product_name from products '
+                "where product_name=%s",
+                ('KillerApp',)
+            )
+            product_name, = cursor.fetchone()
+            eq_(product_name, 'KillerApp')
+        finally:
+            self.connection.rollback()
+
+    def test_post_bad_product_name(self):
+        products = Products(config=self.config)
+
+        ok_(not products.post(
+            product='Spaces not allowed',
+            version='',
+        ))
+
+
+#==============================================================================
+class IntegrationTestProducts(IntegrationTestProductVersionsBase):
+    """
+    NOTE! This class is deprecated. All usage of
+    socorro.external.postgresql.products.Products is deprecated in favor
+    of socorro.external.postgresql.products.ProductVersions.
+    """
     #--------------------------------------------------------------------------
     def test_get(self):
         products = Products(config=self.config)
         now = self.now.date()
+        lastweek = now - datetime.timedelta(days=7)
+        nextweek = now + datetime.timedelta(days=7)
         now_str = datetimeutil.date_to_string(now)
+        lastweek_str = datetimeutil.date_to_string(lastweek)
+        nextweek_str = datetimeutil.date_to_string(nextweek)
 
         #......................................................................
         # Test 1: find one exact match for one product and one version
@@ -185,7 +547,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                     "has_builds": False,
                     "product": "Firefox",
                     "build_type": "Release"
-                 }
+                }
             ],
             "total": 1
         }
@@ -211,9 +573,9 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                     "is_featured": False,
                     "build_type": "Release",
                     "throttle": 10.0,
-                    "has_builds": False
-                 },
-                 {
+                    "has_builds": True
+                },
+                {
                     "product": "Thunderbird",
                     "version": "10.0.2b",
                     "start_date": now_str,
@@ -222,7 +584,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                     "build_type": "Release",
                     "throttle": 10.0,
                     "has_builds": False
-                 }
+                }
             ],
             "total": 2
         }
@@ -247,7 +609,6 @@ class IntegrationTestProducts(PostgreSQLTestCase):
 
         #......................................................................
         # Test 4: Test products list is returned with no parameters
-        # Note that the expired version is not returned
         params = {}
         res = products.get(**params)
         res_expected = {
@@ -256,9 +617,19 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                 "Firefox": [
                     {
                         "product": "Firefox",
-                        "version": "8.0",
+                        "version": "9.0",
                         "start_date": now_str,
-                        "end_date": now_str,
+                        "end_date": nextweek_str,
+                        "throttle": 100.00,
+                        "featured": True,
+                        "release": "Nightly",
+                        "has_builds": True
+                    },
+                    {
+                        "product": "Firefox",
+                        "version": "8.0",
+                        "start_date": lastweek_str,
+                        "end_date": lastweek_str,
                         "throttle": 10.00,
                         "featured": False,
                         "release": "Release",
@@ -270,7 +641,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                         "product": "Thunderbird",
                         "version": "10.0.2b",
                         "start_date": now_str,
-                        "end_date": now_str,
+                        "end_date": nextweek_str,
                         "throttle": 10.00,
                         "featured": False,
                         "release": "Release",
@@ -282,11 +653,11 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                         "product": "Fennec",
                         "version": "12.0b1",
                         "start_date": now_str,
-                        "end_date": now_str,
+                        "end_date": nextweek_str,
                         "throttle": 100.00,
                         "featured": False,
                         "release": "Beta",
-                        "has_builds": False
+                        "has_builds": True
                     },
                     {
                         "product": "Fennec",
@@ -300,7 +671,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                     }
                 ]
             },
-            "total": 4
+            "total": 5
         }
 
         eq_(res['total'], res_expected['total'])
@@ -314,6 +685,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
                 sorted(res['hits'][product][0]),
                 sorted(res_expected['hits'][product][0])
             )
+            eq_(res['hits'][product], res_expected['hits'][product])
 
         # test returned order of versions
         assert len(res['hits']['Fennec']) == 2
@@ -326,7 +698,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
             'versions': [1]
         }
         res = products.get(**params)
-        eq_(res['total'], 4)
+        eq_(res['total'], 5)
 
     def test_get_default_version(self):
         products = Products(config=self.config)
@@ -335,9 +707,9 @@ class IntegrationTestProducts(PostgreSQLTestCase):
         res = products.get_default_version()
         res_expected = {
             "hits": {
-                "Firefox": "8.0",
+                "Firefox": "9.0",
                 "Thunderbird": "10.0.2b",
-                "Fennec": "12.0b1",
+                "Fennec": "11.0.1",
             }
         }
 
@@ -348,7 +720,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
         res = products.get_default_version(**params)
         res_expected = {
             "hits": {
-                "Firefox": "8.0"
+                "Firefox": "9.0"
             }
         }
 
@@ -359,7 +731,7 @@ class IntegrationTestProducts(PostgreSQLTestCase):
         res = products.get_default_version(**params)
         res_expected = {
             "hits": {
-                "Firefox": "8.0",
+                "Firefox": "9.0",
                 "Thunderbird": "10.0.2b"
             }
         }

--- a/socorro/unittest/lib/test_external_common.py
+++ b/socorro/unittest/lib/test_external_common.py
@@ -4,8 +4,10 @@
 
 import datetime
 
-from nose.tools import eq_, ok_
+import isodate
+from nose.tools import eq_, ok_, assert_raises
 
+from socorro.external import BadArgumentError
 from socorro.lib import external_common, util
 from socorro.unittest.testbase import TestCase
 
@@ -107,7 +109,7 @@ class TestExternalCommon(TestCase):
         eq_(res.day, 1)
 
     #--------------------------------------------------------------------------
-    def test_parse_arguments(self):
+    def test_parse_arguments_old_way(self):
         """Test external_common.parse_arguments(). """
         filters = [
             ("param1", "default", ["list", "str"]),
@@ -123,6 +125,101 @@ class TestExternalCommon(TestCase):
         params_exp.param2 = None
         params_exp.param3 = ["list", "of", "4", "values"]
 
-        params = external_common.parse_arguments(filters, arguments)
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=False,
+        )
 
         eq_(params, params_exp)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments(self):
+        """Test external_common.parse_arguments(). """
+        filters = [
+            ("param1", "default", [str]),
+            ("param2", None, int),
+            ("param3", ["some", "default", "list"], [str]),
+            ("param4", ["list", "of", 4, "values"], [str]),
+            ("param5", None, bool),
+            ("param6", None, datetime.date),
+            ("param7", None, datetime.date),
+            ("param8", None, datetime.datetime),
+            ("param9", None, [str]),
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345,
+            "param5": "true",
+            "param7": datetime.date(2016, 2, 9).isoformat(),
+            "param8": datetime.datetime(2016, 2, 9).isoformat(),
+            # note the 'param9' is deliberately not specified.
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = ["value1"]
+        params_exp.param2 = None
+        params_exp.param3 = ['some', 'default', 'list']
+        params_exp.param4 = ["list", "of", "4", "values"]
+        params_exp.param5 = True
+        params_exp.param6 = None
+        params_exp.param7 = datetime.date(2016, 2, 9)
+        params_exp.param8 = datetime.datetime(2016, 2, 9).replace(
+            tzinfo=isodate.UTC
+        )
+        params_exp.param9 = None
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=True
+        )
+        for key in params:
+            eq_(params[key], params_exp[key], '{}: {!r} != {!r}'.format(
+                key,
+                params[key],
+                params_exp[key]
+            ))
+        eq_(params, params_exp)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments_with_class_validators(self):
+
+        class NumberConverter(object):
+
+            def clean(self, value):
+                conv = {'one': 1, 'two': 2, 'three': 3}
+                try:
+                    return conv[value]
+                except KeyError:
+                    raise ValueError('No idea?!')
+
+        # Define a set of filters with some types being non-trivial types
+        # but instead a custom validator.
+
+        filters = [
+            ("param1", 0, NumberConverter()),
+        ]
+        arguments = {
+            "param1": "one",
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = 1
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=True
+        )
+        eq_(params, params_exp)
+
+        # note that a ValueError becomes a BadArgumentError
+        arguments = {
+            "param1": "will cause a ValueError in NumberConverter.clean",
+        }
+        assert_raises(
+            BadArgumentError,
+            external_common.parse_arguments,
+            filters,
+            arguments,
+            modern=True
+        )

--- a/webapp-django/crashstats/api/static/api/css/documentation.css
+++ b/webapp-django/crashstats/api/static/api/css/documentation.css
@@ -50,3 +50,9 @@ p.tokens-callout {
 p.tokens-callout a {
     font-weight: bold;
 }
+
+/* These are the little widgets for boolean choices */
+form.testdrive td ul li {
+    display: inline;
+    margin-right: 10px;
+}

--- a/webapp-django/crashstats/api/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/api/templatetags/jinja_helpers.py
@@ -5,6 +5,8 @@ import datetime
 from django_jinja import library
 import jinja2
 
+from django.forms.widgets import RadioSelect
+
 
 @library.global_function
 def describe_friendly_type(type_):
@@ -18,12 +20,28 @@ def describe_friendly_type(type_):
         return "Date"
     if type_ is datetime.datetime:
         return "Date and time"
+    if type_ is bool:
+        return "Boolean"
     warnings.warn("Don't know how to describe type %r" % type_)
     return type_
 
 
 @library.global_function
 def make_test_input(parameter, defaults):
+    if parameter['type'] is bool:
+        # If it's optional, make it possible to select "Not set",
+        if parameter['required']:
+            raise NotImplementedError(
+                'required booleans are not supported'
+            )
+        else:
+            widget = RadioSelect(choices=(
+                ('', 'Not set'),
+                ('false', 'False'),
+                ('true', 'True'),
+            ))
+            return widget.render(parameter['name'], '')
+
     template = u'<input type="%(type)s" name="%(name)s"'
     data = {
         'name': parameter['name'],

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -119,6 +119,7 @@ TYPE_MAP = {
     datetime.date: forms.DateField,
     datetime.datetime: forms.DateTimeField,
     int: forms.IntegerField,
+    bool: forms.BooleanField,
 }
 
 
@@ -144,6 +145,29 @@ class FormWrapperMeta(DeclarativeFieldsMetaclass):
 
 class FormWrapper(forms.Form):
     __metaclass__ = FormWrapperMeta
+
+    def clean(self):
+        cleaned_data = super(FormWrapper, self).clean()
+
+        for field in self.fields:
+            # Because the context for all of this is the API,
+            # and we're using django forms there's a mismatch to how
+            # boolean fields should be handled.
+            # Django forms are meant for HTML forms. A key principle
+            # functionality of a HTML form and a checkbox is that
+            # if the user choses to NOT check a checkbox, the browser
+            # will not send `mybool=false` or `mybool=''`. It will simply
+            # not send anything and then the server has to assume the user
+            # chose to NOT check it because it was offerend.
+            # On a web API, however, the user doesn't use checkboxes.
+            # He uses `?mybool=truthy` or `&mybool=falsy`.
+            # Therefore, for our boolean fields, if the value is not
+            # present at all, we have to assume it to be None.
+            # That makes it possible to actually set `mybool=false`
+            if isinstance(self.fields[field], forms.BooleanField):
+                if field not in self.data:
+                    self.cleaned_data[field] = None
+        return cleaned_data
 
 
 # Names of models we don't want to serve at all
@@ -231,7 +255,6 @@ def model_wrapper(request, model_name):
 
     form = FormWrapper(model, request.REQUEST)
     if form.is_valid():
-
         try:
             result = function(**form.cleaned_data)
         except models.BadStatusCodeError as e:

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -35,7 +35,10 @@ from crashstats.crashstats.management import PERMISSIONS
 from crashstats.supersearch.tests.common import (
     SUPERSEARCH_FIELDS_MOCKED_RESULTS,
 )
-from crashstats.supersearch.models import SuperSearchFields, SuperSearch
+from crashstats.supersearch.models import (
+    SuperSearchFields,
+    SuperSearchUnredacted,
+)
 from crashstats.crashstats.views import GRAPHICS_REPORT_HEADER
 from .test_models import Response
 
@@ -898,7 +901,9 @@ class TestViews(BaseTestViews):
             ]
             return response
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(url, {'product': 'WaterWolf'})
         eq_(response.status_code, 200)
@@ -941,7 +946,9 @@ class TestViews(BaseTestViews):
                 'total': 0
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(url, {'product': 'Neverheardof'})
         eq_(response.status_code, 400)
@@ -1030,7 +1037,9 @@ class TestViews(BaseTestViews):
                 'total': 0
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(url, {
             'product': 'WaterWolf',
@@ -1767,7 +1776,9 @@ class TestViews(BaseTestViews):
                 'total': 1234
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(url, {'product': 'WaterWolf'})
         ok_(response.status_code, 302)
@@ -2189,7 +2200,9 @@ class TestViews(BaseTestViews):
             ]
             return response
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(url, {
             'p': 'WaterWolf',
@@ -2421,7 +2434,9 @@ class TestViews(BaseTestViews):
             ]
             return response
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(url, {
             'p': 'WaterWolf',
@@ -4494,7 +4509,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 200)
         assert len(mock_calls) == 3
         eq_(mock_calls[-1]['sort'], 'build')
-        ok_('reverse' not in mock_calls[-1])
+        eq_(mock_calls[-1]['reverse'], False)
 
     @mock.patch('requests.get')
     def test_report_list_partial_reports_columns_override(self, rget):

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -18,8 +18,9 @@ from . import models
 
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, datetime.datetime):
+        if isinstance(obj, datetime.date):
             return obj.isoformat()
+
         return json.JSONEncoder.default(self, obj)
 
 

--- a/webapp-django/crashstats/profile/tests/test_views.py
+++ b/webapp-django/crashstats/profile/tests/test_views.py
@@ -4,7 +4,7 @@ from nose.tools import eq_, ok_
 from django.core.urlresolvers import reverse
 
 from crashstats.crashstats.management import PERMISSIONS
-from crashstats.supersearch.models import SuperSearch
+from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.crashstats.tests.test_views import BaseTestViews
 
 
@@ -42,7 +42,9 @@ class TestViews(BaseTestViews):
                 'total': 0
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('profile:profile')
 
@@ -64,7 +66,7 @@ class TestViews(BaseTestViews):
         ok_('1234abcd-ef56-7890-ab12-abcdef130802' in response.content)
         ok_('test@mozilla.com' in response.content)
 
-        SuperSearch.implementation().get.side_effect = (
+        SuperSearchUnredacted.implementation().get.side_effect = (
             mocked_supersearch_get_no_data
         )
 

--- a/webapp-django/crashstats/signature/tests/test_views.py
+++ b/webapp-django/crashstats/signature/tests/test_views.py
@@ -5,7 +5,7 @@ from nose.tools import eq_, ok_
 
 from django.core.urlresolvers import reverse
 
-from crashstats.supersearch.models import SuperSearch
+from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.crashstats.tests.test_views import BaseTestViews, Response
 
 
@@ -78,7 +78,9 @@ class TestViews(BaseTestViews):
 
             return {"hits": [], "total": 0}
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('signature:signature_reports')
 
@@ -154,7 +156,9 @@ class TestViews(BaseTestViews):
                 "total": 0
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('signature:signature_reports')
 
@@ -197,7 +201,9 @@ class TestViews(BaseTestViews):
                 "total": len(hits)
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('signature:signature_reports')
 
@@ -266,7 +272,9 @@ class TestViews(BaseTestViews):
                 "total": 0
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         # Test with no results.
         url = reverse(
@@ -353,7 +361,9 @@ class TestViews(BaseTestViews):
                 }
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         # Test with no results
         url = reverse(
@@ -446,7 +456,9 @@ class TestViews(BaseTestViews):
 
             return {"hits": [], "total": 0}
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('signature:signature_comments')
 
@@ -494,7 +506,9 @@ class TestViews(BaseTestViews):
                 "total": 140
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('signature:signature_comments')
 
@@ -791,7 +805,7 @@ class TestViews(BaseTestViews):
 
             return res
 
-        SuperSearch.implementation().get.side_effect = (
+        SuperSearchUnredacted.implementation().get.side_effect = (
             mocked_supersearch_get
         )
 
@@ -897,7 +911,7 @@ class TestViews(BaseTestViews):
 
             return res
 
-        SuperSearch.implementation().get.side_effect = (
+        SuperSearchUnredacted.implementation().get.side_effect = (
             mocked_supersearch_get
         )
 

--- a/webapp-django/crashstats/supersearch/models.py
+++ b/webapp-django/crashstats/supersearch/models.py
@@ -263,7 +263,6 @@ class SuperSearchField(models.SocorroMiddleware):
         raise NotImplemented()
 
     def create_field(self, **kwargs):
-        # print "IMPL", self.get_implementation()
         return self.get_implementation().create_field(**kwargs)
 
     def update_field(self, **kwargs):

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 from waffle.models import Switch
 
 from crashstats.crashstats.tests.test_views import BaseTestViews, Response
-from crashstats.supersearch.models import SuperSearch
+from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.supersearch.views import (
     get_report_list_parameters,
 )
@@ -268,7 +268,9 @@ class TestViews(BaseTestViews):
             else:
                 return {"hits": [], "facets": [], "total": 0}
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_results')
         response = self.client.get(
@@ -355,7 +357,9 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             return {"hits": [], "facets": [], "total": 0}
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_results')
         limit = int(re.findall('(\d+)', settings.RATELIMIT_SUPERSEARCH)[0])
@@ -458,7 +462,9 @@ class TestViews(BaseTestViews):
             )
             return results
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_results')
 
@@ -554,7 +560,9 @@ class TestViews(BaseTestViews):
                 "total": 0
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_results')
 
@@ -604,12 +612,15 @@ class TestViews(BaseTestViews):
                 "total": len(hits)
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_results')
 
         response = self.client.get(
             url,
+
             {
                 '_columns': ['version'],
                 '_facets': ['platform']
@@ -686,7 +697,9 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             return None
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_custom')
 
@@ -704,7 +717,9 @@ class TestViews(BaseTestViews):
         def mocked_supersearch_get(**params):
             return None
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         self.create_custom_query_perm()
 
@@ -726,7 +741,9 @@ class TestViews(BaseTestViews):
                 "indices": ["socorro200000", "socorro200001"]
             }
 
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = reverse('supersearch.search_custom')
         response = self.client.get(url, {'signature': 'nsA'})

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -6,7 +6,7 @@ from nose.tools import eq_, ok_
 
 from django.core.urlresolvers import reverse
 
-from crashstats.supersearch.models import SuperSearch
+from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.crashstats.tests.test_views import (
     BaseTestViews, Response, mocked_post_123
 )
@@ -150,7 +150,9 @@ class TestViews(BaseTestViews):
                 params['_columns']
             )
             return results
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         url = self.base_url + '?product=WaterWolf&version=19.0'
 
@@ -242,7 +244,9 @@ class TestViews(BaseTestViews):
                 },
                 'total': 0
             }
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         response = self.client.get(self.base_url, {
             'product': 'WaterWolf',
@@ -262,7 +266,9 @@ class TestViews(BaseTestViews):
                 },
                 'total': 0
             }
-        SuperSearch.implementation().get.side_effect = mocked_supersearch_get
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
 
         now = datetime.datetime.utcnow()
         today = now.replace(hour=0, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
@adngdb I know. It's huge. Let me explain...

What you need to play with it start it and use the new `/api/ProductVersions`. It's basically just a tool to read directly from the new class `socorro.external.postgresql.products.ProductVersions`. It works, right?

Next, because this is now the second implementation class that is directly implemented in the webapp, I had to do some surrounding changes...

**1)** Usually the implementation classes return something like this:
```python
things = self.query(sql, sql_params).zipped()
return {
    'hits': things,
    'total': len(things)
}
```
The problem with that is that `.zipped()` return a list of `DotDict` instances. Because `DotDict` is a fancy instance and not just a plain `dict` two very important classes struggled to deal with them. `django.core.cache.backends.locmem.LocMemCache` can't unpickle an object that has itself a method called `__setstate__`. And with `django.core.cache.backends.memcached.MemcachedCache` any attempt to do `cache.set('key', [DotDict({'x': 'y'})], 60)` will *work* but ultimately and silently failing meaning that everything we currently cache on `crashstats.crashstats.models.Bugs` *always* is a cache miss. 
So, because of that I refactored away that fancy use of `DocDict` in `self.query(...).zipped()`. Now, `.zipped()` just returns a list of pure python `dict`s. 
Hence, a hell of a lot of changes to tests related to `socorro.external.postgresql`.

**2)** The list of classes listed whose `.implementation` class attribute had to be replaced with a `mock.MagicMock` was growning. [Remember this?](https://github.com/mozilla/socorro/commit/df1738c950a1b45316bd238f097a17d65a3c69a8#diff-81f36efff7ced5436bb26a38f0c53b2eR33)
So I wrote that stuff in `testbase.py` that uses the `inspect` module. 

**3)** The big change to `001_product_info_view.sql` you may ignore. I just opened the file in Atom and ran the "Beautify Editor" plugin on it which does a half-decent job refactoring the file but doesn't actually change anything. Now the file is somewhat readable. Important because I'll later want to put that query inside `socorro.external.postgresql.products.ProductVersions`. 

**4)** I was tired of seeing `filters = [('somekey', None, ["list"]), ...]` etc. It makes much more sense to let that be real python types instead of strings that describe types. The code (e.g. `modern=False` by default) might be a bit messy right now but given time we should change all places where this happens. 
