### PR TITLE
fixes bug 1275359 - Reprocess from report index page

### DIFF
--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -317,12 +317,12 @@ class ReprocessingOneRabbitMQCrashStore(ReprocessingRabbitMQCrashStore):
     def reprocess(self, crash_ids):
         if not isinstance(crash_ids, (list, tuple)):
             crash_ids = [crash_ids]
-        all_ = True
+        success = bool(crash_ids)
         for crash_id in crash_ids:
             if not self.save_raw_crash(
                 DotDict({'legacy_processing': 0}),
                 [],
                 crash_id
             ):
-                all_ = False
-        return all_
+                success = False
+        return success

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -314,9 +314,15 @@ class ReprocessingOneRabbitMQCrashStore(ReprocessingRabbitMQCrashStore):
         'socorro.reprocessing'
     )
 
-    def reprocess(self, crash_id):
-        return self.save_raw_crash(
-            DotDict({'legacy_processing': 0}),
-            [],
-            crash_id
-        )
+    def reprocess(self, crash_ids):
+        if not isinstance(crash_ids, (list, tuple)):
+            crash_ids = [crash_ids]
+        all_ = True
+        for crash_id in crash_ids:
+            if not self.save_raw_crash(
+                DotDict({'legacy_processing': 0}),
+                [],
+                crash_id
+            ):
+                all_ = False
+        return all_

--- a/webapp-django/crashstats/api/jinja2/api/documentation.html
+++ b/webapp-django/crashstats/api/jinja2/api/documentation.html
@@ -47,7 +47,7 @@
             <h2><a href="#{{ endpoint.name }}">{{ endpoint.name }}</a></h2>
         </div>
         <div class="body">
-            <form class="testdrive">
+            <form class="testdrive" data-methods="{{ endpoint.methods | to_json }}">
                 <p class="url">
                     <strong>{{ ' | '.join(endpoint.methods) }}</strong>
                     <code>{{ base_url }}{{ endpoint.url }}</code>
@@ -119,6 +119,11 @@
                         <a href="">
                             <code></code>
                         </a>
+                    </p>
+                    <p class="used-data">
+                        <strong>Data</strong>
+                        <br>
+                        <code></code>
                     </p>
                     <p class="status">
                         Status

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -1965,8 +1965,6 @@ class TestViews(BaseTestViews):
             return True
 
         Reprocessing.implementation().reprocess = mocked_reprocess
-        # func = ReprocessingOneRabbitMQCrashStore.implementation().reprocess
-        # func.side_effect = mocked_reprocess
 
         url = reverse('api:model_wrapper', args=('Reprocessing',))
         response = self.client.get(url)
@@ -1984,7 +1982,7 @@ class TestViews(BaseTestViews):
         perm = Permission.objects.get(
             codename='reprocess_crashes'
         )
-        # but make a token that only has the 'view_pii'
+        # but make a token that only has the 'reprocess_crashes'
         # permission associated with it
         token = Token.objects.create(
             user=user,

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -25,6 +25,7 @@ from crashstats.crashstats.models import (
     ProductVersions,
     CrontabberState,
     CurrentProducts,
+    Reprocessing,
 )
 from crashstats.tokens.models import Token
 
@@ -1956,3 +1957,44 @@ class TestViews(BaseTestViews):
         dump = json.loads(response.content)
         ok_(dump['reports'])
         ok_('exploitability' in dump['reports'])
+
+    def test_Reprocessing(self):
+
+        def mocked_reprocess(crash_ids):
+            assert crash_ids == ['xxxx']
+            return True
+
+        Reprocessing.implementation().reprocess = mocked_reprocess
+        # func = ReprocessingOneRabbitMQCrashStore.implementation().reprocess
+        # func.side_effect = mocked_reprocess
+
+        url = reverse('api:model_wrapper', args=('Reprocessing',))
+        response = self.client.get(url)
+        eq_(response.status_code, 403)
+
+        params = {
+            'crash_ids': 'xxxx',
+        }
+        response = self.client.get(url, params, HTTP_AUTH_TOKEN='somecrap')
+        eq_(response.status_code, 403)
+
+        user = User.objects.create(username='test')
+        self._add_permission(user, 'reprocess_crashes')
+
+        perm = Permission.objects.get(
+            codename='reprocess_crashes'
+        )
+        # but make a token that only has the 'view_pii'
+        # permission associated with it
+        token = Token.objects.create(
+            user=user,
+            notes="Only reprocessing"
+        )
+        token.permissions.add(perm)
+
+        response = self.client.get(url, params, HTTP_AUTH_TOKEN=token.key)
+        eq_(response.status_code, 405)
+
+        response = self.client.post(url, params, HTTP_AUTH_TOKEN=token.key)
+        eq_(response.status_code, 200)
+        eq_(json.loads(response.content), True)

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -273,8 +273,8 @@ def model_wrapper(request, model_name):
         function = instance.post
     else:
         function = instance.get
-        if not function:
-            return http.HttpResponseNotAllowed(['POST'])
+    if not function:
+        return http.HttpResponseNotAllowed([request.method])
 
     # assume first that it won't need a binary response
     binary_response = False

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -9,6 +9,7 @@ from django.contrib.sites.requests import RequestSite
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django import forms
+from django.views.decorators.csrf import csrf_exempt
 # explicit import because django.forms has an __all__
 from django.forms.forms import DeclarativeFieldsMetaclass
 
@@ -188,8 +189,6 @@ BLACKLIST = (
     'Query',
     # because it's an internal thing only
     'GraphicsReport',
-    # Because we haven't figured out how auth it yet
-    'Reprocessing',
 )
 
 
@@ -208,6 +207,7 @@ def is_valid_model_class(model):
     )
 
 
+@csrf_exempt
 @waffle_switch('!app_api_all_disabled')
 @ratelimit(
     key='ip',
@@ -273,6 +273,8 @@ def model_wrapper(request, model_name):
         function = instance.post
     else:
         function = instance.get
+        if not function:
+            return http.HttpResponseNotAllowed(['POST'])
 
     # assume first that it won't need a binary response
     binary_response = False

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -80,6 +80,13 @@
                             <span>Correlations</span>
                         </a>
                     </li>
+                    {% if request.user.has_perm('crashstats.reprocess_crashes') %}
+                    <li class="ui-state-default ui-corner-top">
+                        <a href="#reprocess" class="ui-tabs-anchor">
+                            <span>Reprocess</span>
+                        </a>
+                    </li>
+                    {% endif %}
                 </ul>
 
                 <div id="details" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
@@ -644,6 +651,64 @@
                     </ul>
                 </div>
                 <!-- /correlation -->
+
+                {% if request.user.has_perm('crashstats.reprocess_crashes') %}
+                <div id="reprocess" class="ui-tabs-hide" data-crash-id="{{ report.uuid }}">
+                    <p>
+                        Reprocessing will submit the this raw crash back into
+                        the processors and the new processed crash will replace
+                        the existing one. The raw crash will never change.
+                    </p>
+                    <form method="post">
+                        <button type="submit">Reprocess this crash</button>
+                    </form>
+                    <div class="waiting" style="display:none">
+                        <p>
+                            <img
+                                src="{{ static('img/ajax-loader16x16.gif') }}"
+                                alt="Waiting...">
+                            <strong>
+                                Sending crash ID in for reprocessing...
+                            </strong>
+                        </p>
+                    </div>
+                    <div class="reprocessing-success" style="display:none">
+                        <p>
+                            <strong>
+                                Success!
+                            </strong>
+                        </p>
+                        <p>
+                            But unfortunately, it's hard to predict when this
+                            crash will be precisely reprocessed and the new
+                            processed crash uploaded.
+                            Also, there's <b>caching on the
+                            webapp</b> that might hold on to old crash a little
+                            bit longer.
+                        </p>
+                        <p>
+                            Expect to <a href="">Reload this crash</a> in about
+                            1 hour.
+                        </p>
+                    </div>
+                    <div class="reprocessing-error" style="display:none">
+                        <p>
+                            <strong>
+                                Sadly, it seems we were unable to send this crash
+                                in for reprocessing.
+                            </strong>
+                        </p>
+                        <p>
+                            HTTP Status code: <code class="status"></code>
+                        </p>
+                        <pre>
+
+                        </pre>
+                    </div>
+                </div>
+                <!-- /reproces -->
+                {% endif %}
+
             </div>
             <!-- /report-index -->
         </div>

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1858,17 +1858,25 @@ class GraphicsReport(SocorroMiddleware):
 
 
 class Reprocessing(SocorroMiddleware):
-    """Return true the supplied crash ID
+    """Return true if all supplied crash IDs
     was sucessfully submitted onto the reprocessing queue.
     """
+
+    API_REQUIRED_PERMISSIONS = (
+        'crashstats.reprocess_crashes',
+    )
+
+    API_WHITELIST = None
 
     implementation = ReprocessingOneRabbitMQCrashStore
 
     implementation_config_namespace = 'queuing'
 
     required_params = (
-        'crash_id',
+        ('crash_ids', list),
     )
+
+    get = None
 
     def post(self, **data):
         return self.get_implementation().reprocess(**data)

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1859,7 +1859,7 @@ class GraphicsReport(SocorroMiddleware):
 
 class Reprocessing(SocorroMiddleware):
     """Return true if all supplied crash IDs
-    was sucessfully submitted onto the reprocessing queue.
+    were sucessfully submitted onto the reprocessing queue.
     """
 
     API_REQUIRED_PERMISSIONS = (

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/reprocessing.js
@@ -1,0 +1,37 @@
+$(function() {
+    var parent = $('#reprocess');
+
+    $('form', parent).on('submit', function(event) {
+        event.preventDefault();
+        var crash_id = parent.data('crash-id');
+
+        // make sure previous result flash messages are hidden
+        $('.reprocessing-success', parent).hide();
+        $('.reprocessing-error', parent).hide();
+
+        // disable the submit button
+        $('form button', parent).prop('disabled', true);
+
+        // show a waiting message
+        $('.waiting', parent).show();
+
+        $.post('/api/Reprocessing/', {crash_ids: crash_id})
+        .done(function(response) {
+            $('.reprocessing-success', parent).show();
+        })
+        .error(function(jqXHR, textStatus, errorThrown) {
+            $('.reprocessing-error .status', parent).text(jqXHR.status);
+            $('.reprocessing-error pre', parent).text(jqXHR.responseText);
+            $('.reprocessing-error', parent).show();
+        })
+        .complete(function() {
+            $('.waiting', parent).hide();
+            $('form button', parent).prop('disabled', false);
+        });
+    });
+
+    $('.reprocessing-success a', parent).on('click', function(event) {
+        event.preventDefault();
+        document.location.reload(true);
+    });
+});

--- a/webapp-django/crashstats/manage/tests/test_views.py
+++ b/webapp-django/crashstats/manage/tests/test_views.py
@@ -1685,12 +1685,13 @@ class TestViews(BaseTestViews):
         good_crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
         bad_crash_id = '00000000-0000-0000-0000-000000020611'
 
-        def mocked_reprocess(crash_id):
-            if crash_id == good_crash_id:
+        def mocked_reprocess(crash_ids):
+            assert isinstance(crash_ids, list)
+            if crash_ids == [good_crash_id]:
                 return True
-            elif crash_id == bad_crash_id:
+            elif crash_ids == [bad_crash_id]:
                 return
-            raise NotImplementedError(crash_id)
+            raise NotImplementedError(crash_ids)
 
         models.Reprocessing.implementation().reprocess = mocked_reprocess
 

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -976,7 +976,7 @@ def reprocessing(request):
         if form.is_valid():
             crash_id = form.cleaned_data['crash_id']
             url = reverse('manage:reprocessing')
-            worked = Reprocessing().post(crash_id=crash_id)
+            worked = Reprocessing().post(crash_ids=[crash_id])
             if worked:
                 url += '?crash_id={}'.format(crash_id)
                 messages.success(

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -326,6 +326,7 @@ PIPELINE_JS = {
     'report_index': {
         'source_filenames': (
             'crashstats/js/socorro/report.js',
+            'crashstats/js/socorro/reprocessing.js',
         ),
         'output_filename': 'js/report-index.min.js',
     },


### PR DESCRIPTION
See:
<img width="945" alt="screen shot 2016-05-25 at 4 27 36 pm" src="https://cloud.githubusercontent.com/assets/26739/15555210/af232f9a-2295-11e6-8eae-904d4964213a.png">

This is quite a lot a bigger change than I had planned. It's because we don't have any exposed API endpoints that take only POST. So, apart from regular code reviews, here's what you ought to also test. 

First of all, make sure you have run `./manage.py migrate` so that you have the new reprocessing permission. 

Then, go to a report index page. Notice the new Reprocessing tab. It should just work. To trigger the AJAX error state you have to temporarily "mess" with the code or just switch off your django server (so you'd get a http error). 

You should now also be able to reprocess crashes from the command line. E.g.:
```
curl -v -X POST -H "Auth-token: 8b9bfcb0872d4b1881a61e5d7247d617" -d 'crash_ids=9a715a26-02d0-4fe8-856c-4cdcd2160524' -d 'crash_ids=7f6cfce8-0c6b-4d9c-a59a-562da2160524' http://socorro.dev/api/Reprocessing/
```
(If you run the same with `-X GET` you should get a 405 error)

The last thing to test is that the rest of `testdrive.js` still works. Just execute any endpoint from the API documentation page. Like the ProductVersions. 

