### PR TITLE
fixes bug 1268043 - "More Reports" link on report index links to old report list

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -77,7 +77,7 @@
                                 <th scope="row">Signature</th>
                                 <td>
                                     {{ report.signature }}
-                                    <a href="{{ url('signature:signature_report') }}?product={{ report.product }}&amp;signature={{ report.signature|urlencode }}&amp;version={{ report.version|urlencode }}" class="sig-overview" title="View more reports of this type">More Reports</a>
+                                    <a href="{{ url('signature:signature_report') }}?product={{ report.product }}&amp;signature={{ report.signature|urlencode }}" class="sig-overview" title="View more reports of this type">More Reports</a>
                                     <a href="{{ url('supersearch.search') }}?product={{ report.product }}&amp;signature=%3D{{ report.signature|urlencode }}" class="sig-search" title="Search for more reports of this type">Search</a>
                                 </td>
                             </tr>

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -77,7 +77,7 @@
                                 <th scope="row">Signature</th>
                                 <td>
                                     {{ report.signature }}
-                                    <a href="{{ url('crashstats:report_list') }}?product={{ report.product }}&amp;signature={{ report.signature|urlencode }}" class="sig-overview" title="View more reports of this type">More Reports</a>
+                                    <a href="{{ url('signature:signature_report') }}?product={{ report.product }}&amp;signature={{ report.signature|urlencode }}&amp;version={{ report.version|urlencode }}" class="sig-overview" title="View more reports of this type">More Reports</a>
                                     <a href="{{ url('supersearch.search') }}?product={{ report.product }}&amp;signature=%3D{{ report.signature|urlencode }}" class="sig-search" title="Search for more reports of this type">Search</a>
                                 </td>
                             </tr>


### PR DESCRIPTION
We could maybe add to the URL, the `&date=>...&date=<...` like it does on `topcrashers.html` but it feels slightly out of context. What do you think? We'd have to arbitrarily pick today and today minus 7 days. 