### PR TITLE
fixes bug 1264960 - Super searching for future dates

### DIFF
--- a/socorro/middleware/search_common.py
+++ b/socorro/middleware/search_common.py
@@ -272,10 +272,16 @@ class SearchBase(object):
             for param in parameters['date']:
                 if not param.operator:
                     # dates can't be a specific date
-                    raise BadArgumentError('date must have a prefix operator')
+                    raise BadArgumentError(
+                        'date',
+                        msg='date must have a prefix operator'
+                    )
                 today = datetimeutil.utc_now()
                 if param.value > today:
-                    raise BadArgumentError('future date')
+                    raise BadArgumentError(
+                        'date',
+                        msg="date can't be in the future"
+                    )
                 if (
                     '<' in param.operator and (
                         not lower_than or

--- a/socorro/middleware/search_common.py
+++ b/socorro/middleware/search_common.py
@@ -273,6 +273,9 @@ class SearchBase(object):
                 if not param.operator:
                     # dates can't be a specific date
                     raise BadArgumentError('date must have a prefix operator')
+                today = datetimeutil.utc_now()
+                if param.value > today:
+                    raise BadArgumentError('future date')
                 if (
                     '<' in param.operator and (
                         not lower_than or

--- a/socorro/unittest/middleware/test_search_common.py
+++ b/socorro/unittest/middleware/test_search_common.py
@@ -222,6 +222,22 @@ class TestSearchBase(TestCase):
             date='2016-01-01'
         )
 
+    def test_get_parameters_date_future_date(self):
+        with _get_config_manager().context() as config:
+            search = SearchBaseWithFields(
+                config=config,
+            )
+
+        # the date parameter must always have a prefix operator
+        tomorrow = (
+            datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        ).strftime('%Y-%m-%d')
+        assert_raises(
+            BadArgumentError,
+            search.get_parameters,
+            date=tomorrow
+        )
+
     def test_get_parameters_date_defaults(self):
         with _get_config_manager().context() as config:
             search = SearchBaseWithFields(

--- a/webapp-django/crashstats/base/tests/test_utils.py
+++ b/webapp-django/crashstats/base/tests/test_utils.py
@@ -1,0 +1,22 @@
+from nose.tools import eq_
+
+from crashstats.base.tests.testbase import TestCase
+from crashstats.base.utils import render_exception
+
+
+class TestRenderException(TestCase):
+
+    def test_basic(self):
+        html = render_exception('hi!')
+        eq_(html, '<ul><li>hi!</li></ul>')
+
+    def test_escaped(self):
+        html = render_exception('<hi>')
+        eq_(html, '<ul><li>&lt;hi&gt;</li></ul>')
+
+    def test_to_string(self):
+        try:
+            raise NameError('<hack>')
+        except NameError as exc:
+            html = render_exception(exc)
+        eq_(html, '<ul><li>&lt;hack&gt;</li></ul>')

--- a/webapp-django/crashstats/base/utils.py
+++ b/webapp-django/crashstats/base/utils.py
@@ -1,0 +1,13 @@
+from django.template import engines
+
+
+def render_exception(exception):
+    """When we need to render an exception as HTML.
+
+    Often used to supply as the response body when there's a
+    HttpResponseBadRequest.
+    """
+    template = engines['backend'].from_string(
+        '<ul><li>{{ exception }}</li></ul>'
+    )
+    return template.render({'exception': exception})

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -9,6 +9,9 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render
 from django.conf import settings
 
+from socorrolib.lib import BadArgumentError
+
+from crashstats.base.utils import render_exception
 from crashstats.api.views import has_permissions
 from crashstats.crashstats import models, utils
 from crashstats.crashstats.views import pass_default_context
@@ -172,10 +175,10 @@ def signature_reports(request, params):
     api = SuperSearchUnredacted()
     try:
         search_results = api.get(**params)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery to
         # pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     search_results['total_pages'] = int(
         math.ceil(
@@ -219,10 +222,10 @@ def signature_aggregation(request, params, aggregation):
     api = SuperSearchUnredacted()
     try:
         search_results = api.get(**params)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery to
         # pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     context['aggregates'] = []
     if aggregation in search_results['facets']:
@@ -265,10 +268,10 @@ def signature_graphs(request, params, field):
     api = SuperSearchUnredacted()
     try:
         search_results = api.get(**params)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery to
         # pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     context['aggregates'] = search_results['facets'].get('histogram_date', [])
     context['term_counts'] = search_results['facets'].get(field, [])
@@ -322,10 +325,10 @@ def signature_comments(request, params):
     api = SuperSearchUnredacted()
     try:
         search_results = api.get(**params)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery to
         # pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     search_results['total_pages'] = int(
         math.ceil(
@@ -354,10 +357,10 @@ def signature_correlations(request, params):
     api = SuperSearchUnredacted()
     try:
         search_results = api.get(**params)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery to
         # pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     all_combos = []
     for product in search_results['facets']['product']:
@@ -479,10 +482,10 @@ def signature_summary(request, params):
     # Now make the actual request with all expected parameters.
     try:
         search_results = api.get(**params)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery to
         # pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     facets = search_results['facets']
 
@@ -495,10 +498,10 @@ def signature_summary(request, params):
 
     try:
         product_results = api.get(**params_copy)
-    except models.BadStatusCodeError as e:
+    except BadArgumentError as e:
         # We need to return the error message in some HTML form for jQuery
         # to pick it up.
-        return http.HttpResponseBadRequest('<ul><li>%s</li></ul>' % e)
+        return http.HttpResponseBadRequest(render_exception(e))
 
     if 'product' in product_results['facets']:
         facets['product'] = product_results['facets']['product']


### PR DESCRIPTION
This is quite an important fix. First of all, if you do a `/api/SuperSearch/` query with a future date, instead of getting an error from ElasticSearch about the index not existing, you now get this:
<img width="1040" alt="screen shot 2016-04-15 at 4 29 26 pm" src="https://cloud.githubusercontent.com/assets/26739/14574065/3f023ee6-0327-11e6-8f25-e059d31d34c3.png">

Secondly, when we talk to ES from the webapp, we used to do that via the middleware using `requests.get`. We don't any more. Instead we use the `get_implementation()` and a pure python solution. That means that any errors happening in the implementation will be pure raised exception in the django views where this is used. Note the lack of `try:except:` [here](https://github.com/peterbe/socorro/blob/8e513792f3474b55fcfb16908283f1c5dffc07ba/webapp-django/crashstats/crashstats/models.py#L350).
That means that all the places where we do things like `models.SuperSearch().get(**params)` if anything went wrong, it would ultimately become a internal server error. Now, with my change, some errors (namely `BadArgumentError`) will at least be re-wrapped and returned as a 400 Bad Request. 