### PR TITLE
bug 1270248 - Read active versions from the API instead

### DIFF
--- a/scripts/crons/active-firefox-versions.py
+++ b/scripts/crons/active-firefox-versions.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import json
+import urllib
+
+product_versions = json.load(urllib.urlopen(
+    'https://crash-stats.mozilla.com/api/ProductVersions/'
+    '?active=true&product=Firefox'
+))['hits']
+
+versions = [
+    x['version'] for x in product_versions if 'esr' not in x['version']
+]
+print ' '.join(sorted(versions))

--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -69,12 +69,13 @@ do
   techo "Phase 1: end"
 done
 
-MANUAL_VERSION_OVERRIDE="47.0b1 47.0b2 47.0b3 47.0b4 47.0b5 47.0b6 47.0b7 47.0b8 47.0b9 47.0b99 48.0a2 49.0a1"
+#MANUAL_VERSION_OVERRIDE="47.0b1 47.0b2 47.0b3 47.0b4 47.0b5 47.0b6 47.0b7 47.0b8 47.0b9 47.0b99 48.0a2 49.0a1"
+VERSIONS=`./active-firefox-versions.py`
 techo "Phase 2: start"
 for I in Firefox
 do
   techo "Phase 2: Product: $I"
-  for J in $MANUAL_VERSION_OVERRIDE
+  for J in $VERSIONS
   do
     techo "Phase 1: Version: $J start"
     techo "Pulling processed JSON from PostgreSQL"


### PR DESCRIPTION
cc @KaiRo-at 

@jdotpz The reason I'm asking you for a review is because you're the best at bash and stuff. Also you might need to be aware of what we're trying to do since you're the expert at deploying this script on crash-analysis. 

[First read this](https://bugzilla.mozilla.org/show_bug.cgi?id=1270248#c0)

I've tested this script on the crash-analysis to make sure it works (I just ssh'ed in and pasted the code in vi):
```
[centos@prod-analysis-i-d66ada10 ~]$ vi active-firefox-versions.py
[centos@prod-analysis-i-d66ada10 ~]$ ./active-firefox-versions.py
43.0.4 44.0 44.0.1 44.0.2 45.0 45.0.1 45.0.2 46.0 46.0.1 46.0b 46.0b1 46.0b10 46.0b11 46.0b2 46.0b4 46.0b5 46.0b6 46.0b7 46.0b8 46.0b9 46.0b99 47.0a2 47.0b 47.0b1 47.0b2 48.0a1 48.0a2 49.0a1
```

What I'm not sure about is the execution of it into a variable like that. It seems to work:
```
[centos@prod-analysis-i-d66ada10 ~]$ vi peterbetest.sh
[centos@prod-analysis-i-d66ada10 ~]$ cat peterbetest.sh
#!/bin/bash -x

VERSIONS=`./active-firefox-versions.py`
for J in $VERSIONS
do
  echo "Version: $J"
done

[centos@prod-analysis-i-d66ada10 ~]$ bash peterbetest.sh
Version: 43.0.4
Version: 44.0
Version: 44.0.1
Version: 44.0.2
Version: 45.0
Version: 45.0.1
Version: 45.0.2
Version: 46.0
Version: 46.0.1
Version: 46.0b
Version: 46.0b1
Version: 46.0b10
Version: 46.0b11
Version: 46.0b2
Version: 46.0b4
Version: 46.0b5
Version: 46.0b6
Version: 46.0b7
Version: 46.0b8
Version: 46.0b9
Version: 46.0b99
Version: 47.0a2
Version: 47.0b
Version: 47.0b1
Version: 47.0b2
Version: 48.0a1
Version: 48.0a2
Version: 49.0a1
```