### PR TITLE
fixes bug 1248730 - Don't compare correlation .json files with whitespace

### DIFF
--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -557,9 +557,13 @@ fi
 
 check_for_logged_fatal_errors $? correlations
 
-diff ./correlations/20151130 ./testcrash/correlations-integration-correct-output >correlation.diff
+diff -w ./correlations/20151130 ./testcrash/correlations-integration-correct-output >correlation.diff
 if [ $? = 1 ]
 then
+    echo "CONTENT OF ./correlations/20151130"
+    ls -ltr ./correlations/20151130
+    echo "CONTENT of ./testcrash/correlations-integration-correct-output"
+    ls -ltr ./testcrash/correlations-integration-correct-output
     # something went wrong
     echo "ERROR: correlations produced unexpected output"
     echo "***** BEGIN correlation log *****"


### PR DESCRIPTION
I don't think this will definitely remove all those weird integration test errors we see. I still don't know for sure if this is the explanation. 
But there have been cases where we're seen some strange diffs related to whitespace. Let's avoid that. 

I'm also adding a bit more verbosity to compare the directory contents when there is a diff. 