### PR TITLE
bug 1140937 - Change missing symbols cron to include filename and code_id

### DIFF
--- a/alembic/versions/89ef86a3d57a_extend_missing_symbols.py
+++ b/alembic/versions/89ef86a3d57a_extend_missing_symbols.py
@@ -1,0 +1,38 @@
+"""extend missing symbols
+
+Revision ID: 89ef86a3d57a
+Revises: 02da1335e26e
+Create Date: 2016-05-26 13:17:17.145484
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '89ef86a3d57a'
+down_revision = '02da1335e26e'
+
+
+def upgrade():
+    op.add_column(
+        'missing_symbols',
+        sa.Column(
+            'code_file',
+            sa.TEXT(),
+            nullable=True,
+        )
+    )
+    op.add_column(
+        'missing_symbols',
+        sa.Column(
+            'code_id',
+            sa.TEXT(),
+            nullable=True,
+        )
+    )
+
+
+def downgrade():
+    op.drop_column('missing_symbols', 'code_file')
+    op.drop_column('missing_symbols', 'code_id')

--- a/socorro/external/postgresql/models.py
+++ b/socorro/external/postgresql/models.py
@@ -1414,6 +1414,8 @@ class MissingSymbols(DeclarativeBase):
     date_processed = Column(u'date_processed', DATE(), nullable=False)
     debug_file = Column(u'debug_file', TEXT(), nullable=True)
     debug_id = Column(u'debug_id', TEXT(), nullable=True)
+    code_file = Column(u'code_file', TEXT(), nullable=True)
+    code_id = Column(u'code_id', TEXT(), nullable=True)
 
     __mapper_args__ = {'primary_key': (date_processed, debug_file, debug_id)}
 


### PR DESCRIPTION


Note that this commit does not fix the bug. I just want to make sure the tables (in particular on prod) is updated so when I change the processor rule and the cron job, the columns are there. 

CC @luser 