### PR TITLE
bug 1270487 - New permission to reprocess crashes

### DIFF
--- a/webapp-django/crashstats/crashstats/management/__init__.py
+++ b/webapp-django/crashstats/crashstats/management/__init__.py
@@ -20,6 +20,7 @@ PERMISSIONS = {
     'run_long_queries': 'Run Long Queries',
     'upload_symbols': 'Upload Symbols Files',
     'view_all_symbol_uploads': 'View all Symbol Uploads',
+    'reprocess_crashes': 'Reprocess Crashes',
 }
 
 


### PR DESCRIPTION
I'm not letting this git commit close the bug automatically. 
Once this lands we need to run `envconsulstuff ./manage.py migrate` and I'll run this `__init__.py` and make sure the permission exists there. 

