### PR TITLE
fixes bug 1272053 - Refactor how we cache individual bug data cache

### DIFF
--- a/webapp-django/crashstats/crashstats/forms.py
+++ b/webapp-django/crashstats/crashstats/forms.py
@@ -1,4 +1,3 @@
-import re
 import datetime
 
 from django import forms
@@ -49,7 +48,6 @@ class Html5DateInput(forms.DateInput):
 class BugInfoForm(BaseForm):
 
     bug_ids = forms.CharField(required=True)
-    include_fields = forms.CharField(required=True)
 
     def clean_bug_ids(self):
         value = self.cleaned_data['bug_ids']
@@ -62,19 +60,6 @@ class BugInfoForm(BaseForm):
                 (', '.join(repr(x) for x in nasty_bug_ids))
             )
         return bug_ids
-
-    def clean_include_fields(self):
-        value = self.cleaned_data['include_fields']
-        include_fields = [x.strip() for x in value.split(',') if x.strip()]
-        # include fields must be variable looking strings
-        regex = re.compile('[^\w_]+')
-        nasty_fields = [x for x in include_fields if regex.findall(x)]
-        if nasty_fields:
-            raise forms.ValidationError(
-                'Not valid include_fields %s' %
-                (', '.join(repr(x) for x in nasty_fields))
-            )
-        return include_fields
 
 
 def make_choices(seq):

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1518,7 +1518,11 @@ class BugzillaAPI(SocorroCommon):
 
 class BugzillaBugInfo(BugzillaAPI):
 
+    # This is for the whole model.
     cache_seconds = 0
+
+    # This is for how long we cache the metadata of each individual bug.
+    BUG_CACHE_SECONDS = 60 * 60
 
     @staticmethod
     def make_cache_key(bug_id):
@@ -1550,7 +1554,7 @@ class BugzillaBugInfo(BugzillaAPI):
             fetched = self.fetch(url, headers)
             for each in fetched['bugs']:
                 cache_key = self.make_cache_key(each['id'])
-                cache.set(cache_key, each, 60 * 60)
+                cache.set(cache_key, each, self.BUG_CACHE_SECONDS)
                 results.append(each)
         return {'bugs': results}
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/bugzilla.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/bugzilla.js
@@ -23,7 +23,7 @@ var BugLinks = (function() {
 
     function fetch_remotely(bug_ids) {
         var deferred = $.Deferred();
-        var data = {bug_ids: bug_ids.join(','), include_fields: 'summary,status,id,resolution'};
+        var data = {bug_ids: bug_ids.join(',')};
         var req = $.getJSON(URL, data);
         req.done(function(response) {
             var table = {};

--- a/webapp-django/crashstats/crashstats/tests/test_forms.py
+++ b/webapp-django/crashstats/crashstats/tests/test_forms.py
@@ -286,26 +286,14 @@ class TestForms(DjangoTestCase):
             return forms.BugInfoForm(data)
 
         form = get_new_form({})
-        ok_(not form.is_valid())  # missing both
-
-        form = get_new_form({'include_fields': 'foo,bar'})
         ok_(not form.is_valid())  # missing bug_ids
 
-        form = get_new_form({'bug_ids': '456,123'})
-        ok_(not form.is_valid())  # missing include_fields
+        form = get_new_form({'bug_ids': '456, not a bug'})
+        ok_(not form.is_valid())  # invalid bug_ids
 
-        form = get_new_form({'bug_ids': '456, not a bug',
-                             'include_fields': 'foo'})
-        ok_(not form.is_valid())  # invalid bug_id
-
-        form = get_new_form({'bug_ids': '123', 'include_fields': 'foo,&123'})
-        ok_(not form.is_valid())  # invalid include field
-
-        form = get_new_form({'bug_ids': '123 , 345 ,, 100',
-                             'include_fields': 'foo_1 ,, bar_2 '})
+        form = get_new_form({'bug_ids': '123 , 345 ,, 100'})
         ok_(form.is_valid())
         eq_(form.cleaned_data['bug_ids'], ['123', '345', '100'])
-        eq_(form.cleaned_data['include_fields'], ['foo_1', 'bar_2'])
 
     def test_adubysignature_form(self):
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -649,9 +649,17 @@ class TestViews(BaseTestViews):
         def mocked_get(url, params, **options):
             if 'bug?id=' in url:
                 return Response({
-                    'bugs': [
-                        {'product': 'allizom.org'},
-                    ]
+                    'bugs': [{
+                        'id': 123,
+                        'status': 'NEW',
+                        'resolution': '',
+                        'summary': 'Some Summary',
+                    }, {
+                        'id': 456,
+                        'status': 'NEW',
+                        'resolution': '',
+                        'summary': 'Other Summary',
+                    }],
                 })
 
             raise NotImplementedError(url)
@@ -661,19 +669,15 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         eq_(response.status_code, 400)
 
-        response = self.client.get(url, {'bug_ids': '123,456'})
+        response = self.client.get(url, {'bug_ids': ''})
         eq_(response.status_code, 400)
 
-        response = self.client.get(url, {'include_fields': 'product'})
-        eq_(response.status_code, 400)
-
-        response = self.client.get(url, {'bug_ids': ' 123, 456 ',
-                                         'include_fields': ' product'})
+        response = self.client.get(url, {'bug_ids': ' 123, 456 '})
         eq_(response.status_code, 200)
 
         struct = json.loads(response.content)
         ok_(struct['bugs'])
-        eq_(struct['bugs'][0]['product'], 'allizom.org')
+        eq_(struct['bugs'][0]['summary'], 'Some Summary')
 
     @mock.patch('requests.get')
     def test_buginfo_with_caching(self, rget):

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -2060,16 +2060,10 @@ def buginfo(request, signatures=None):
     if not form.is_valid():
         return http.HttpResponseBadRequest(str(form.errors))
 
-    bugs = form.cleaned_data['bug_ids']
-    fields = form.cleaned_data['include_fields']
+    bug_ids = form.cleaned_data['bug_ids']
 
     bzapi = models.BugzillaBugInfo()
-    result = bzapi.get(bugs, fields)
-    # store all of these in a cache
-    for bug in result['bugs']:
-        if 'id' in bug:
-            cache_key = 'buginfo:%s' % bug['id']
-            cache.set(cache_key, bug, 60 * 60)  # one hour
+    result = bzapi.get(bug_ids)
     return result
 
 


### PR DESCRIPTION
cc @adngdb 

The bug description is pretty extensive. 

The **tl;dr** is that we don't change anything on the outside. Instead, when calling the URL `/buginfo/bug?bugs_ids=123,124,125` that whole request does not get cached. Instead it individually caches `123`, `124` and `125`. 

Also, I refactored it so that with that view, you can't specify the `include_fields` any more. It's hardcoded. It's no longer trying to be a cached proxy to Bugzilla's API. It tries to be smarter than that. 

One cool benefit with this is that we can now write a Pulse consumer (I have a working prototype of this on my laptop) that connects to the same memcache as we use in production. Then it can immediately invalidate the cache so we'd be able to set the cache time to 24h or 7days AND never ever have stale information for the bug info. 

A possibly easier alternative is to make a crontabber app that queries bugzilla for ALL bugs that have changed in the last, say, 30 minutes and again connect to the same memcache, and invalidate them all.

But first things first, let's explode this model. 