### PR TITLE
fixes bug 1270662 - Supersearch drops special characters from URL

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/utils.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/utils.js
@@ -203,7 +203,6 @@
                     temp = queries[i].split('=');
                     var key = temp[0];
                     var value = decodeURIComponent(temp[1]);
-                    value = value.replace(/\+/g, ' ');
 
                     if (params[key] && Array.isArray(params[key])) {
                         params[key].push(value);


### PR DESCRIPTION
This certainly fixes the problem. 
Before this fix, loading [this url](http://socorro.dev/search/?product=Firefox&app_notes=~WGL%2B&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#facet-signature) would insert into the `app_notes` search this value: `WGL`. After this change that value becomes `WGL+`. 

But I suspect this line that I'm removing might be there for a good reason. Some other reason. Perhaps an old reason. 