### PR TITLE
fixes bug 1269453 - Improve cachability for the first signature dates

### DIFF
--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -45,8 +45,16 @@ class TestViews(BaseTestViews):
                         ),
                         "first_build": "20000101122334",
                     },
+                    {
+                        "signature": u"mozCool()",
+                        "first_date": datetime.datetime(
+                            2016, 5, 2, 0, 0, 0,
+                            tzinfo=UTC(),
+                        ),
+                        "first_build": "20160502000000",
+                    },
                 ],
-                "total": 1
+                "total": 2
             }
 
         SignatureFirstDate.implementation().get.side_effect = (

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -335,9 +335,12 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
     sig_date_data = {}
     if signatures:
         sig_api = models.SignatureFirstDate()
-        first_dates = sig_api.get(signatures=signatures)
-        for sig in first_dates['hits']:
-            sig_date_data[sig['signature']] = sig['first_date']
+        # SignatureFirstDate().get_dates() is an optimized version
+        # of SignatureFirstDate().get() that returns a dict of
+        # signature --> dates.
+        first_dates = sig_api.get_dates(signatures)
+        for sig, dates in first_dates.items():
+            sig_date_data[sig] = dates['first_date']
 
     for crash in tcbs:
         crash_counts = []


### PR DESCRIPTION
I put in a print statement [here](https://github.com/peterbe/socorro/blob/6e89e6ac4dab66c622e1c229780c5f4312d11a5b/socorro/external/postgresql/signature_first_date.py#L19) that said `print "Querying for", len(params['signatures']), "signatures"`. 
Then I opened the Top Crashers for each version of Firefox. Before this patch, it said:
```
Querying for 50 signatures
Querying for 50 signatures
Querying for 50 signatures
Querying for 50 signatures
```
Then, after writing this patch, same thing and this time it printed this out:
```
Querying for 50 signatures
Querying for 47 signatures
Querying for 29 signatures
Querying for 40 signatures
```
In other words, it stops querying PG for signatures' first date if it's already done that for some other version. 

So this patch makes it less SQL select work on PG but that's the small part. 
What really makes a difference is that now EACH signature has its own first_date cache and it's 24 hours. It means that we'll only really need something like a total of 150ish queries against PG in a day.  Instead of 200x24. 

That's going to make the Top Crashers page faster. 