### PR TITLE
fixes bug 1270498 - ! should be URL encoded in the SuperSearch API URL

### DIFF
--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
@@ -130,6 +130,7 @@ $(function () {
     function updatePublicApiUrl(params) {
         // Update the public API URL.
         var queryString = $.param(params, true);
+        queryString = queryString.replace(/!/g, '%21');
         publicApiUrlInput.val(BASE_URL + publicApiUrl + '?' + queryString);
     }
 


### PR DESCRIPTION
Seem's jQuery's `$.params({'foo': ['!']})` fails us. It manages to get other characters right. 

See http://codepen.io/peterbe/pen/reovmx?editors=1010