### PR TITLE
Fixes bug 1273538 - Correctly encode white spaces in URLs.

### DIFF
--- a/webapp-django/crashstats/api/static/api/js/testdrive.js
+++ b/webapp-django/crashstats/api/static/api/js/testdrive.js
@@ -78,7 +78,7 @@
         // The second parameter (`true`) is so that things like
         // `{products: ["Firefox", "Thunderbird"]}`
         // becomes: `products=Firefox&products=Thunderbird`
-        var qs = $.param(form.serializeExclusive(), true);
+        var qs = Qs.stringify(form.serializeExclusive(), { indices: false });
         if (qs) {
             url += '?' + qs;
         }

--- a/webapp-django/crashstats/base/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/base/templatetags/jinja_helpers.py
@@ -86,6 +86,9 @@ def change_query_string(context, **kwargs):
             # change it
             qs[key] = value
     new_qs = urllib.urlencode(qs, True)
+
+    # We don't like + as the encoding character for spaces. %20 is better.
+    new_qs = new_qs.replace('+', '%20')
     if new_qs:
         return '%s?%s' % (base, new_qs)
     return base
@@ -93,4 +96,4 @@ def change_query_string(context, **kwargs):
 
 @library.global_function
 def make_query_string(**kwargs):
-    return urllib.urlencode(kwargs, True)
+    return urllib.urlencode(kwargs, True).replace('+', '%20')

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/lib/qs.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/lib/qs.js
@@ -1,0 +1,487 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Qs = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+'use strict';
+
+var Stringify = require('./stringify');
+var Parse = require('./parse');
+
+module.exports = {
+    stringify: Stringify,
+    parse: Parse
+};
+
+},{"./parse":2,"./stringify":3}],2:[function(require,module,exports){
+'use strict';
+
+var Utils = require('./utils');
+
+var defaults = {
+    delimiter: '&',
+    depth: 5,
+    arrayLimit: 20,
+    parameterLimit: 1000,
+    strictNullHandling: false,
+    plainObjects: false,
+    allowPrototypes: false,
+    allowDots: false,
+    decoder: Utils.decode
+};
+
+var parseValues = function parseValues(str, options) {
+    var obj = {};
+    var parts = str.split(options.delimiter, options.parameterLimit === Infinity ? undefined : options.parameterLimit);
+
+    for (var i = 0; i < parts.length; ++i) {
+        var part = parts[i];
+        var pos = part.indexOf(']=') === -1 ? part.indexOf('=') : part.indexOf(']=') + 1;
+
+        if (pos === -1) {
+            obj[options.decoder(part)] = '';
+
+            if (options.strictNullHandling) {
+                obj[options.decoder(part)] = null;
+            }
+        } else {
+            var key = options.decoder(part.slice(0, pos));
+            var val = options.decoder(part.slice(pos + 1));
+
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                obj[key] = [].concat(obj[key]).concat(val);
+            } else {
+                obj[key] = val;
+            }
+        }
+    }
+
+    return obj;
+};
+
+var parseObject = function parseObject(chain, val, options) {
+    if (!chain.length) {
+        return val;
+    }
+
+    var root = chain.shift();
+
+    var obj;
+    if (root === '[]') {
+        obj = [];
+        obj = obj.concat(parseObject(chain, val, options));
+    } else {
+        obj = options.plainObjects ? Object.create(null) : {};
+        var cleanRoot = root[0] === '[' && root[root.length - 1] === ']' ? root.slice(1, root.length - 1) : root;
+        var index = parseInt(cleanRoot, 10);
+        if (
+            !isNaN(index) &&
+            root !== cleanRoot &&
+            String(index) === cleanRoot &&
+            index >= 0 &&
+            (options.parseArrays && index <= options.arrayLimit)
+        ) {
+            obj = [];
+            obj[index] = parseObject(chain, val, options);
+        } else {
+            obj[cleanRoot] = parseObject(chain, val, options);
+        }
+    }
+
+    return obj;
+};
+
+var parseKeys = function parseKeys(givenKey, val, options) {
+    if (!givenKey) {
+        return;
+    }
+
+    // Transform dot notation to bracket notation
+    var key = options.allowDots ? givenKey.replace(/\.([^\.\[]+)/g, '[$1]') : givenKey;
+
+    // The regex chunks
+
+    var parent = /^([^\[\]]*)/;
+    var child = /(\[[^\[\]]*\])/g;
+
+    // Get the parent
+
+    var segment = parent.exec(key);
+
+    // Stash the parent if it exists
+
+    var keys = [];
+    if (segment[1]) {
+        // If we aren't using plain objects, optionally prefix keys
+        // that would overwrite object prototype properties
+        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1])) {
+            if (!options.allowPrototypes) {
+                return;
+            }
+        }
+
+        keys.push(segment[1]);
+    }
+
+    // Loop through children appending to the array until we hit depth
+
+    var i = 0;
+    while ((segment = child.exec(key)) !== null && i < options.depth) {
+        i += 1;
+        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1].replace(/\[|\]/g, ''))) {
+            if (!options.allowPrototypes) {
+                continue;
+            }
+        }
+        keys.push(segment[1]);
+    }
+
+    // If there's a remainder, just add whatever is left
+
+    if (segment) {
+        keys.push('[' + key.slice(segment.index) + ']');
+    }
+
+    return parseObject(keys, val, options);
+};
+
+module.exports = function (str, opts) {
+    var options = opts || {};
+
+    if (options.decoder !== null && options.decoder !== undefined && typeof options.decoder !== 'function') {
+        throw new TypeError('Decoder has to be a function.');
+    }
+
+    options.delimiter = typeof options.delimiter === 'string' || Utils.isRegExp(options.delimiter) ? options.delimiter : defaults.delimiter;
+    options.depth = typeof options.depth === 'number' ? options.depth : defaults.depth;
+    options.arrayLimit = typeof options.arrayLimit === 'number' ? options.arrayLimit : defaults.arrayLimit;
+    options.parseArrays = options.parseArrays !== false;
+    options.decoder = typeof options.decoder === 'function' ? options.decoder : defaults.decoder;
+    options.allowDots = typeof options.allowDots === 'boolean' ? options.allowDots : defaults.allowDots;
+    options.plainObjects = typeof options.plainObjects === 'boolean' ? options.plainObjects : defaults.plainObjects;
+    options.allowPrototypes = typeof options.allowPrototypes === 'boolean' ? options.allowPrototypes : defaults.allowPrototypes;
+    options.parameterLimit = typeof options.parameterLimit === 'number' ? options.parameterLimit : defaults.parameterLimit;
+    options.strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
+
+    if (str === '' || str === null || typeof str === 'undefined') {
+        return options.plainObjects ? Object.create(null) : {};
+    }
+
+    var tempObj = typeof str === 'string' ? parseValues(str, options) : str;
+    var obj = options.plainObjects ? Object.create(null) : {};
+
+    // Iterate over the keys and setup the new object
+
+    var keys = Object.keys(tempObj);
+    for (var i = 0; i < keys.length; ++i) {
+        var key = keys[i];
+        var newObj = parseKeys(key, tempObj[key], options);
+        obj = Utils.merge(obj, newObj, options);
+    }
+
+    return Utils.compact(obj);
+};
+
+},{"./utils":4}],3:[function(require,module,exports){
+'use strict';
+
+var Utils = require('./utils');
+
+var arrayPrefixGenerators = {
+    brackets: function brackets(prefix) {
+        return prefix + '[]';
+    },
+    indices: function indices(prefix, key) {
+        return prefix + '[' + key + ']';
+    },
+    repeat: function repeat(prefix) {
+        return prefix;
+    }
+};
+
+var defaults = {
+    delimiter: '&',
+    strictNullHandling: false,
+    skipNulls: false,
+    encode: true,
+    encoder: Utils.encode
+};
+
+var stringify = function stringify(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots) {
+    var obj = object;
+    if (typeof filter === 'function') {
+        obj = filter(prefix, obj);
+    } else if (obj instanceof Date) {
+        obj = obj.toISOString();
+    } else if (obj === null) {
+        if (strictNullHandling) {
+            return encoder ? encoder(prefix) : prefix;
+        }
+
+        obj = '';
+    }
+
+    if (typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean' || Utils.isBuffer(obj)) {
+        if (encoder) {
+            return [encoder(prefix) + '=' + encoder(obj)];
+        }
+        return [prefix + '=' + String(obj)];
+    }
+
+    var values = [];
+
+    if (typeof obj === 'undefined') {
+        return values;
+    }
+
+    var objKeys;
+    if (Array.isArray(filter)) {
+        objKeys = filter;
+    } else {
+        var keys = Object.keys(obj);
+        objKeys = sort ? keys.sort(sort) : keys;
+    }
+
+    for (var i = 0; i < objKeys.length; ++i) {
+        var key = objKeys[i];
+
+        if (skipNulls && obj[key] === null) {
+            continue;
+        }
+
+        if (Array.isArray(obj)) {
+            values = values.concat(stringify(obj[key], generateArrayPrefix(prefix, key), generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots));
+        } else {
+            values = values.concat(stringify(obj[key], prefix + (allowDots ? '.' + key : '[' + key + ']'), generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots));
+        }
+    }
+
+    return values;
+};
+
+module.exports = function (object, opts) {
+    var obj = object;
+    var options = opts || {};
+    var delimiter = typeof options.delimiter === 'undefined' ? defaults.delimiter : options.delimiter;
+    var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
+    var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults.skipNulls;
+    var encode = typeof options.encode === 'boolean' ? options.encode : defaults.encode;
+    var encoder = encode ? (typeof options.encoder === 'function' ? options.encoder : defaults.encoder) : null;
+    var sort = typeof options.sort === 'function' ? options.sort : null;
+    var allowDots = typeof options.allowDots === 'undefined' ? false : options.allowDots;
+    var objKeys;
+    var filter;
+
+    if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
+        throw new TypeError('Encoder has to be a function.');
+    }
+
+    if (typeof options.filter === 'function') {
+        filter = options.filter;
+        obj = filter('', obj);
+    } else if (Array.isArray(options.filter)) {
+        objKeys = filter = options.filter;
+    }
+
+    var keys = [];
+
+    if (typeof obj !== 'object' || obj === null) {
+        return '';
+    }
+
+    var arrayFormat;
+    if (options.arrayFormat in arrayPrefixGenerators) {
+        arrayFormat = options.arrayFormat;
+    } else if ('indices' in options) {
+        arrayFormat = options.indices ? 'indices' : 'repeat';
+    } else {
+        arrayFormat = 'indices';
+    }
+
+    var generateArrayPrefix = arrayPrefixGenerators[arrayFormat];
+
+    if (!objKeys) {
+        objKeys = Object.keys(obj);
+    }
+
+    if (sort) {
+        objKeys.sort(sort);
+    }
+
+    for (var i = 0; i < objKeys.length; ++i) {
+        var key = objKeys[i];
+
+        if (skipNulls && obj[key] === null) {
+            continue;
+        }
+
+        keys = keys.concat(stringify(obj[key], key, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots));
+    }
+
+    return keys.join(delimiter);
+};
+
+},{"./utils":4}],4:[function(require,module,exports){
+'use strict';
+
+var hexTable = (function () {
+    var array = new Array(256);
+    for (var i = 0; i < 256; ++i) {
+        array[i] = '%' + ((i < 16 ? '0' : '') + i.toString(16)).toUpperCase();
+    }
+
+    return array;
+}());
+
+exports.arrayToObject = function (source, options) {
+    var obj = options.plainObjects ? Object.create(null) : {};
+    for (var i = 0; i < source.length; ++i) {
+        if (typeof source[i] !== 'undefined') {
+            obj[i] = source[i];
+        }
+    }
+
+    return obj;
+};
+
+exports.merge = function (target, source, options) {
+    if (!source) {
+        return target;
+    }
+
+    if (typeof source !== 'object') {
+        if (Array.isArray(target)) {
+            target.push(source);
+        } else if (typeof target === 'object') {
+            target[source] = true;
+        } else {
+            return [target, source];
+        }
+
+        return target;
+    }
+
+    if (typeof target !== 'object') {
+        return [target].concat(source);
+    }
+
+    var mergeTarget = target;
+    if (Array.isArray(target) && !Array.isArray(source)) {
+        mergeTarget = exports.arrayToObject(target, options);
+    }
+
+    return Object.keys(source).reduce(function (acc, key) {
+        var value = source[key];
+
+        if (Object.prototype.hasOwnProperty.call(acc, key)) {
+            acc[key] = exports.merge(acc[key], value, options);
+        } else {
+            acc[key] = value;
+        }
+        return acc;
+    }, mergeTarget);
+};
+
+exports.decode = function (str) {
+    try {
+        return decodeURIComponent(str.replace(/\+/g, ' '));
+    } catch (e) {
+        return str;
+    }
+};
+
+exports.encode = function (str) {
+    // This code was originally written by Brian White (mscdex) for the io.js core querystring library.
+    // It has been adapted here for stricter adherence to RFC 3986
+    if (str.length === 0) {
+        return str;
+    }
+
+    var string = typeof str === 'string' ? str : String(str);
+
+    var out = '';
+    for (var i = 0; i < string.length; ++i) {
+        var c = string.charCodeAt(i);
+
+        if (
+            c === 0x2D || // -
+            c === 0x2E || // .
+            c === 0x5F || // _
+            c === 0x7E || // ~
+            (c >= 0x30 && c <= 0x39) || // 0-9
+            (c >= 0x41 && c <= 0x5A) || // a-z
+            (c >= 0x61 && c <= 0x7A) // A-Z
+        ) {
+            out += string.charAt(i);
+            continue;
+        }
+
+        if (c < 0x80) {
+            out = out + hexTable[c];
+            continue;
+        }
+
+        if (c < 0x800) {
+            out = out + (hexTable[0xC0 | (c >> 6)] + hexTable[0x80 | (c & 0x3F)]);
+            continue;
+        }
+
+        if (c < 0xD800 || c >= 0xE000) {
+            out = out + (hexTable[0xE0 | (c >> 12)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)]);
+            continue;
+        }
+
+        i += 1;
+        c = 0x10000 + (((c & 0x3FF) << 10) | (string.charCodeAt(i) & 0x3FF));
+        out += hexTable[0xF0 | (c >> 18)] + hexTable[0x80 | ((c >> 12) & 0x3F)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)];
+    }
+
+    return out;
+};
+
+exports.compact = function (obj, references) {
+    if (typeof obj !== 'object' || obj === null) {
+        return obj;
+    }
+
+    var refs = references || [];
+    var lookup = refs.indexOf(obj);
+    if (lookup !== -1) {
+        return refs[lookup];
+    }
+
+    refs.push(obj);
+
+    if (Array.isArray(obj)) {
+        var compacted = [];
+
+        for (var i = 0; i < obj.length; ++i) {
+            if (obj[i] && typeof obj[i] === 'object') {
+                compacted.push(exports.compact(obj[i], refs));
+            } else if (typeof obj[i] !== 'undefined') {
+                compacted.push(obj[i]);
+            }
+        }
+
+        return compacted;
+    }
+
+    var keys = Object.keys(obj);
+    for (var j = 0; j < keys.length; ++j) {
+        var key = keys[j];
+        obj[key] = exports.compact(obj[key], refs);
+    }
+
+    return obj;
+};
+
+exports.isRegExp = function (obj) {
+    return Object.prototype.toString.call(obj) === '[object RegExp]';
+};
+
+exports.isBuffer = function (obj) {
+    if (obj === null || typeof obj === 'undefined') {
+        return false;
+    }
+
+    return !!(obj.constructor && obj.constructor.isBuffer && obj.constructor.isBuffer(obj));
+};
+
+},{}]},{},[1])(1)
+});

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_graph.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/report_list_graph.js
@@ -346,7 +346,7 @@ var Plot = (function() {
             signature: dataSet.signature
         };
 
-        var url = dataSet.jsonurl + '?' + $.param(params) + '&' + formParams;
+        var url = dataSet.jsonurl + '?' + Qs.stringify(params, { indices: false }) + '&' + formParams;
 
         $.getJSON(url, function(data) {
 

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/topcrash.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/topcrash.js
@@ -30,7 +30,7 @@ var Correlations = (function() {
         for (var platform in osnames) {
             data.platforms.push(platform);
         }
-        $.getJSON(SocReport.sig_base + '?' + $.param(data, true))
+        $.getJSON(SocReport.sig_base + '?' + Qs.stringify(data, { indices: false }))
         .done(function (json) {
             for (var type in json) {
                 json[type].hits.forEach(function(sig) {
@@ -56,7 +56,7 @@ var Correlations = (function() {
             correlation_report_types: correlations,
         };
 
-        $.getJSON(SocReport.base + '?' + $.param(data, true))
+        $.getJSON(SocReport.base + '?' + Qs.stringify(data, { indices: false }))
         .done(function(json) {
             for (var i in correlations) {
                 var type = correlations[i];

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -3490,7 +3490,7 @@ class TestViews(BaseTestViews):
         doc = pyquery.PyQuery(response.content)
         for link in doc('a'):
             if link.text and 'View ALL' in link.text:
-                ok_(urllib.quote_plus(sig) in link.attrib['href'])
+                ok_(urllib.quote(sig) in link.attrib['href'])
 
     def test_report_list_all_link_columns_offered(self):
         url = reverse('crashstats:report_list')

--- a/webapp-django/crashstats/home/static/home/js/home.js
+++ b/webapp-django/crashstats/home/static/home/js/home.js
@@ -120,7 +120,7 @@ $(function () {
             _results_number: 0,
         };
 
-        var url = superSearchApiUrl + '?' + $.param(params, true);
+        var url = superSearchApiUrl + '?' + Qs.stringify(params, { indices: false });
         $.ajax({url: url})
         .then(onSuperSearchData)
         .done(function (data) {
@@ -148,7 +148,7 @@ $(function () {
             end_date: dateIsoFormat(endDate),
         };
 
-        var url = adiApiUrl + '?' + $.param(params, true);
+        var url = adiApiUrl + '?' + Qs.stringify(params, { indices: false });
         $.ajax({url: url})
         .then(onADIData)
         .done(function (data) {
@@ -180,7 +180,7 @@ $(function () {
             product: product,
         };
 
-        var url = productBuildTypesApiUrl + '?' + $.param(params, true);
+        var url = productBuildTypesApiUrl + '?' + Qs.stringify(params, { indices: false });
         $.ajax({url: url})
         .then(onBuildTypesData)
         .done(function (data) {

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -251,6 +251,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'crashstats/js/jquery/jquery-2.0.3.min.js',
             'crashstats/js/jquery/plugins/jquery.cookies.2.2.0.js',
+            'crashstats/js/lib/qs.js',
             'crashstats/js/socorro/nav.js',
             'crashstats/js/socorro/analytics.js',
             'browserid/api.js',

--- a/webapp-django/crashstats/signature/static/signature/js/signature_report.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_report.js
@@ -152,7 +152,7 @@ SignatureReport.init = function () {
         searchSection.on('click', 'button[type=submit]', function (e) {
             e.preventDefault();
             var params = SignatureReport.getParamsWithSignature();
-            var queryString = '?' + $.param(params, true);
+            var queryString = '?' + Qs.stringify(params, { indices: false });
             window.location.search = queryString;
         });
 

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
@@ -117,7 +117,7 @@ SignatureReport.Tab.prototype.getParamsForUrl = function () {
 // Extend this if anything different needs to be added to the URL.
 SignatureReport.Tab.prototype.buildUrl = function (params, option) {
     option = option ? option + '/' : '';
-    return this.dataUrl + option + '?' + $.param(params, true);
+    return this.dataUrl + option + '?' + Qs.stringify(params, { indices: false });
 };
 
 // Extend this if anything different should be done with the returned data.

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
@@ -108,7 +108,7 @@ SignatureReport.ReportsTab.prototype.getParamsForUrl = function () {
 SignatureReport.ReportsTab.prototype.buildUrl = function (params) {
 
     // Build the query string.
-    var queryString = '?' + $.param(params, true);
+    var queryString = '?' + Qs.stringify(params, { indices: false });
 
     // Replace the history.
     window.history.replaceState(params, null, queryString);

--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/search.js
@@ -123,13 +123,13 @@ $(function () {
             }
         }
 
-        var queryString = $.param(params, true);
+        var queryString = Qs.stringify(params, { indices: false });
         return '?' + queryString;
     }
 
     function updatePublicApiUrl(params) {
         // Update the public API URL.
-        var queryString = $.param(params, true);
+        var queryString = Qs.stringify(params, { indices: false });
         queryString = queryString.replace(/!/g, '%21');
         publicApiUrlInput.val(BASE_URL + publicApiUrl + '?' + queryString);
     }
@@ -226,7 +226,7 @@ $(function () {
         if (params) {
             // If there are some parameters, fill the form with those params
             // and run the search and show results.
-            queryString = $.param(params, true);
+            queryString = Qs.stringify(params, { indices: false });
             showResults(resultsURL + '?' + queryString);
             SimpleSearch.setParams(params);
             updatePublicApiUrl(params);
@@ -372,7 +372,7 @@ $(function () {
         if (params) {
             // If there are some parameters, fill the form with those params
             // and run the search and show results
-            queryString = $.param(params, true);
+            queryString = Qs.stringify(params, { indices: false });
             showResults(resultsURL + '?' + queryString);
             params = socorro.search.getFilteredParams(params);
             updatePublicApiUrl(params);

--- a/webapp-django/crashstats/topcrashers/static/topcrashers/js/topcrashers.js
+++ b/webapp-django/crashstats/topcrashers/static/topcrashers/js/topcrashers.js
@@ -30,7 +30,7 @@ var Correlations = (function() {
         for (var platform in osnames) {
             data.platforms.push(platform);
         }
-        $.getJSON(SocReport.sig_base + '?' + $.param(data, true))
+        $.getJSON(SocReport.sig_base + '?' + Qs.stringify(data, { indices: false }))
         .done(function (json) {
             for (var type in json) {
                 json[type].hits.forEach(function(sig) {
@@ -56,7 +56,7 @@ var Correlations = (function() {
             correlation_report_types: correlations,
         };
 
-        $.getJSON(SocReport.base + '?' + $.param(data, true))
+        $.getJSON(SocReport.base + '?' + Qs.stringify(data, { indices: false }))
         .done(function(json) {
             for (var i in correlations) {
                 var type = correlations[i];


### PR DESCRIPTION
``$.param`` uses the ``+`` sign to encode white spaces. So I added a new library to Socorro, called ``Qs``, to deal with query string creation. 