### PR TITLE
fixes bug 1214033 - Session CSRF cookies not needed for API views

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -17,6 +17,7 @@ from waffle.decorators import waffle_switch
 
 import crashstats
 from socorro.external import BadArgumentError, MissingArgumentError
+from crashstats.base.decorators import no_csrf_cookie
 from crashstats.crashstats import models
 from crashstats.crashstats import utils
 from crashstats.tokens.models import Token
@@ -195,6 +196,7 @@ def has_permissions(user, permissions):
     return True
 
 
+@no_csrf_cookie
 @waffle_switch('!app_api_all_disabled')
 @ratelimit(
     key='ip',

--- a/webapp-django/crashstats/base/decorators.py
+++ b/webapp-django/crashstats/base/decorators.py
@@ -1,0 +1,12 @@
+import functools
+
+
+def no_csrf_cookie(view_func):
+    """Use this to make sure our CSRF session middleware doesn't
+    set a cookie."""
+
+    @functools.wraps(view_func)
+    def inner(request, *args, **kwargs):
+        request.no_session_csrf_cookie = True
+        return view_func(request, *args, **kwargs)
+    return inner

--- a/webapp-django/crashstats/base/middleware.py
+++ b/webapp-django/crashstats/base/middleware.py
@@ -1,0 +1,24 @@
+from session_csrf import CsrfMiddleware
+
+
+class ExtendedCsrfMiddleware(CsrfMiddleware):
+    """The only difference between this class and the base class
+    from session_csrf is that it's possible to make it not set a
+    cookie on the response. That basically makes it impossible to use
+    CSRF but for certain requests that's perfectly fine.
+
+    Note: The inbound cookie on the request is still valid and might
+    help the user get additional access.
+
+    The companion decorator to leverage this is
+    crashstats.base.decorators.no_csrf_cookie
+    Use that on your views and no anonymous CSRF cookie will be set
+    on the response.
+    """
+
+    def process_response(self, request, response):
+        if getattr(request, 'no_session_csrf_cookie', None):
+            return response
+        return super(ExtendedCsrfMiddleware, self).process_response(
+            request, response
+        )

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -106,7 +106,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'session_csrf.CsrfMiddleware',
+    '%s.base.middleware.ExtendedCsrfMiddleware' % PROJECT_MODULE,
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 


### PR DESCRIPTION
@willkg you're pretty good at these kinds of deeper Django security things. r?