### PR TITLE
fixes bug 889491 - Improve error messages for invalid queries

### DIFF
--- a/webapp-django/crashstats/base/jinja2/400.html
+++ b/webapp-django/crashstats/base/jinja2/400.html
@@ -1,0 +1,43 @@
+{% extends "crashstats_base.html" %}
+
+{% block page_title %}Bad Request{% endblock %}
+
+{% block product_nav_filter %}&nbsp;{% endblock %}
+
+{% block site_css %}
+{{ super() }}
+<style type="text/css">
+ul.errorlist li {
+    list-style: unset;
+    margin-left: 30px;
+}
+.body p {
+    color: red;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="mainbody">
+    <div class="page-heading">
+        <h2>Bad Request</h2>
+    </div>
+    <div class="panel">
+        <div class="title">
+            <h2>The request's parameters could not be understood.</h2>
+        </div>
+        <div class="body">
+            {% if 'ul class="errorlist"' in error %}
+                {{ error | safe }}
+            {% else %}
+                <p>
+                    Error Message:
+                </p>
+                <pre>{{ error }}
+                </pre>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/webapp-django/crashstats/crashstats/middleware.py
+++ b/webapp-django/crashstats/crashstats/middleware.py
@@ -1,6 +1,8 @@
 from django import http
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
+from django.shortcuts import render
+
 from crashstats.crashstats.models import BadStatusCodeError
 
 
@@ -41,3 +43,21 @@ class Propagate400Errors(object):
             # "400" error
             if exception.status == 400:
                 return http.HttpResponseBadRequest(exception.message)
+
+
+class Pretty400Errors(object):
+
+    def process_response(self, request, response):
+
+        if (
+            response.status_code == 400 and
+            not request.is_ajax() and
+            response['Content-Type'].startswith('text/html')
+        ):
+            return render(
+                request,
+                '400.html',
+                {'error': response.content},
+                status=400
+            )
+        return response

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -2845,6 +2845,8 @@ class TestViews(BaseTestViews):
                       args=['11cb72f5-eb28-41e1-a8e4-849982120230'])
         response = self.client.get(url)
         eq_(response.status_code, 400)
+        ok_('Invalid crash ID' in response.content)
+        eq_(response['Content-Type'], 'text/html; charset=utf-8')
 
     @mock.patch('requests.get')
     def test_report_pending_today(self, rget):

--- a/webapp-django/crashstats/home/tests/test_views.py
+++ b/webapp-django/crashstats/home/tests/test_views.py
@@ -47,3 +47,10 @@ class TestViews(BaseTestViews):
         response = self.client.get(intermediate_dest)
         eq_(response.status_code, redirect_code)
         ok_(destination in response['Location'], response['Location'])
+
+    def test_home_400(self):
+        url = reverse('home:home', args=('WaterWolf',))
+        response = self.client.get(url, {'days': 'xxx'})
+        eq_(response.status_code, 400)
+        ok_('Enter a whole number' in response.content)
+        eq_(response['Content-Type'], 'text/html; charset=utf-8')

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -114,6 +114,7 @@ MIDDLEWARE_CLASSES = (
     'ratelimit.middleware.RatelimitMiddleware',
     '%s.tokens.middleware.APIAuthenticationMiddleware' % PROJECT_MODULE,
     '%s.crashstats.middleware.Propagate400Errors' % PROJECT_MODULE,
+    '%s.crashstats.middleware.Pretty400Errors' % PROJECT_MODULE,
 )
 
 

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -15,7 +15,8 @@ from socorrolib.lib import BadArgumentError
 from crashstats.base.utils import render_exception
 from crashstats.api.views import has_permissions
 from crashstats.crashstats import models, utils
-from crashstats.crashstats.views import pass_default_context
+from crashstats.crashstats.decorators import pass_default_context
+
 from crashstats.supersearch.models import (
     SuperSearchFields,
     SuperSearchUnredacted,

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -389,8 +389,11 @@ class TestViews(BaseTestViews):
 
         url = reverse('supersearch.search_results')
         params = {'product': 'WaterWolf'}
-        self.client.get(url, params)
-        response = self.client.get(url, params)
+        response = self.client.get(
+            url,
+            params,
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
         eq_(response.status_code, 400)
         eq_(response['content-type'], 'text/html; charset=utf-8')
         ok_('<script>' not in response.content)

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -214,6 +214,16 @@ class TestViews(BaseTestViews):
         # Check the startup crash icon is there.
         ok_('Startup Crash' in response.content)
 
+    def test_topcrashers_400_by_bad_days(self):
+        response = self.client.get(self.base_url, {
+            'product': 'SnowLion',
+            'version': '0.1',
+            'days': 'xxxxxx',
+        })
+        eq_(response.status_code, 400)
+        ok_('not a number' in response.content)
+        eq_(response['Content-Type'], 'text/html; charset=utf-8')
+
     def test_topcrasher_with_product_sans_release(self):
         # SnowLion is not a product at all
         response = self.client.get(self.base_url, {

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -8,7 +8,6 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.utils.http import urlquote
 
-
 from session_csrf import anonymous_csrf
 
 from crashstats.crashstats import models


### PR DESCRIPTION
Don't ask why I dedicated an hour of my Friday afternoon to this. The short answer was that I was just curious. I wanted to play with the [`handler400`](https://docs.djangoproject.com/en/1.8/ref/urls/#django.conf.urls.handler400) but that's not at all what that's for. :)

Before:
<img width="1715" alt="screen shot 2016-05-27 at 3 55 55 pm" src="https://cloud.githubusercontent.com/assets/26739/15619652/829a8f1a-2423-11e6-9181-ab527a4b3f87.png">
<img width="1715" alt="screen shot 2016-05-27 at 3 56 15 pm" src="https://cloud.githubusercontent.com/assets/26739/15619656/8ac8ec18-2423-11e6-881c-0a7b83011889.png">
<img width="1715" alt="screen shot 2016-05-27 at 3 56 32 pm" src="https://cloud.githubusercontent.com/assets/26739/15619662/9341b0b4-2423-11e6-8f9e-cdae9f6555a1.png">


After:
<img width="1715" alt="screen shot 2016-05-27 at 3 54 18 pm" src="https://cloud.githubusercontent.com/assets/26739/15619615/4732db80-2423-11e6-9511-24db91e7b958.png">
<img width="1715" alt="screen shot 2016-05-27 at 3 54 45 pm" src="https://cloud.githubusercontent.com/assets/26739/15619621/567dedc8-2423-11e6-9066-bb72d145f578.png">
<img width="1715" alt="screen shot 2016-05-27 at 3 55 13 pm" src="https://cloud.githubusercontent.com/assets/26739/15619631/68d8c7f4-2423-11e6-8f0f-5fdacb40f01b.png">
