### PR TITLE
Bug 1266400 - Update forced versions for correlations for Firefox cycle starting 2016-04-25

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -69,7 +69,7 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="46.0b1 46.0b2 46.0b3 46.0b4 46.0b5 46.0b6 46.0b7 46.0b8 46.0b9 46.0b99 47.0a2 48.0a1"
+MANUAL_VERSION_OVERRIDE="47.0b1 47.0b2 47.0b3 47.0b4 47.0b5 47.0b6 47.0b7 47.0b8 47.0b9 47.0b99 48.0a2 49.0a1"
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
This adds current aurora and nightly versions as well as all planned beta versions for this cycle, and should land on prod early next week (2016-04-25 or closely after).

Note that once again we need to update the crash-analysis node with that code (and make sure this version of the script is actually being run) to actually make it live. I can actually do that, just need the latest rpm to contain this patch when I should deploy it.
