### PR TITLE
fixes bug 1126776 - Analytics for the public API

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -18,7 +18,7 @@ from waffle.decorators import waffle_switch
 from socorrolib.lib import BadArgumentError, MissingArgumentError
 
 import crashstats
-from crashstats.crashstats.decorators import track_api_pageview_decorator
+from crashstats.crashstats.decorators import track_api_pageview
 from crashstats.crashstats import models
 from crashstats.crashstats import utils
 from crashstats.tokens.models import Token
@@ -205,7 +205,7 @@ def has_permissions(user, permissions):
     rate=utils.ratelimit_rate,
     block=True
 )
-@track_api_pageview_decorator
+@track_api_pageview
 @utils.add_CORS_header  # must be before `utils.json_view`
 @utils.json_view
 def model_wrapper(request, model_name):

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -18,6 +18,7 @@ from waffle.decorators import waffle_switch
 from socorrolib.lib import BadArgumentError, MissingArgumentError
 
 import crashstats
+from crashstats.base.ga import track_api_pageview
 from crashstats.crashstats import models
 from crashstats.crashstats import utils
 from crashstats.tokens.models import Token
@@ -317,6 +318,9 @@ def model_wrapper(request, model_name):
                 json.dumps({'error': str(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
+
+        # Execution was successful, inform Google Analytics
+        track_api_pageview(request)
 
         # Some models allows to return a binary reponse. It does so based on
         # the models `BINARY_RESPONSE` dict in which all keys and values

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -18,7 +18,7 @@ from waffle.decorators import waffle_switch
 from socorrolib.lib import BadArgumentError, MissingArgumentError
 
 import crashstats
-from crashstats.base.ga import track_api_pageview
+from crashstats.crashstats.decorators import track_api_pageview_decorator
 from crashstats.crashstats import models
 from crashstats.crashstats import utils
 from crashstats.tokens.models import Token
@@ -205,6 +205,7 @@ def has_permissions(user, permissions):
     rate=utils.ratelimit_rate,
     block=True
 )
+@track_api_pageview_decorator
 @utils.add_CORS_header  # must be before `utils.json_view`
 @utils.json_view
 def model_wrapper(request, model_name):
@@ -318,9 +319,6 @@ def model_wrapper(request, model_name):
                 json.dumps({'error': str(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
-
-        # Execution was successful, inform Google Analytics
-        track_api_pageview(request)
 
         # Some models allows to return a binary reponse. It does so based on
         # the models `BINARY_RESPONSE` dict in which all keys and values

--- a/webapp-django/crashstats/base/ga.py
+++ b/webapp-django/crashstats/base/ga.py
@@ -91,15 +91,9 @@ def track_pageview(
         params['uid'] = str(request.user.id)
 
     params['dp'] = request.path  # Page
-    if request.META.get('QUERY_STRING'):
-        params['dp'] += '?{}'.format(request.META.get('QUERY_STRING'))
+    params['dl'] = request.build_absolute_uri()
 
     params['dt'] = page_title
-
-    if request.META.get('REMOTE_ADDR'):
-        ip = request.META['REMOTE_ADDR']
-        if ip != '127.0.0.1':
-            params['uip'] = ip
 
     if request.META.get('HTTP_USER_AGENT'):
         params['ua'] = request.META['HTTP_USER_AGENT']

--- a/webapp-django/crashstats/base/ga.py
+++ b/webapp-django/crashstats/base/ga.py
@@ -104,7 +104,7 @@ def track_pageview(
     )
 
     def success_cb():
-        # Note! This will trigger as long as there's not python exception
+        # Note! This will trigger as long as there's no python exception
         # happening inside the send.
         # Meaning, if the requests.post(...).status_code != 200, this
         # callback is still called.
@@ -114,7 +114,13 @@ def track_pageview(
         )
 
     def failure_cb(exception):
-        logger.error('Failed to send GA page tracking (%s)', exception)
+        # This can happen if it fails to make the connection to the
+        # remote. E.g. ssl.google-analytics.com
+        # If the HTTP connection is made but, for some reason, GA
+        # refuses the call or they timeout or any other 5xx error,
+        # then this will NOT be a failure callback. In fact, the
+        # success callback will be executed.
+        logger.exception('Failed to send GA page tracking')
 
     transporter.async_send(
         params,

--- a/webapp-django/crashstats/base/ga.py
+++ b/webapp-django/crashstats/base/ga.py
@@ -115,7 +115,7 @@ def track_pageview(
         # Meaning, if the requests.post(...).status_code != 200, this
         # callback is still called.
         logger.info(
-            'Successfully attempted to sent pageview to Google Analytics (%s)',
+            'Successfully attempted to send pageview to Google Analytics (%s)',
             params,
         )
 

--- a/webapp-django/crashstats/base/ga.py
+++ b/webapp-django/crashstats/base/ga.py
@@ -1,0 +1,135 @@
+"""
+Sending Google Analytics events from the webapp.
+
+See https://developers.google.com/analytics/devguides/collection/protocol/\
+v1/devguide#page
+"""
+
+import logging
+import urlparse
+import uuid
+
+from raven.transport.threaded_requests import ThreadedRequestsHTTPTransport
+
+from django.contrib.sites.requests import RequestSite
+from django.conf import settings
+
+logger = logging.getLogger('crashstats:ga')
+
+# Uncomment for local debugging. This will print all logging on stdout.
+# logger.setLevel(logging.DEBUG)
+# import sys
+# logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+def track_api_pageview(
+    request,
+    page_title=None,
+    data_source='api',
+    client_id=None,
+    async=True,
+    **headers
+):
+    """Convenient wrapper function geared for the API calls. This way
+    the page title is automatically guessed to something sensible."""
+    page_title = page_title or 'API ({})'.format(request.path)
+    track_pageview(
+        request,
+        page_title=page_title,
+        data_source=data_source,
+        client_id=client_id,
+        async=async,
+        **headers
+    )
+
+
+def track_pageview(
+    request,
+    page_title,
+    data_source='web',
+    client_id=None,
+    async=True,
+    **headers
+):
+    """Trigger a HTTP POST to Google Analytics about a particular page being
+    viewed. Most paramters are being picked out of the request object.
+
+    :arg request: The Django request object.
+    :arg page_title: A string to act as a title for the page. Not relevant
+    or particularly needed for API requests.
+    :arg data_source: A string like 'web' or 'api'. See documentation.
+    :arg client_id: Some string to identify the client.
+
+    """
+    if not settings.GOOGLE_ANALYTICS_ID:
+        logging.debug('GOOGLE_ANALYTICS_ID not set up. No pageview tracking.')
+        return
+
+    domain = settings.GOOGLE_ANALYTICS_DOMAIN
+    if not domain or domain == 'auto':
+        domain = RequestSite(request).domain
+
+    params = {}
+    params['v'] = 1  # version
+    params['tid'] = settings.GOOGLE_ANALYTICS_ID  # Tracking ID / Property ID
+    params['dh'] = domain
+    params['t'] = 'pageview'
+    params['ds'] = data_source
+
+    # Here's what the documentation says on
+    # https://developers.google.com/analytics/devguides/collection/protocol\
+    # /v1/parameters#cid
+    #
+    #   Required for all hit types.
+    #
+    #   This anonymously identifies a particular user, device, or browser
+    #   instance. For the web, this is generally stored as a first-party
+    #   cookie with a two-year expiration. For mobile apps, this is randomly
+    #   generated for each particular instance of an application install.
+    #   The value of this field should be a random UUID (version 4) as
+    #   described in http://www.ietf.org/rfc/rfc4122.txt
+    params['cid'] = client_id or uuid.uuid4().hex
+
+    if not request.user.is_anonymous():
+        params['uid'] = str(request.user.id)
+
+    params['dp'] = request.path  # Page
+    if request.META.get('QUERY_STRING'):
+        params['dp'] += '?{}'.format(request.META.get('QUERY_STRING'))
+
+    params['dt'] = page_title
+
+    if request.META.get('REMOTE_ADDR'):
+        ip = request.META['REMOTE_ADDR']
+        if ip != '127.0.0.1':
+            params['uip'] = ip
+
+    if request.META.get('HTTP_USER_AGENT'):
+        params['ua'] = request.META['HTTP_USER_AGENT']
+
+    transporter = ThreadedRequestsHTTPTransport(
+        urlparse.urlparse(settings.GOOGLE_ANALYTICS_API_URL),
+        timeout=settings.GOOGLE_ANALYTICS_API_TIMEOUT
+    )
+
+    def success_cb():
+        # Note! This will trigger as long as there's not python exception
+        # happening inside the send.
+        # Meaning, if the requests.post(...).status_code != 200, this
+        # callback is still called.
+        logger.info(
+            'Successfully attempted to sent pageview to Google Analytics (%s)',
+            params,
+        )
+
+    def failure_cb(exception):
+        logger.error('Failed to send GA page tracking (%s)', exception)
+
+    function = async and transporter.async_send or transporter.send_sync
+
+    function(
+        params,
+        headers,
+        success_cb,
+        failure_cb
+    )

--- a/webapp-django/crashstats/base/ga.py
+++ b/webapp-django/crashstats/base/ga.py
@@ -27,7 +27,6 @@ def track_api_pageview(
     page_title=None,
     data_source='api',
     client_id=None,
-    async=True,
     **headers
 ):
     """Convenient wrapper function geared for the API calls. This way
@@ -38,7 +37,6 @@ def track_api_pageview(
         page_title=page_title,
         data_source=data_source,
         client_id=client_id,
-        async=async,
         **headers
     )
 
@@ -48,7 +46,6 @@ def track_pageview(
     page_title,
     data_source='web',
     client_id=None,
-    async=True,
     **headers
 ):
     """Trigger a HTTP POST to Google Analytics about a particular page being
@@ -125,9 +122,7 @@ def track_pageview(
     def failure_cb(exception):
         logger.error('Failed to send GA page tracking (%s)', exception)
 
-    function = async and transporter.async_send or transporter.send_sync
-
-    function(
+    transporter.async_send(
         params,
         headers,
         success_cb,

--- a/webapp-django/crashstats/base/tests/test_ga.py
+++ b/webapp-django/crashstats/base/tests/test_ga.py
@@ -55,9 +55,10 @@ class TestTrackingPageviews(DjangoTestCase):
                 'dt': 'Test page',
                 'ds': 'web',
                 'dp': '/some/page',
+                'dl': 'http://testserver/some/page',
             }
             logger.info.assert_called_with(
-                'Successfully attempted to sent pageview to Google '
+                'Successfully attempted to send pageview to Google '
                 'Analytics (%s)',
                 params
             )
@@ -90,13 +91,13 @@ class TestTrackingPageviews(DjangoTestCase):
                 'tid': 'XYZ-123',
                 'dt': 'Test page',
                 'ds': 'web',
-                'dp': '/other/page?foo=bar',
+                'dp': '/other/page',
                 'uid': str(user.id),
                 'ua': 'testingthings 1.0',
-                'uip': '123.123.123.123',
+                'dl': 'http://testserver/other/page?foo=bar',
             }
             logger.info.assert_called_with(
-                'Successfully attempted to sent pageview to Google '
+                'Successfully attempted to send pageview to Google '
                 'Analytics (%s)',
                 params
             )
@@ -134,9 +135,10 @@ class TestTrackingPageviews(DjangoTestCase):
                 'dt': 'API (/api/SomeAPI/)',
                 'ds': 'api',
                 'dp': '/api/SomeAPI/',
+                'dl': 'http://testserver/api/SomeAPI/',
             }
             logger.info.assert_called_with(
-                'Successfully attempted to sent pageview to Google '
+                'Successfully attempted to send pageview to Google '
                 'Analytics (%s)',
                 params
             )
@@ -218,13 +220,21 @@ class TestTrackingPageviews(DjangoTestCase):
             eq_(response.status_code, 200)
             eq_(len(queues), 1)  # the mutable
             assert len(gets) == 1
-            eq_(queues[0]['dp'], '/api/ProductBuildTypes/?product=WaterWolf')
+            eq_(queues[0]['dp'], '/api/ProductBuildTypes/')
+            eq_(
+                queues[0]['dl'],
+                'http://testserver/api/ProductBuildTypes/?product=WaterWolf'
+            )
 
             response = self.client.get(url, {'product': '400'})
             assert len(gets) == 2, len(gets)
             eq_(response.status_code, 400)
             eq_(len(queues), 2)
-            eq_(queues[1]['dp'], '/api/ProductBuildTypes/?product=400')
+            eq_(queues[1]['dp'], '/api/ProductBuildTypes/')
+            eq_(
+                queues[1]['dl'],
+                'http://testserver/api/ProductBuildTypes/?product=400'
+            )
 
             response = self.client.get(
                 url,

--- a/webapp-django/crashstats/base/tests/test_ga.py
+++ b/webapp-django/crashstats/base/tests/test_ga.py
@@ -175,9 +175,8 @@ class TestTrackingPageviews(DjangoTestCase):
             # working.
             assert errors_raised
 
-            logger.error.assert_called_with(
-                'Failed to send GA page tracking (%s)',
-                errors_raised[0]
+            logger.exception.assert_called_with(
+                'Failed to send GA page tracking'
             )
 
     @mock.patch('raven.transport.threaded_requests.AsyncWorker')

--- a/webapp-django/crashstats/base/tests/test_ga.py
+++ b/webapp-django/crashstats/base/tests/test_ga.py
@@ -1,0 +1,174 @@
+import mock
+from raven.conf import defaults
+
+from django.test.client import RequestFactory
+from django.conf import settings
+from django.contrib.auth.models import User, AnonymousUser
+
+from crashstats.base.tests.testbase import DjangoTestCase
+from crashstats.base.ga import track_api_pageview, track_pageview
+
+
+class TestTrackingPageviews(DjangoTestCase):
+    """Note, we're using DjangoTestCase so we can use `with self.settings()`
+    in the tests to flip settings around.
+    """
+
+    @mock.patch('raven.transport.threaded_requests.AsyncWorker')
+    @mock.patch('requests.post')
+    @mock.patch('crashstats.base.ga.logger')
+    def test_basic_pageview(self, logger, rpost, aw):
+
+        queues_started = []
+
+        def mocked_queue(function, data, headers, success_cb, failure_cb):
+            queues_started.append(data)
+            function(data, headers, success_cb, failure_cb)
+
+        aw().queue.side_effect = mocked_queue
+
+        request = RequestFactory().get('/some/page')
+        request.user = AnonymousUser()
+        assert not settings.GOOGLE_ANALYTICS_ID  # the default
+        track_pageview(request, 'Test page')
+        assert not queues_started
+
+        with self.settings(GOOGLE_ANALYTICS_ID='XYZ-123'):
+            # The reason for setting a client_id value is because if we
+            # don't set it, it'll be a randomly generated UUID string
+            # which we can't know. Then it becomes really hard to do
+            # some_mocked_thing.assert_called_with(...)
+            track_pageview(request, 'Test page', client_id='mycid')
+            assert queues_started
+
+            params = {
+                'v': 1,
+                't': 'pageview',
+                'cid': 'mycid',
+                'dh': 'testserver',
+                'tid': 'XYZ-123',
+                'dt': 'Test page',
+                'ds': 'web',
+                'dp': '/some/page',
+            }
+            logger.info.assert_called_with(
+                'Successfully attempted to sent pageview to Google '
+                'Analytics (%s)',
+                params
+            )
+
+            rpost.assert_called_with(
+                settings.GOOGLE_ANALYTICS_API_URL,
+                verify=defaults.CA_BUNDLE,
+                data=params,
+                timeout=settings.GOOGLE_ANALYTICS_API_TIMEOUT,
+                headers={}
+            )
+
+        # Now test with a few more parameters and a user that is not
+        # anonymous.
+        request = RequestFactory(**{
+            'REMOTE_ADDR': '123.123.123.123',
+            'HTTP_USER_AGENT': 'testingthings 1.0',
+        }).get('/other/page?foo=bar')
+        user = User.objects.create_user('koblaikahn')
+        request.user = user
+
+        with self.settings(GOOGLE_ANALYTICS_ID='XYZ-123'):
+            track_pageview(request, 'Test page', client_id='mycid')
+
+            params = {
+                'v': 1,
+                't': 'pageview',
+                'cid': 'mycid',
+                'dh': 'testserver',
+                'tid': 'XYZ-123',
+                'dt': 'Test page',
+                'ds': 'web',
+                'dp': '/other/page?foo=bar',
+                'uid': str(user.id),
+                'ua': 'testingthings 1.0',
+                'uip': '123.123.123.123',
+            }
+            logger.info.assert_called_with(
+                'Successfully attempted to sent pageview to Google '
+                'Analytics (%s)',
+                params
+            )
+
+            rpost.assert_called_with(
+                settings.GOOGLE_ANALYTICS_API_URL,
+                verify=defaults.CA_BUNDLE,
+                data=params,
+                timeout=settings.GOOGLE_ANALYTICS_API_TIMEOUT,
+                headers={}
+            )
+
+    @mock.patch('raven.transport.threaded_requests.AsyncWorker')
+    @mock.patch('requests.post')
+    @mock.patch('crashstats.base.ga.logger')
+    def test_api_pageview(self, logger, rpost, aw):
+
+        def mocked_queue(function, data, headers, success_cb, failure_cb):
+            function(data, headers, success_cb, failure_cb)
+
+        aw().queue.side_effect = mocked_queue
+
+        request = RequestFactory().get('/api/SomeAPI/')
+        request.user = AnonymousUser()
+
+        with self.settings(GOOGLE_ANALYTICS_ID='XYZ-123'):
+            track_api_pageview(request, client_id='mycid')
+
+            params = {
+                'v': 1,
+                't': 'pageview',
+                'cid': 'mycid',
+                'dh': 'testserver',
+                'tid': 'XYZ-123',
+                'dt': 'API (/api/SomeAPI/)',
+                'ds': 'api',
+                'dp': '/api/SomeAPI/',
+            }
+            logger.info.assert_called_with(
+                'Successfully attempted to sent pageview to Google '
+                'Analytics (%s)',
+                params
+            )
+
+    @mock.patch('raven.transport.threaded_requests.AsyncWorker')
+    @mock.patch('requests.post')
+    @mock.patch('crashstats.base.ga.logger')
+    def test_basic_pageview_failure(self, logger, rpost, aw):
+
+        def mocked_queue(function, data, headers, success_cb, failure_cb):
+            function(data, headers, success_cb, failure_cb)
+
+        aw().queue.side_effect = mocked_queue
+
+        errors_raised = []
+
+        def failing_post(*a, **kw):
+            try:
+                raise NameError('oh no!')
+            except Exception as exp:
+                errors_raised.append(exp)
+                raise
+
+        rpost.side_effect = failing_post
+
+        request = RequestFactory().get('/some/page')
+        request.user = AnonymousUser()
+
+        with self.settings(GOOGLE_ANALYTICS_ID='XYZ-123'):
+            track_pageview(request, 'Test page')
+
+            # Note that even those the mocked requests.post method
+            # did raise an error, we're still here and things are still
+            # working.
+            assert errors_raised
+
+            logger.error.assert_called_with(
+                'Failed to send GA page tracking (%s)',
+                errors_raised[0]
+            )

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
 
 from . import utils
-from crashstats.base.ga import track_api_pageview
+from crashstats.base import ga
 
 
 _marker = object()
@@ -70,7 +70,7 @@ def pass_default_context(view):
     return inner
 
 
-def track_api_pageview_decorator(view):
+def track_api_pageview(view):
     @functools.wraps(view)
     def inner(request, *args, **kwargs):
         response = view(request, *args, **kwargs)
@@ -83,6 +83,6 @@ def track_api_pageview_decorator(view):
                 referer_host = urlparse.urlparse(referer).netloc
                 if referer_host == request.META.get('HTTP_HOST'):
                     return response
-            track_api_pageview(request)
+            ga.track_api_pageview(request)
         return response
     return inner

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -723,3 +723,18 @@ CRONTABBER_STALE_MINUTES = config(
     # to a higher default.
     default=60 * 2
 )
+
+# URL to send the Google Analytics pageviews and event tracking.
+# The value of this is extremely unlikely to change any time soon,
+GOOGLE_ANALYTICS_API_URL = config(
+    'GOOGLE_ANALYTICS_API_URL',
+    'https://ssl.google-analytics.com/collect'
+)
+
+# If calls to the Google Analytics API are done asynchronously, this
+# value can be quite high (5-10 seconds).
+GOOGLE_ANALYTICS_API_TIMEOUT = config(
+    'GOOGLE_ANALYTICS_API_TIMEOUT',
+    5,  # seconds
+    cast=int
+)

--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -72,3 +72,9 @@ CRASH_ANALYSIS_MONITOR_DAYS_BACK = 2
 
 MIDDLEWARE_RETRIES = 10
 MIDDLEWARE_MIDDLEWARE_RETRY_SLEEPTIME = 3
+
+# During testing, if mocking isn't done right, we never want to
+# accidentally send data to Google Analytics.
+GOOGLE_ANALYTICS_API_URL = 'https://fake.guugle-analytics.fake/collect'
+# By default, unset the GOOGLE_ANALYTICS_ID
+GOOGLE_ANALYTICS_ID = None

--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -75,6 +75,9 @@ MIDDLEWARE_MIDDLEWARE_RETRY_SLEEPTIME = 3
 
 # During testing, if mocking isn't done right, we never want to
 # accidentally send data to Google Analytics.
-GOOGLE_ANALYTICS_API_URL = 'https://fake.guugle-analytics.fake/collect'
+GOOGLE_ANALYTICS_API_URL = 'https://example.com/collect'
 # By default, unset the GOOGLE_ANALYTICS_ID
 GOOGLE_ANALYTICS_ID = None
+# Forcibly setting this to be what the default is in settings/base.py
+# so that local settings don't break tests.
+GOOGLE_ANALYTICS_DOMAIN = 'auto'


### PR DESCRIPTION
CC @adngdb 

To test this manually, I ran this: https://gist.github.com/ccc7d2f3a4329febfd777f4441baa2f0
Then I edited my `.env` like this:
```
GOOGLE_ANALYTICS_API_URL=http://localhost:5000/?timeout=2
GOOGLE_ANALYTICS_DOMAIN=what.ever.org
GOOGLE_ANALYTICS_ID=ANY-THING
```

Things to note;

I'm still not 100% sure what to put for the `cid` value. In `fjord` the `cid` was usually made around a particular Django ORM object. That doesn't really exist in this context. The documentation on `cid` is both vague and clear at the same time. Generally, it's supposed to be like a session ID for the client. That doesn't exist when people do `curl https://crash-stats.m.c/api/SomeModel/` since "curlers" wouldn't re-use a cookie. We could do something like this:
```
cid = request.session.get('ga_cid')
if not cid:
    cid = uuid.uuid4().hex
    request.session['ga_cid'] = cid
params['cid'] = cid
```
But I'm not sure how I feel about modifying the `request` object in a tracking function like this. Also, our goal is to find out how many hits we get per Web API endpoint. Not who's surfing from one to another. 

~~I've tried to fire this against our stage domain, but nothing shows up when I'm logged in to Google Analytics Real-time Overview. Not sure if I'm expected to. The only way to know is to use it I suspect. Or wait a day and see if it appears in the aggregates.~~
Using my local curl and editing my `.env` to simulate stage's I really was able to trigger pageviews on API calls. See:
<img width="936" alt="screen shot 2016-04-18 at 4 15 01 pm" src="https://cloud.githubusercontent.com/assets/26739/14618528/f24fe6d2-0580-11e6-8c3a-92c268459dbf.png"> 
In other words! Unless google analytics later filter these out; it works!


I have tested this code when running my local django via uwsgi as a socket. Things worked just fine. 