### PR TITLE
Bug 1257572 - Add js::AutoEnterOOMUnsafeRegion::crash to our markers for OOM signatures

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -853,7 +853,8 @@ class OOMSignature(Rule):
     signature_fragments = (
         'NS_ABORT_OOM',
         'mozalloc_handle_oom',
-        'CrashAtUnhandlableOOM'
+        'CrashAtUnhandlableOOM',
+        'AutoEnterOOMUnsafeRegion'
     )
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
From what I understand, js::AutoEnterOOMUnsafeRegion::crash is either a replacement or at least a similar thing to js::CrashAtUnhandlableOOM which we already handle, and from the name, I'm pretty sure that all of AutoEnterOOMUnsafeRegion is pretty surely OOM handling, so if we crash there, we should assign an "OOM" signature.