### PR TITLE
bug 1246253 - pivot productversions

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -119,6 +119,7 @@ TYPE_MAP = {
     datetime.date: forms.DateField,
     datetime.datetime: forms.DateTimeField,
     int: forms.IntegerField,
+    bool: forms.BooleanField,
 }
 
 
@@ -145,6 +146,28 @@ class FormWrapperMeta(DeclarativeFieldsMetaclass):
 class FormWrapper(forms.Form):
     __metaclass__ = FormWrapperMeta
 
+    def clean(self):
+        cleaned_data = super(FormWrapper, self).clean()
+
+        for field in self.fields:
+            # Because the context for all of this is the API,
+            # and we're using django forms there's a mismatch to how
+            # boolean fields should be handled.
+            # Django forms are meant for HTML forms. A key principle
+            # functionality of a HTML form and a checkbox is that
+            # if the user choses to NOT check a checkbox, the browser
+            # will not send `mybool=false` or `mybool=''`. It will simply
+            # not send anything and then the server has to assume the user
+            # chose to NOT check it because it was offerend.
+            # On a web API, however, the user doesn't use checkboxes.
+            # He uses `?mybool=truthy` or `&mybool=falsy`.
+            # Therefore, for our boolean fields, if the value is not
+            # present at all, we have to assume it to be None.
+            # That makes it possible to actually set `mybool=false`
+            if isinstance(self.fields[field], forms.BooleanField):
+                if field not in self.data:
+                    self.cleaned_data[field] = None
+        return cleaned_data
 
 # Names of models we don't want to serve at all
 BLACKLIST = (

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -18,7 +18,7 @@ from . import models
 
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, datetime.datetime):
+        if isinstance(obj, datetime.date):
             return obj.isoformat()
         return json.JSONEncoder.default(self, obj)
 

--- a/webapp-django/crashstats/legacy/models.py
+++ b/webapp-django/crashstats/legacy/models.py
@@ -1,0 +1,55 @@
+from django.db import models
+
+
+class Router(object):
+
+    def db_for_read(self, model, **hints):
+        return {
+            'legacy': 'legacy'
+        }.get(model._meta.app_label)
+
+    # at the moment
+    db_for_write = db_for_read
+
+
+class Product(models.Model):
+    name = models.TextField(primary_key=True, db_column='product_name')
+    sort = models.SmallIntegerField()
+    rapid_release_version = models.TextField(blank=True, null=True)
+    release_name = models.TextField()  # This field type is a guess.
+    rapid_beta_version = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'products'
+
+
+class ProductVersion(models.Model):
+    product_version_id = models.AutoField(primary_key=True)
+    product = models.ForeignKey('Product', db_column='product_name')
+    # major_version = models.TextField()
+    # release_version = models.TextField()  # This field type is a guess.
+    version = models.TextField(db_column='version_string')
+    beta_number = models.IntegerField(blank=True, null=True)
+    version_sort = models.TextField()
+    build_date = models.DateField()
+    sunset_date = models.DateField()
+    is_featured = models.BooleanField(db_column='featured_version')
+    build_type = models.TextField()  # This field type is a guess.
+    has_builds = models.NullBooleanField()
+    is_rapid_beta = models.NullBooleanField()
+    rapid_beta = models.ForeignKey('self', blank=True, null=True)
+    # build_type_enum = models.TextField(blank=True, null=True)
+    version_build = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'product_versions'
+        unique_together = (
+            ('product', 'version'),
+            # ('product', 'release_version', 'beta_number'),
+        )
+
+        # api_mapping = {
+        #     'product':
+        # }


### PR DESCRIPTION
There's a lot of work left to be done. But it works. 

I took some very few ideas from https://github.com/mozilla/socorro/pull/3192 but what you'll notice here is that this change is ALL in the webapp. No new messy class in `socorro/external/postgresql/`.

So the web API continues to work (might need some more testing). You can do things like `http://socorro.dev/api/ProductVersions/?product=Thunderbird`. But you can't add things like `&end_date__lt=2016-02-18` or `&end_date=<2016-02-18`. 

The idea is that any view code that needs the product versions would fetch it just like any other django ORM model. E.g. Instead of ...
```python
from crashstats.crashstats.models import ProductVersions
...
api = ProductVersions()
today = datetime.datetime.utcnow().date()
products = api.get(product='Firefox', end_date='>' + today.isoformat())['hits']
versions = [x['version'] for x in products]
```
We'd do this instead...
```python
from crashstats.legacy.models import ProductVersion
...
today = datetime.datetime.utcnow().date()
products = ProductVersion.objects.filter(product='Firefox', end_date__gte=today)
versions = products.values_list('version', flat=True)
```
So, "inside the web API" we'll have a much richer and better querying system/ORM. On the outside we'll have wrappers for these ORM models that we hack together. 

If you think this is an awesome idea and we go ahead with it, it means that not only can we take out `/products/` from the middleware app, we'd also be able to entirely delete `socorro/external/postgresql/products.py` and `socorro/unittest/external/postgresql/test_products.py`.
(There might be some processor, collector or something like that that relies on these, so we'll delete carefully)