### PR TITLE
Revert "Fixes bug 803779 - Added a rule for Abort signatures."

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -58,7 +58,6 @@ mozilla_processor_rule_sets = [
         "socorro.processor.signature_utilities.SignatureGenerationRule,"
         "socorro.processor.signature_utilities.StackwalkerErrorSignatureRule, "
         "socorro.processor.signature_utilities.OOMSignature, "
-        "socorro.processor.signature_utilities.AbortSignature, "
         "socorro.processor.signature_utilities.SignatureRunWatchDog, "
         "socorro.processor.signature_utilities.SignatureIPCChannelError, "
         "socorro.processor.signature_utilities.SigTrunc, "

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -551,42 +551,6 @@ class OOMSignature(Rule):
 
 
 #==============================================================================
-class AbortSignature(Rule):
-    """To satisfy Bug 803779, this rule will modify the signature to
-    tag Abort crashes"""
-
-    #--------------------------------------------------------------------------
-    def version(self):
-        return '1.0'
-
-    #--------------------------------------------------------------------------
-    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        return 'AbortMessage' in raw_crash and raw_crash.AbortMessage
-
-    #--------------------------------------------------------------------------
-    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
-        processed_crash.original_signature = processed_crash.signature
-
-        abort_message = raw_crash.AbortMessage
-
-        if '###!!! ABORT:' in abort_message:
-            # Recent crash reports added some irrelevant information at the
-            # beginning of the abort message. We want to remove that and keep
-            # just the actual abort message.
-            abort_message = abort_message.split('###!!! ABORT:', 1)[1].strip()
-
-        if len(abort_message) > 80:
-            abort_message = abort_message[:77] + '...'
-
-        processed_crash.signature = 'Abort | {} | {}'.format(
-            abort_message,
-            processed_crash.signature
-        )
-
-        return True
-
-
-#==============================================================================
 class SigTrunc(Rule):
     """ensure that the signature is never longer than 255 characters"""
 

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -11,16 +11,15 @@ import socorrolib.lib.util as sutil
 
 from socorrolib.lib.util import DotDict
 from socorro.processor.signature_utilities import (
-    AbortSignature,
     CSignatureTool,
     JavaSignatureTool,
+    SignatureGenerationRule,
     OOMSignature,
+    SigTrunc,
     StackwalkerErrorSignatureRule,
     SignatureIPCChannelError,
-    SignatureGenerationRule,
     SignatureJitCategory,
     SignatureRunWatchDog,
-    SigTrunc,
 )
 from socorro.unittest.testbase import TestCase
 
@@ -1385,8 +1384,8 @@ class TestOOMSignature(TestCase):
         action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
-        eq_(pc.original_signature, 'hello')
-        eq_(pc.signature, 'OOM | unknown | hello')
+        ok_(pc.original_signature, 'hello')
+        ok_(pc.signature, 'OOM | unknown | hello')
 
     #--------------------------------------------------------------------------
     def test_action_small(self):
@@ -1403,8 +1402,8 @@ class TestOOMSignature(TestCase):
         action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
-        eq_(pc.original_signature, 'hello')
-        eq_(pc.signature, 'OOM | small')
+        ok_(pc.original_signature, 'hello')
+        ok_(pc.signature, 'OOM | small')
 
     #--------------------------------------------------------------------------
     def test_action_large(self):
@@ -1421,112 +1420,8 @@ class TestOOMSignature(TestCase):
         action_result = rule.action(rc, rd, pc, fake_processor)
 
         ok_(action_result)
-        eq_(pc.original_signature, 'hello')
-        eq_(pc.signature, 'OOM | large | hello')
-
-
-#==============================================================================
-class TestAbortSignature(TestCase):
-
-    #--------------------------------------------------------------------------
-    def get_config(self):
-        fake_processor = create_basic_fake_processor()
-        return fake_processor.config
-
-    #--------------------------------------------------------------------------
-    def test_predicate(self):
-        config = self.get_config()
-        rule = AbortSignature(config)
-
-        processed_crash = DotDict()
-        processed_crash.signature = 'hello'
-
-        raw_crash = DotDict()
-        raw_crash.AbortMessage = 'something'
-
-        predicate_result = rule.predicate(raw_crash, {}, processed_crash, {})
-        ok_(predicate_result)
-
-    #--------------------------------------------------------------------------
-    def test_predicate_no_match(self):
-        config = self.get_config()
-        rule = AbortSignature(config)
-
-        processed_crash = DotDict()
-        processed_crash.signature = 'hello'
-
-        raw_crash = DotDict()
-        # No AbortMessage.
-
-        predicate_result = rule.predicate(raw_crash, {}, processed_crash, {})
-        ok_(not predicate_result)
-
-    #--------------------------------------------------------------------------
-    def test_predicate_empty_message(self):
-        config = self.get_config()
-        rule = AbortSignature(config)
-
-        processed_crash = DotDict()
-        processed_crash.signature = 'hello'
-
-        raw_crash = DotDict()
-        raw_crash.AbortMessage = ''
-
-        predicate_result = rule.predicate(raw_crash, {}, processed_crash, {})
-        ok_(not predicate_result)
-
-    #--------------------------------------------------------------------------
-    def test_action_success(self):
-        config = self.get_config()
-        rule = AbortSignature(config)
-
-        processed_crash = DotDict()
-        processed_crash.signature = 'hello'
-
-        raw_crash = DotDict()
-        raw_crash.AbortMessage = 'unknown'
-
-        action_result = rule.action(raw_crash, {}, processed_crash, {})
-
-        ok_(action_result)
-        eq_(processed_crash.original_signature, 'hello')
-        eq_(processed_crash.signature, 'Abort | unknown | hello')
-
-    #--------------------------------------------------------------------------
-    def test_action_success_long_message(self):
-        config = self.get_config()
-        rule = AbortSignature(config)
-
-        processed_crash = DotDict()
-        processed_crash.signature = 'hello'
-
-        raw_crash = DotDict()
-        raw_crash.AbortMessage = 'a' * 81
-
-        action_result = rule.action(raw_crash, {}, processed_crash, {})
-
-        ok_(action_result)
-        eq_(processed_crash.original_signature, 'hello')
-        expected_sig = 'Abort | {}... | hello'.format('a' * 77)
-        eq_(processed_crash.signature, expected_sig)
-
-    #--------------------------------------------------------------------------
-    def test_action_success_remove_beginning(self):
-        config = self.get_config()
-        rule = AbortSignature(config)
-
-        processed_crash = DotDict()
-        processed_crash.signature = 'hello'
-
-        raw_crash = DotDict()
-        raw_crash.AbortMessage = '[5392] ###!!! ABORT: foo bar line 42'
-
-        action_result = rule.action(raw_crash, {}, processed_crash, {})
-
-        ok_(action_result)
-        eq_(processed_crash.original_signature, 'hello')
-        expected_sig = 'Abort | foo bar line 42 | hello'
-        eq_(processed_crash.signature, expected_sig)
+        ok_(pc.original_signature, 'hello')
+        ok_(pc.signature, 'OOM | large | hello')
 
 
 #==============================================================================


### PR DESCRIPTION
Reverts mozilla/socorro#3354

Revert because the feature is not good enough yet, and I don't have time to work on making it perfect now. 