### PR TITLE
bug 1187852 - make stackwalker expose symbol URLs for modules with loaded symbols

### DIFF
--- a/minidump-stackwalk/http_symbol_supplier.h
+++ b/minidump-stackwalk/http_symbol_supplier.h
@@ -91,6 +91,9 @@ class HTTPSymbolSupplier : public SimpleSymbolSupplier {
     // If was_cached_on_disk is false, the time in milliseconds
     // that the full HTTP request to fetch the symbol file took.
     float fetch_time_ms;
+    // The URL from which this symbol was fetched. In the case
+    // of a cache hit, this is a guess.
+    string url;
   };
 
   // Get stats on symbols for a module.
@@ -104,8 +107,17 @@ class HTTPSymbolSupplier : public SimpleSymbolSupplier {
                       float* fetch_time);
   bool SymbolWasError(const CodeModule* module, const SystemInfo* system_info);
   void StoreCacheHit(const CodeModule* Module);
-  void StoreCacheMiss(const CodeModule* module, float fetch_time);
+  void StoreCacheMiss(const CodeModule* module, float fetch_time,
+                      const string& url);
   void StoreSymbolStats(const CodeModule* module, const SymbolStats& stats);
+  // Given a module, get the relative paths to locate its symbol file on disk
+  // (path) and from a URL (url).
+  bool GetRelativeURLAndPathToSymbolFile(const CodeModule* module,
+                                         string& url,
+                                         string& path);
+  // Guess what URL symbols for this module would have been loaded from,
+  // if it were not already a cache hit.
+  string GuessURL(const CodeModule* module);
 
   vector<string> server_urls_;
   string cache_path_;

--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -588,6 +588,9 @@ int ConvertModulesToJSON(const ProcessState& process_state,
       HTTPSymbolSupplier::SymbolStats stats;
       if (supplier && supplier->GetStats(module, &stats)) {
         module_data["symbol_disk_cache_hit"] = stats.was_cached_on_disk;
+        if (!stats.url.empty()) {
+          module_data["symbol_url"] = stats.url;
+        }
         if (!stats.was_cached_on_disk) {
           module_data["symbol_fetch_time"] = stats.fetch_time_ms;
         }


### PR DESCRIPTION
This will let us link to symbol files from the report page (bug 1184101), which would be useful.

This is mostly just refactoring things to reuse the "build a symbol URL" logic, and then storing the URL the existing SymbolStats struct.