### PR TITLE
Pull the Breakpad tarball from a Taskcluster index

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -23,7 +23,7 @@ fi
 
 if [ "`uname -sm`" == "Linux x86_64" ]; then
   # pull pre-built, known version of breakpad
-  wget -N --quiet 'https://org-mozilla-breakpad.s3-us-west-2.amazonaws.com/breakpad.tar.gz'
+  wget -N --quiet 'https://index.taskcluster.net/v1/task/project.socorro.breakpad.v1.builds.linux64.latest/artifacts/public/breakpad.tar.gz'
   tar -zxf breakpad.tar.gz
   rm -rf stackwalk
   mv breakpad stackwalk


### PR DESCRIPTION
This immediately gets us a newer Breakpad build, and will also
streamline the process for updating Breakpad in the future, since
new runs of the same Taskcluster task will update the index to
point at the most recent build.

@peterbe: this is the better solution I was talking about this morning.