### PR TITLE
Bug 1249359 store correlations in es

### DIFF
--- a/socorro/external/es/correlations.py
+++ b/socorro/external/es/correlations.py
@@ -2,19 +2,37 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import datetime
 import json
 import os
+import hashlib
 
-from configman import Namespace, RequiredConfig
-from configman.converters import class_converter
+from configman import Namespace
+from configman.converters import class_converter, str_to_list
+
+from socorro.analysis.correlations.correlations_rule_base import (
+    CorrelationsStorageBase,
+)
 
 
+# Needed for the ability to find the
+# mappings/correlations_index_settings.json file whose path is relative
+# to this file.
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-class Correlations(RequiredConfig):
+class Correlations(CorrelationsStorageBase):
 
     required_config = Namespace()
+
+    required_config.elasticsearch = Namespace()
+    required_config.elasticsearch.add_option(
+        'elasticsearch_class',
+        default='socorro.external.es.connection_context.ConnectionContext',
+        from_string_converter=class_converter,
+        reference_value_from='resource.elasticsearch',
+    )
+
     required_config.add_option(
         'index_creator',
         default='socorro.external.es.index_creator.IndexCreator',
@@ -33,9 +51,20 @@ class Correlations(RequiredConfig):
         doc='the index that handles data about correlations',
     )
 
+    required_config.add_option(
+        'recognized_platforms',
+        default='Windows NT, Linux, Mac OS X',
+        doc='The kinds of platform names we recognize',
+        from_string_converter=str_to_list,
+    )
+
     def __init__(self, config):
-        super(Correlations, self).__init__()
+        super(Correlations, self).__init__(config)
         self.config = config
+
+        self.es_context = self.config.elasticsearch.elasticsearch_class(
+            config=self.config.elasticsearch
+        )
 
         self.indices_cache = set()
 
@@ -51,6 +80,135 @@ class Correlations(RequiredConfig):
             es_settings = json.loads(settings_json)
 
             index_creator = self.config.index_creator(self.config)
+            # This is resilient to being called repeatedly even
+            # when the index already exists.
             index_creator.create_index(es_index, es_settings)
-
             self.indices_cache.add(es_index)
+
+    def _prefix_to_datetime_date(self, prefix):
+        yy = int(prefix[:4])
+        mm = int(prefix[4:6])
+        dd = int(prefix[6:8])
+        return datetime.date(yy, mm, dd)
+
+    @staticmethod
+    def make_id(document, only_keys=None):
+        only_keys = only_keys or (
+            'platform',
+            'product',
+            'version',
+            'date',
+            'key',
+            'signature',
+        )
+
+        string_parts = []
+        for key, value in sorted(document.items()):
+            if key not in only_keys:
+                continue
+            if isinstance(value, datetime.date):
+                value = value.isoformat()
+            if isinstance(value, int):
+                value = str(value)
+            if isinstance(value, basestring):
+                string_parts.append(value)
+        return hashlib.md5(
+            (''.join(string_parts)).encode('utf-8')
+        ).hexdigest()
+
+    def close(self):
+        """for the benefit of this class's subclasses that need to have
+        this defined."""
+        pass
+
+
+class CoreCounts(Correlations):
+
+    def store(
+        self,
+        counts_summary_structure,
+        prefix,
+        name,
+        key,
+    ):
+        date = self._prefix_to_datetime_date(prefix)
+        index = self.get_index_for_date(date)
+        self.create_correlations_index(index)
+
+        notes = counts_summary_structure['notes']
+        product = key.split('_', 1)[0]
+        version = key.split('_', 1)[1]
+
+        for platform in counts_summary_structure:
+            if platform not in self.config.recognized_platforms:
+                continue
+            count = counts_summary_structure[platform]['count']
+            signatures = counts_summary_structure[platform]['signatures']
+
+            for signature, payload in signatures.items():
+                doc = {
+                    'platform': platform,
+                    'product': product,
+                    'version': version,
+                    'count': count,
+                    'signature': signature,
+                    'payload': json.dumps(payload),
+                    'date': date,
+                    'key': name,
+                    'notes': notes,
+                }
+                with self.es_context() as conn:
+                    conn.index(
+                        index=index,
+                        # see correlations_index_settings.json
+                        doc_type='correlations',
+                        body=doc,
+                        id=self.make_id(doc)
+                    )
+
+
+class InterestingModules(Correlations):
+
+    def store(
+        self,
+        counts_summary_structure,
+        prefix,
+        name,
+        key,
+    ):
+        date = self._prefix_to_datetime_date(prefix)
+        index = self.get_index_for_date(date)
+        self.create_correlations_index(index)
+
+        notes = counts_summary_structure['notes']
+        product = key.split('_', 1)[0]
+        version = key.split('_', 1)[1]
+        os_counters = counts_summary_structure['os_counters']
+        for platform in os_counters:
+            if not platform:
+                continue
+            if platform not in self.config.recognized_platforms:
+                continue
+            count = os_counters[platform]['count']
+            signatures = os_counters[platform]['signatures']
+
+            for signature, payload in signatures.items():
+                doc = {
+                    'platform': platform,
+                    'product': product,
+                    'version': version,
+                    'count': count,
+                    'signature': signature,
+                    'payload': json.dumps(payload),
+                    'date': date,
+                    'key': name,
+                    'notes': notes,
+                }
+                with self.es_context() as conn:
+                    conn.index(
+                        index=index,
+                        # see correlations_index_settings.json
+                        doc_type='correlations',
+                        body=doc,
+                        id=self.make_id(doc)
+                    )

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -2,18 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import elasticsearch
-
 from threading import Thread
 from Queue import Queue
 from contextlib import contextmanager
 
-from socorro.external.crashstorage_base import CrashStorageBase
-from socorro.external.es.index_creator import IndexCreator
-from socorrolib.lib import datetimeutil
-
+import elasticsearch
 from configman import Namespace
 from configman.converters import class_converter
+
+from socorro.external.crashstorage_base import CrashStorageBase
+from socorro.external.es.index_creator import IndexCreator
+from socorrolib.lib.converters import change_default
+from socorrolib.lib.datetimeutil import string_to_datetime
+from socorro.external.crashstorage_base import Redactor
 
 
 #==============================================================================
@@ -156,11 +157,6 @@ class ESCrashStorage(CrashStorageBase):
                 exc_info=True
             )
             raise
-
-
-from socorrolib.lib.converters import change_default
-from socorrolib.lib.datetimeutil import string_to_datetime
-from socorro.external.crashstorage_base import Redactor
 
 
 #==============================================================================
@@ -375,4 +371,3 @@ ESBulkCrashStorageRedactedSave = _create_bulk_load_crashstore(
 
 #==============================================================================
 ESCrashStorageNoStackwalkerOutput = ESCrashStorageRedactedSave
-

--- a/socorro/external/es/index_creator.py
+++ b/socorro/external/es/index_creator.py
@@ -63,5 +63,6 @@ class IndexCreator(RequiredConfig):
             )
         except elasticsearch.exceptions.RequestError, e:
             # If this index already exists, swallow the error.
+            # NOTE! This is NOT how the error looks like in ES 2.x
             if 'IndexAlreadyExistsException' not in str(e):
                 raise

--- a/socorro/external/es/new_crash_source.py
+++ b/socorro/external/es/new_crash_source.py
@@ -1,0 +1,103 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+from elasticsearch import helpers
+from configman import Namespace, RequiredConfig, class_converter
+
+
+class ESNewCrashSource(RequiredConfig):
+
+    required_config = Namespace()
+    required_config.add_option(
+        'cap',
+        default=0,
+        doc='If set to something other than 0, caps how many to yield'
+    )
+    required_config.elasticsearch = Namespace()
+    required_config.elasticsearch.add_option(
+        'elasticsearch_class',
+        default='socorro.external.es.connection_context.ConnectionContext',
+        from_string_converter=class_converter,
+        reference_value_from='resource.elasticsearch',
+    )
+
+    def __init__(self, config, name=None, quit_check_callback=None):
+        self.config = config
+        self.es_context = self.config.elasticsearch.elasticsearch_class(
+            config=self.config.elasticsearch
+        )
+
+    def new_crashes(self, date, product, versions):
+        """Return an iterator of crash IDs.
+
+        Confusingly, inside this method we're using an iterator.
+        The reason we first exhaust the iterator BEFORE returning it
+        is because *if* we do this:
+
+            res = helpers.scan(...)
+            for hit in res:
+                yield hit['fields']['crash_id'][0]
+
+        Then, between each of these yields the fetch transform save
+        app will do something with this crash ID. That's cute but the
+        problem is that if you get 1,000 crash IDs out and between each
+        1,000 you have to do a S3 boto get, you have to wait many
+        milliseconds between each and then the scroll connection
+        has to stay open too long.
+
+        Instead, we get all the crash IDs out first, and *then* return
+        an iterator.
+        """
+        next_day = date + datetime.timedelta(days=1)
+
+        query = {
+            'filter': {
+                'bool': {
+                    'must': [
+                        {
+                            'range': {
+                                'processed_crash.date_processed': {
+                                    'gte': date.isoformat(),
+                                    'lt': next_day.isoformat(),
+                                }
+                            }
+                        },
+                        {
+                            'term': {
+                                'processed_crash.product': product.lower()
+                            }
+                        },
+                        {
+                            'terms': {
+                                'processed_crash.version': [
+                                    x.lower() for x in versions
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        es_index = date.strftime(self.config.elasticsearch.elasticsearch_index)
+        es_doctype = self.config.elasticsearch.elasticsearch_doctype
+
+        crash_ids = []
+        with self.es_context() as es_context:
+            res = helpers.scan(
+                es_context,
+                scroll='2m',  # keep the "scroll" connection open for 2 minutes
+                index=es_index,
+                doc_type=es_doctype,
+                fields=['crash_id'],
+                query=query,
+            )
+            for hit in res:
+                crash_ids.append(hit['fields']['crash_id'][0])
+                if self.config.cap and len(crash_ids) >= self.config.cap:
+                    break
+
+        return iter(crash_ids)

--- a/socorro/unittest/external/es/base.py
+++ b/socorro/unittest/external/es/base.py
@@ -6,9 +6,9 @@ import mock
 import random
 import uuid
 from distutils.version import LooseVersion
-from elasticsearch.helpers import bulk
 from functools import wraps
 
+from elasticsearch.helpers import bulk
 from configman import ConfigurationManager, environment
 from nose import SkipTest
 
@@ -167,7 +167,9 @@ SUPERSEARCH_FIELDS = {
         'is_mandatory': False,
         'storage_mapping': {
             'type': 'date',
-            'format': 'yyyy-MM-dd\'T\'HH:mm:ssZZ||yyyy-MM-dd\'T\'HH:mm:ss.SSSSSSZZ'
+            'format': (
+                'yyyy-MM-dd\'T\'HH:mm:ssZZ||yyyy-MM-dd\'T\'HH:mm:ss.SSSSSSZZ'
+            )
         },
     },
     'address': {
@@ -843,6 +845,12 @@ class ElasticsearchTestCase(TestCase):
 
         super(ElasticsearchTestCase, self).tearDown()
 
+    def health_check(self):
+        self.connection.cluster.health(
+            wait_for_status='yellow',
+            request_timeout=1
+        )
+
     def get_tuned_config(self, sources, extra_values=None):
         if not isinstance(sources, (list, tuple)):
             sources = [sources]
@@ -963,7 +971,7 @@ class ElasticsearchTestCase(TestCase):
         )
         self.refresh_index()
 
-    def refresh_index(self):
+    def refresh_index(self, es_index=None):
         self.index_client.refresh(
-            index=self.config.elasticsearch.elasticsearch_index
+            index=es_index or self.config.elasticsearch.elasticsearch_index
         )

--- a/socorro/unittest/external/es/test_correlations.py
+++ b/socorro/unittest/external/es/test_correlations.py
@@ -3,10 +3,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
+import json
 
 from nose.tools import eq_, ok_
 
-from socorro.external.es.correlations import Correlations
+from socorro.external.es.correlations import (
+    Correlations,
+    CoreCounts,
+    InterestingModules,
+)
 from socorro.unittest.external.es.base import ElasticsearchTestCase
 
 # Uncomment these lines to decrease verbosity of the elasticsearch library
@@ -19,9 +24,67 @@ from socorro.unittest.external.es.base import ElasticsearchTestCase
 ES_CORRELATIONS_INDEX = 'integration_test_correlations_%Y%m'
 
 
-class IntegrationTestCorrelations(ElasticsearchTestCase):
+sample_core_counts_summary = {
+    'notes': 'Some notes',
+    '': {
+        'count': 4,
+        'signatures': {},
+    },
+    'Linux': {
+        'count': 1,
+        'signatures': {},
+    },
+    'Windows NT': {
+        'count': 493,
+        'signatures': {
+            'my__special__signature': {
+                'cores': {
+                    'amd64 with 4 cores': {
+                        'in_os_count': 1,
+                        'in_os_ratio': 0.002028397565922921,
+                        'in_sig_count': 0,
+                        'in_sig_ratio': 0.0,
+                        'rounded_in_os_ratio': 0,
+                        'rounded_in_sig_ratio': 0
+                    }
+                }
+            }
+        }
+
+    }
+}
+
+sample_interesting_modules_summary = {
+    'notes': [],
+    'os_counters': {
+        '': {
+            'count': 4,
+            'signatures': {},
+        },
+        'Windows NT': {
+            'count': 493,
+            'signatures': {
+                'F1398665248_|EXCEPTION_BREAKPOINT': {
+                    'count': 19,
+                    'modules': {
+                        "{82AF8DCA-6DE9-405D-BD5E-43525BDAD38A}": {
+                            "in_os_count": 43,
+                            "in_os_ratio": 9,
+                            "in_sig_count": 8,
+                            "in_sig_ratio": 22,
+                            "osys_count": 493,
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+class BaseTestCorrelations(ElasticsearchTestCase):
     def __init__(self, *args, **kwargs):
-        super(IntegrationTestCorrelations, self).__init__(*args, **kwargs)
+        super(BaseTestCorrelations, self).__init__(*args, **kwargs)
 
         self.config = self.get_tuned_config(Correlations, {
             'elasticsearch_correlations_index': ES_CORRELATIONS_INDEX
@@ -36,7 +99,10 @@ class IntegrationTestCorrelations(ElasticsearchTestCase):
         for index in self.indices_for_deletion:
             self.index_client.delete(index)
 
-        super(IntegrationTestCorrelations, self).tearDown()
+        super(BaseTestCorrelations, self).tearDown()
+
+
+class IntegrationTestCorrelations(BaseTestCorrelations):
 
     def test_create_correlations_index(self):
         today = datetime.datetime.utcnow().date()
@@ -53,3 +119,90 @@ class IntegrationTestCorrelations(ElasticsearchTestCase):
 
         # We should be able to create that index again without any errors.
         correlations.create_correlations_index(es_index)
+
+
+class TestCoreCounts(BaseTestCorrelations):
+
+    def test_store(self):
+        correlations = CoreCounts(config=self.config)
+        today = datetime.datetime.utcnow()
+        correlations.store(
+            sample_core_counts_summary,
+            today.strftime('%Y%m%d'),
+            'core-counts',
+            'Firefox_43.0.1'
+        )
+        es_index = correlations.get_index_for_date(today.date())
+        correlations.create_correlations_index(es_index)
+        self.indices_for_deletion.append(es_index)
+        self.refresh_index(es_index)
+        result = self.connection.search(
+            index=es_index,
+            doc_type='correlations',
+        )['hits']
+        eq_(result['total'], 1)
+        hit, = result['hits']
+        _source = hit['_source']
+        eq_(
+            _source['count'],
+            sample_core_counts_summary['Windows NT']['count']
+        )
+        eq_(
+            _source['signature'],
+            sample_core_counts_summary['Windows NT']['signatures'].keys()[0]
+        )
+        eq_(_source['date'], today.strftime('%Y-%m-%d'))
+        eq_(_source['notes'], sample_core_counts_summary['notes'])
+        eq_(_source['key'], 'core-counts')
+        eq_(_source['platform'], 'Windows NT')
+        eq_(_source['product'], 'Firefox')
+        eq_(_source['version'], '43.0.1')
+        payload, = (
+            sample_core_counts_summary['Windows NT']['signatures'].values()
+        )
+        eq_(_source['payload'], json.dumps(payload))
+
+
+class TestInterestingModules(BaseTestCorrelations):
+
+    def test_store(self):
+        correlations = InterestingModules(config=self.config)
+        today = datetime.datetime.utcnow()
+        correlations.store(
+            sample_interesting_modules_summary,
+            today.strftime('%Y%m%d'),
+            'interesting-addons',
+            'Firefox_45.0b1'
+        )
+        es_index = correlations.get_index_for_date(today.date())
+        correlations.create_correlations_index(es_index)
+        self.indices_for_deletion.append(es_index)
+        self.refresh_index(es_index)
+        result = self.connection.search(
+            index=es_index,
+            doc_type='correlations',
+        )['hits']
+        eq_(result['total'], 1)
+        hit, = result['hits']
+        _source = hit['_source']
+        eq_(
+            _source['count'],
+            sample_interesting_modules_summary
+            ['os_counters']['Windows NT']['count']
+        )
+        eq_(
+            _source['signature'],
+            sample_interesting_modules_summary
+            ['os_counters']['Windows NT']['signatures'].keys()[0]
+        )
+        eq_(_source['date'], today.strftime('%Y-%m-%d'))
+        eq_(_source['notes'], sample_interesting_modules_summary['notes'])
+        eq_(_source['key'], 'interesting-addons')
+        eq_(_source['platform'], 'Windows NT')
+        eq_(_source['product'], 'Firefox')
+        eq_(_source['version'], '45.0b1')
+        payload, = (
+            sample_interesting_modules_summary
+            ['os_counters']['Windows NT']['signatures'].values()
+        )
+        eq_(_source['payload'], json.dumps(payload))

--- a/socorro/unittest/external/es/test_new_crash_source.py
+++ b/socorro/unittest/external/es/test_new_crash_source.py
@@ -1,0 +1,168 @@
+import datetime
+from copy import deepcopy
+
+from nose.tools import eq_
+
+from socorrolib.lib.datetimeutil import utc_now
+from socorro.external.es.new_crash_source import ESNewCrashSource
+from socorro.unittest.external.es.base import ElasticsearchTestCase
+
+
+# A dummy crash report that is used for testing.
+a_processed_crash = {
+    'addons': [['{1a5dabbd-0e74-41da-b532-a364bb552cab}', '1.0.4.1']],
+    'addons_checked': None,
+    'address': '0x1c',
+    'app_notes': '...',
+    'build': '20120309050057',
+    'client_crash_date': '2012-04-08T10:52:42+00:00',
+    'completeddatetime': '2012-04-08T10:56:50.902884+00:00',
+    'cpu_info': 'None | 0',
+    'cpu_name': 'arm',
+    'crashedThread': 8,
+    'date_processed': '2012-04-08T10:56:41.558922+00:00',
+    'distributor': None,
+    'distributor_version': None,
+    'dump': '...',
+    'email': 'bogus@bogus.com',
+    'flash_version': '[blank]',
+    'hangid': None,
+    'id': 361399767,
+    # 'json_dump': {
+    #     'things': 'stackwalker output',
+    # },
+    'install_age': 22385,
+    'last_crash': None,
+    'os_name': 'Linux',
+    'os_version': '0.0.0 Linux 2.6.35.7-perf-CL727859 #1 ',
+    'processor_notes': 'SignatureTool: signature truncated due to length',
+    'process_type': 'plugin',
+    'product': 'FennecAndroid',
+    'PluginFilename': 'dwight.txt',
+    'PluginName': 'wilma',
+    'PluginVersion': '69',
+    'reason': 'SIGSEGV',
+    'release_channel': 'default',
+    'ReleaseChannel': 'default',
+    'signature': 'libxul.so@0x117441c',
+    'started_datetime': '2012-04-08T10:56:50.440752+00:00',
+    'startedDateTime': '2012-04-08T10:56:50.440752+00:00',
+    'success': True,
+    'topmost_filenames': [],
+    'truncated': False,
+    'uptime': 170,
+    'url': 'http://embarasing.porn.com',
+    'user_comments': None,
+    'user_id': None,
+    'uuid': '936ce666-ff3b-4c7a-9674-367fe2120408',
+    'version': '13.0a1',
+    'upload_file_minidump_flash1': {
+        'things': 'untouched',
+        'json_dump': 'stackwalker output',
+    },
+    'upload_file_minidump_flash2': {
+        'things': 'untouched',
+        'json_dump': 'stackwalker output',
+    },
+    'upload_file_minidump_browser': {
+        'things': 'untouched',
+        'json_dump': 'stackwalker output',
+    },
+}
+
+a_processed_crash['date_processed'] = utc_now().isoformat()
+
+a_firefox_processed_crash = deepcopy(a_processed_crash)
+a_firefox_processed_crash['product'] = 'Firefox'
+a_firefox_processed_crash['version'] = '43.0.1'
+a_firefox_processed_crash['uuid'] = '825bc666-ff3b-4c7a-9674-367fe1019397'
+a_firefox_processed_crash['date_processed'] = utc_now().isoformat()
+
+a_raw_crash = {
+    'foo': 'alpha',
+    'bar': 42
+}
+
+
+# Uncomment these lines to decrease verbosity of the elasticsearch library
+# while running unit tests.
+# import logging
+# logging.getLogger('elasticsearch').setLevel(logging.ERROR)
+
+
+class IntegrationTestESNewCrashSource(ElasticsearchTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(IntegrationTestESNewCrashSource, self).__init__(*args, **kwargs)
+
+        self.config = self.get_tuned_config(ESNewCrashSource)
+
+    def test_no_new_crashes(self):
+        new_crash_source = ESNewCrashSource(self.config)
+        self.health_check()
+
+        generator = new_crash_source.new_crashes(
+            utc_now() - datetime.timedelta(days=1),
+            'Firefox',
+            ['43.0.1']
+        )
+        eq_(list(generator), [])
+
+        self.index_crash(
+            a_processed_crash,
+            raw_crash=a_raw_crash,
+            crash_id=a_processed_crash['uuid']
+        )
+        self.refresh_index()
+
+        # Same test now that there is a processed crash in there
+        # but notably under a different name and version.
+        generator = new_crash_source.new_crashes(
+            utc_now() - datetime.timedelta(days=1),
+            'Firefox',
+            ['43.0.1']
+        )
+        eq_(list(generator), [])
+
+    def test_new_crashes(self):
+        new_crash_source = ESNewCrashSource(self.config)
+        self.index_crash(
+            a_processed_crash,
+            raw_crash=a_raw_crash,
+            crash_id=a_processed_crash['uuid']
+        )
+        self.index_crash(
+            a_firefox_processed_crash,
+            raw_crash=a_raw_crash,
+            crash_id=a_firefox_processed_crash['uuid']
+        )
+        other_firefox_processed_crash = deepcopy(a_firefox_processed_crash)
+        other_firefox_processed_crash['uuid'] = (
+            other_firefox_processed_crash['uuid'].replace('a', 'e')
+        )
+        other_firefox_processed_crash['date_processed'] = (
+            utc_now() - datetime.timedelta(days=1)
+        )
+        self.index_crash(
+            other_firefox_processed_crash,
+            raw_crash=a_raw_crash,
+            crash_id=other_firefox_processed_crash['uuid']
+        )
+        self.refresh_index()
+
+        assert self.connection.get(
+            index=self.config.elasticsearch.elasticsearch_index,
+            id=a_processed_crash['uuid']
+        )
+        assert self.connection.get(
+            index=self.config.elasticsearch.elasticsearch_index,
+            id=a_firefox_processed_crash['uuid']
+        )
+
+        # same test now that there is a processed crash in there
+        generator = new_crash_source.new_crashes(
+            utc_now() - datetime.timedelta(days=1),
+            'Firefox',
+            ['43.0.1']
+        )
+        eq_(list(generator), [a_firefox_processed_crash['uuid']])


### PR DESCRIPTION
The way to run this is like this:

```
socorro correlations  \
--resource.postgresql.database_port=5433 \
--resource.postgresql.database_name=breakpad \
--secrets.postgresql.database_username=breakpad_rw \
--secrets.postgresql.database_password=*********** \
--resource.boto.access_key="**********************" \
--secrets.boto.secret_access_key="*********************" \
--resource.boto.resource_class=socorro.external.boto.connection_context.RegionalS3ConnectionContext \
--resource.boto.bucket_name="org.allizom.crash-stats.rhelmer-test.crashes" \
--resource.postgresql.transaction_executor_class=socorro.database.transaction_executor.TransactionExecutor \
--global.correlations.core.output_class=socorro.external.es.correlations.CoreCounts \
--global.correlations.interesting.output_class=socorro.external.es.correlations.InterestingModules \
--new_crash_source.elasticsearch.elasticsearch_urls=localhost:9222 \
--source.crashstorage_class=socorro.analysis.correlations.correlations_app.LocallyCachedBotoS3CrashStorage \
--producer_consumer.number_of_threads=5 \
--new_crash_source.cap=2000 \
$@
```

That'll start 5 threads that jointly download 2000 processed crashes and then generates the summaries which it inserts into a local ES. 

Note: I have my ssh tunnel set to so that localhost:9222 is the stage ES. That's where I get a days worth of UUIDs from. 