### PR TITLE
Fixes bug 803779 - Added a rule for Abort signatures.

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -58,6 +58,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.signature_utilities.SignatureGenerationRule,"
         "socorro.processor.signature_utilities.StackwalkerErrorSignatureRule, "
         "socorro.processor.signature_utilities.OOMSignature, "
+        "socorro.processor.signature_utilities.AbortSignature, "
         "socorro.processor.signature_utilities.SignatureRunWatchDog, "
         "socorro.processor.signature_utilities.SigTrunc, "
     ],

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -893,6 +893,35 @@ class OOMSignature(Rule):
 
 
 #==============================================================================
+class AbortSignature(Rule):
+    """To satisfy Bug 803779, this rule will modify the signature to
+    tag Abort crashes"""
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '1.0'
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return 'AbortMessage' in raw_crash and raw_crash.AbortMessage
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        processed_crash.original_signature = processed_crash.signature
+
+        abort_message = raw_crash.AbortMessage
+        if len(abort_message) > 80:
+            abort_message = abort_message[:77] + '...'
+
+        processed_crash.signature = 'Abort | {} | {}'.format(
+            abort_message,
+            processed_crash.signature
+        )
+
+        return True
+
+
+#==============================================================================
 class SigTrunc(Rule):
     """ensure that the signature is never longer than 255 characters"""
 

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -12,14 +12,15 @@ import socorrolib.lib.util as sutil
 from socorro.database.transaction_executor import TransactionExecutor
 from socorrolib.lib.util import DotDict
 from socorro.processor.signature_utilities import (
+    AbortSignature,
     CSignatureTool,
     CSignatureToolDB,
     JavaSignatureTool,
-    SignatureGenerationRule,
     OOMSignature,
-    SigTrunc,
     StackwalkerErrorSignatureRule,
+    SignatureGenerationRule,
     SignatureRunWatchDog,
+    SigTrunc,
 )
 from socorro.unittest.testbase import TestCase
 
@@ -1530,8 +1531,8 @@ class TestOOMSignature(TestCase):
         action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
-        ok_(pc.original_signature, 'hello')
-        ok_(pc.signature, 'OOM | unknown | hello')
+        eq_(pc.original_signature, 'hello')
+        eq_(pc.signature, 'OOM | unknown | hello')
 
     #--------------------------------------------------------------------------
     def test_OOMAllocationSize_action_small(self):
@@ -1548,8 +1549,8 @@ class TestOOMSignature(TestCase):
         action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
-        ok_(pc.original_signature, 'hello')
-        ok_(pc.signature, 'OOM | small')
+        eq_(pc.original_signature, 'hello')
+        eq_(pc.signature, 'OOM | small')
 
     #--------------------------------------------------------------------------
     def test_OOMAllocationSize_action_large(self):
@@ -1566,8 +1567,88 @@ class TestOOMSignature(TestCase):
         action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
-        ok_(pc.original_signature, 'hello')
-        ok_(pc.signature, 'OOM | large | hello')
+        eq_(pc.original_signature, 'hello')
+        eq_(pc.signature, 'OOM | large | hello')
+
+
+#==============================================================================
+class TestAbortSignature(TestCase):
+
+    #--------------------------------------------------------------------------
+    def test_predicate(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+        rd = {}
+        rc = DotDict()
+        rc.AbortMessage = 'something'
+
+        fake_processor = create_basic_fake_processor()
+        rule = AbortSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
+        ok_(predicate_result)
+
+    #--------------------------------------------------------------------------
+    def test_predicate_no_match(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+        rc = DotDict()
+        # No AbortMessage.
+        rd = {}
+
+        fake_processor = create_basic_fake_processor()
+        rule = AbortSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
+        ok_(not predicate_result)
+
+    #--------------------------------------------------------------------------
+    def test_predicate_empty_message(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+        rc = DotDict()
+        rc.AbortMessage = ''
+        rd = {}
+
+        fake_processor = create_basic_fake_processor()
+        rule = AbortSignature(fake_processor.config)
+        predicate_result = rule.predicate(rc, rd, pc, fake_processor)
+        ok_(not predicate_result)
+
+    #--------------------------------------------------------------------------
+    def test_action_success(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+
+        rc = DotDict()
+        rc.AbortMessage = 'unknown'
+        rd = {}
+
+        fake_processor = create_basic_fake_processor()
+
+        rule = AbortSignature(fake_processor.config)
+        action_result = rule.action(rc, rd, pc, fake_processor)
+
+        ok_(action_result)
+        eq_(pc.original_signature, 'hello')
+        eq_(pc.signature, 'Abort | unknown | hello')
+
+    #--------------------------------------------------------------------------
+    def test_action_success_long_message(self):
+        pc = DotDict()
+        pc.signature = 'hello'
+
+        rc = DotDict()
+        rc.AbortMessage = 'a' * 81
+        rd = {}
+
+        fake_processor = create_basic_fake_processor()
+
+        rule = AbortSignature(fake_processor.config)
+        action_result = rule.action(rc, rd, pc, fake_processor)
+
+        ok_(action_result)
+        eq_(pc.original_signature, 'hello')
+        expected_sig = 'Abort | {}... | hello'.format('a' * 77)
+        eq_(pc.signature, expected_sig)
 
 
 #==============================================================================


### PR DESCRIPTION
Added a new transform Rule to the processor to add the abort message to the signature of crashes that have an AbortMessage field. The format is "Abort | <AbortMessage[0:80]> | <C signature>".

cc @KaiRo-at @twobraids 