### PR TITLE
fixes bug 1263247 - Web API doesn't convert BadArgumentErrors to 400 …

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -11,7 +11,7 @@ import mock
 import pyquery
 from nose.tools import eq_, ok_
 
-from socorro.external import BadArgumentError, MissingArgumentError
+from socorrolib.lib import BadArgumentError, MissingArgumentError
 from crashstats.base.tests.testbase import TestCase
 from crashstats.crashstats.tests.test_views import (
     BaseTestViews,

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -16,7 +16,7 @@ from ratelimit.decorators import ratelimit
 from waffle.decorators import waffle_switch
 
 import crashstats
-from socorro.external import BadArgumentError, MissingArgumentError
+from socorrolib.lib import BadArgumentError, MissingArgumentError
 from crashstats.crashstats import models
 from crashstats.crashstats import utils
 from crashstats.tokens.models import Token


### PR DESCRIPTION
…requests

CC @adngdb It is strange that we didn't notice this earlier. Basically, there's a `class BadArgumentError` in socorro and one in socorrolib. Same name but totally different classes. 