### PR TITLE
Add 'RefPtr.*' to prefixSignatureRegEx.

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -473,6 +473,7 @@ class CSignatureTool(CSignatureToolBase):
           'realloc',
           'recv',
           '.*ReentrantMonitor::Wait.*',
+          'RefPtr.*',
           '_RTC_Terminate',
           'Rtl.*',
           '_Rtl.*',


### PR DESCRIPTION
This is since nsRefPtr has been renamed to RefPtr.  I'm leaving the equivalent nsRefPtr.* line for older versions.