### PR TITLE
Fix stackwalk build against newer Breakpad

### DIFF
--- a/minidump-stackwalk/Makefile
+++ b/minidump-stackwalk/Makefile
@@ -36,6 +36,7 @@ CURL_LIBS := $(shell pkg-config libcurl --libs)
 CXXFLAGS += \
   -I$(BREAKPAD_SRCDIR) \
   -I$(JSON_INCLUDEDIR) \
+  -D__STDC_FORMAT_MACROS=1 \
   -std=gnu++0x \
   -Wno-format \
   -Werror \


### PR DESCRIPTION
This small change is necessary to build the stackwalker against the latest Breakpad code, which is https://bugzilla.mozilla.org/show_bug.cgi?id=1262135 .