### PR TITLE
Fixes bug 1266827: Add keybuilder class to s3 crash storage [DO NOT MERGE]

### DIFF
--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -16,6 +16,7 @@ from socorro.external.crashstorage_base import (
     MemoryDumpsMapping
 )
 from socorro.external.boto.connection_context import (
+    KeyBuilderBase,
     S3ConnectionContext
 )
 from socorro.external.boto.crashstorage import (
@@ -128,6 +129,7 @@ class TestCase(socorro.unittest.testbase.TestCase):
             'transaction_executor_class': executor,
             'transaction_executor_class_for_get': executor_for_gets,
             'resource_class': S3ConnectionContext,
+            'keybuilder_class': KeyBuilderBase,
             'backoff_delays': [0, 0, 0],
             'redactor_class': Redactor,
             'forbidden_keys': Redactor.required_config.forbidden_keys.default,


### PR DESCRIPTION
This breaks out key building into a separate class allowing us to
specify which keybuilder class to use.

It also creates a new DatePrefixKeyBuilder which will pull the date
portion off the end of a raw_crash ooid and add that to the s3
pseudo-filename before the ooid. This new pseudo-filename form lets us
list all the crashes that came in on a specific date.

Further, it does this in a backwards compatible way by changing
build_key() to build_keys() which returns a list of keys to try in order
of "goodness". That way .fetch() can try the keys in order until it
finds the object in question.

r?