### PR TITLE
fixes bug 1267301 - Postgres table for storing correlations

### DIFF
--- a/alembic/versions/373ef4569b93_correlations_table.py
+++ b/alembic/versions/373ef4569b93_correlations_table.py
@@ -1,0 +1,71 @@
+"""correlations table
+
+Revision ID: 373ef4569b93
+Revises: 335c2bfd99a6
+Create Date: 2016-04-25 14:11:28.373859
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from socorrolib.lib import jsontype
+
+# revision identifiers, used by Alembic.
+revision = '373ef4569b93'
+down_revision = '335c2bfd99a6'
+
+
+def upgrade():
+    op.create_table(
+        'correlations',
+        sa.Column('id', sa.INTEGER(), nullable=False),
+        sa.Column(
+            'product_version_id',
+            sa.INTEGER(),
+            autoincrement=False,
+            nullable=False
+        ),
+        sa.Column('platform', sa.TEXT(), nullable=False),
+        sa.Column('signature_id', sa.INTEGER(), nullable=False),
+        sa.Column('key', sa.TEXT(), nullable=False),
+        sa.Column(
+            'count',
+            sa.INTEGER(),
+            server_default=sa.text(u'0'),
+            nullable=False
+        ),
+        sa.Column('notes', sa.TEXT(), server_default=u'', nullable=False),
+        sa.Column('date', sa.DATE(), nullable=False),
+        sa.Column('payload', jsontype.JsonType(), nullable=True),
+        sa.PrimaryKeyConstraint('id', 'platform')
+    )
+    op.create_index(
+        'correlations_signature_idx',
+        'correlations',
+        [
+            'product_version_id',
+            'platform',
+            'key',
+            'date',
+            'signature_id'
+        ],
+        unique=True
+    )
+    op.create_index(
+        'correlations_signatures_idx',
+        'correlations',
+        [
+            'product_version_id',
+            'platform',
+            'key',
+            'date'
+        ],
+        unique=True
+    )
+
+
+def downgrade():
+    op.drop_index('correlations_signatures_idx', table_name='correlations')
+    op.drop_index('correlations_signature_idx', table_name='correlations')
+    op.drop_table('correlations')

--- a/alembic/versions/373ef4569b93_correlations_table.py
+++ b/alembic/versions/373ef4569b93_correlations_table.py
@@ -50,7 +50,6 @@ def upgrade():
             'date',
             'signature_id'
         ],
-        unique=True
     )
     op.create_index(
         'correlations_signatures_idx',
@@ -61,7 +60,6 @@ def upgrade():
             'key',
             'date'
         ],
-        unique=True
     )
 
 

--- a/alembic/versions/373ef4569b93_correlations_table.py
+++ b/alembic/versions/373ef4569b93_correlations_table.py
@@ -50,6 +50,7 @@ def upgrade():
             'date',
             'signature_id'
         ],
+        unique=True,
     )
     op.create_index(
         'correlations_signatures_idx',

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1459,7 +1459,6 @@ class Correlations(DeclarativeBase):
             platform,
             key,
             date,
-            unique=True
         ),
         Index(
             'correlations_signature_idx',

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1425,6 +1425,54 @@ class MissingSymbols(DeclarativeBase):
     __mapper_args__ = {'primary_key': (date_processed, debug_file, debug_id)}
 
 
+class Correlations(DeclarativeBase):
+    __tablename__ = 'correlations'
+
+    #column definitions
+    id = Column(u'id', INTEGER(), primary_key=True, autoincrement=True, nullable=False)
+    product_version_id = Column(u'product_version_id', INTEGER(), nullable=False, autoincrement=False, index=True)
+    platform = Column(u'platform', TEXT(), primary_key=True, nullable=False)
+    signature_id = Column(u'signature_id', INTEGER(), primary_key=False, nullable=False, index=True)
+    key = Column(u'key', TEXT(), nullable=False)
+    count = Column(u'count', INTEGER(), nullable=False, server_default=text('0'))
+    notes = Column(u'notes', TEXT(), primary_key=False, nullable=False, server_default='')
+    date = Column(u'date', DATE(), primary_key=False, nullable=False, index=True)
+    payload = Column(u'payload', JSON())
+
+    # When looking for signatures by the correlations you need to query by:
+    #  product_version_id
+    #  platform
+    #  date
+    #  key
+    #
+    # When looking for correlations for a specific signature you need:
+    #  product_version_id
+    #  platform
+    #  key
+    #  date
+    #  signature
+    #
+    __table_args__ = (
+        Index(
+            'correlations_signatures_idx',
+            product_version_id,
+            platform,
+            key,
+            date,
+            unique=True
+        ),
+        Index(
+            'correlations_signature_idx',
+            product_version_id,
+            platform,
+            key,
+            date,
+            signature_id,
+            unique=True
+        ),
+    )
+
+
 ###########################################
 ##  Schema definition: Aggregates
 ###########################################


### PR DESCRIPTION
This was tricky to make. But I think I figured it out and I have no, in my local psql, a nice looking table. 

Here's how I created it:

```
$ dropdb 
$ createdb socorro_integration_test
$ PYTHONPATH=. python socorro/external/postgresql/setupdb_app.py --database_name=socorro_integration_test --database_username=peterbe --database_password=secret --database_superusername=peterbe --database_superuserpassword=secret
$ alembic -c config/alembic.ini revision --autogenerate -m 'correlations table'
$ jed alembic/versions/373ef4569b93_correlations_table.py
```