### PR TITLE
fixes bug 1254124 - Crontabber state pure implementation

### DIFF
--- a/socorro/external/postgresql/crontabber_state.py
+++ b/socorro/external/postgresql/crontabber_state.py
@@ -5,7 +5,6 @@
 import logging
 
 from socorro.external.postgresql.base import PostgreSQLBase
-from socorrolib.lib import datetimeutil
 
 logger = logging.getLogger("webapi")
 
@@ -40,17 +39,5 @@ class CrontabberState(PostgreSQLBase):
         for row in results.zipped():
             app_name = row.pop('app_name')
             state[app_name] = row
-            possible_datetimes = (
-                'next_run',
-                'first_run',
-                'last_run',
-                'last_success',
-                'ongoing'
-            )
-            for key in possible_datetimes:
-                value = state[app_name][key]
-                if value is None:
-                    continue
-                state[app_name][key] = datetimeutil.date_to_string(value)
 
         return {"state": state}

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -51,7 +51,6 @@ SERVICES_LIST = (
         r'signature_history|exploitability|adu_by_signature)/(.*)',
         'crashes.Crashes'
     ),
-    (r'/crontabber_state/(.*)', 'crontabber_state.CrontabberState'),
     (r'/field/(.*)', 'field.Field'),
     (r'/priorityjobs/(.*)', 'priorityjobs.Priorityjobs'),
     (r'/products/build_types/(.*)', 'product_build_types.ProductBuildTypes'),

--- a/socorro/unittest/external/postgresql/test_crontabber_state.py
+++ b/socorro/unittest/external/postgresql/test_crontabber_state.py
@@ -67,10 +67,22 @@ class IntegrationTestCrontabberStatus(PostgreSQLTestCase):
         res = state.get()
 
         slow_one = res['state']['slow-one']
-        eq_(slow_one['next_run'], '2013-02-09T01:16:00+00:00')
-        eq_(slow_one['first_run'], '2012-11-05T23:27:07+00:00')
-        eq_(slow_one['last_run'], '2013-02-09T00:16:00+00:00')
-        eq_(slow_one['last_success'], '2012-12-24T22:27:07+00:00')
+        eq_(
+            slow_one['next_run'].isoformat(),
+            '2013-02-09T01:16:00.893834+00:00'
+        )
+        eq_(
+            slow_one['first_run'].isoformat(),
+            '2012-11-05T23:27:07.316347+00:00'
+        )
+        eq_(
+            slow_one['last_run'].isoformat(),
+            '2013-02-09T00:16:00.893834+00:00'
+        )
+        eq_(
+            slow_one['last_success'].isoformat(),
+            '2012-12-24T22:27:07.316893+00:00'
+        )
         eq_(slow_one['error_count'], 6)
         eq_(slow_one['depends_on'], [])
         eq_(slow_one['last_error'], {
@@ -80,10 +92,22 @@ class IntegrationTestCrontabberStatus(PostgreSQLTestCase):
         })
 
         slow_two = res['state']['slow-two']
-        eq_(slow_two['next_run'], '2012-11-12T19:39:59+00:00')
-        eq_(slow_two['first_run'], '2012-11-05T23:27:17+00:00')
-        eq_(slow_two['last_run'], '2012-11-12T18:39:59+00:00')
-        eq_(slow_two['last_success'], '2012-11-12T18:27:17+00:00')
+        eq_(
+            slow_two['next_run'].isoformat(),
+            '2012-11-12T19:39:59.521605+00:00'
+        )
+        eq_(
+            slow_two['first_run'].isoformat(),
+            '2012-11-05T23:27:17.341879+00:00'
+        )
+        eq_(
+            slow_two['last_run'].isoformat(),
+            '2012-11-12T18:39:59.521605+00:00'
+        )
+        eq_(
+            slow_two['last_success'].isoformat(),
+            '2012-11-12T18:27:17.341895+00:00'
+        )
         eq_(slow_two['error_count'], 0)
         eq_(slow_two['depends_on'], ['slow-one'])
         eq_(slow_two['last_error'], {})

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -24,6 +24,7 @@ import socorro.external.postgresql.products
 import socorro.external.postgresql.graphics_report
 import socorro.external.postgresql.graphics_devices
 import socorro.external.postgresql.gccrashes
+import socorro.external.postgresql.crontabber_state
 
 from socorrolib.app import socorro_app
 
@@ -1500,7 +1501,9 @@ class Status(SocorroMiddleware):
 
 class CrontabberState(SocorroMiddleware):
 
-    URL_PREFIX = '/crontabber_state/'
+    implementation = (
+        socorro.external.postgresql.crontabber_state.CrontabberState
+    )
 
     # make it small but but non-zero
     cache_seconds = 60  # 1 minute

--- a/webapp-django/crashstats/monitoring/views.py
+++ b/webapp-django/crashstats/monitoring/views.py
@@ -2,7 +2,6 @@ import datetime
 import urlparse
 
 import elasticsearch
-import isodate
 import requests
 
 from django.shortcuts import render
@@ -101,7 +100,7 @@ def crontabber_status(request):
 
     all_apps = api.get()['state']
     last_runs = [
-        isodate.parse_datetime(x['last_run']) for x in all_apps.values()
+        x['last_run'] for x in all_apps.values()
     ]
     if last_runs:
         ancient_times = timezone.now() - datetime.timedelta(


### PR DESCRIPTION
Note how I took the liberty to delete the `test_carry_mware_error_codes` test. 
That one was about testing how the middleware response HTTP error codes. It had to use something so it used the `CrontabberState` (because it's simple). 

As of this PR, the middleware isn't gone. But it's dying. The `CrontabberState` no longer comes from the middleware and I **could** change the test to instead use some other implementation that's still in `middleware_app` but at this rate, that'd just have to be change and be changed as we continue to dismantle the middleware. 