### PR TITLE
bug 1140937 - update missing symbols rule to for code_*

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -802,8 +802,8 @@ class MissingSymbolsRule(Rule):
         )
         self.sql = (
             "INSERT INTO missing_symbols_%s"
-            " (date_processed, debug_file, debug_id)"
-            " VALUES (%%s, %%s, %%s)"
+            " (date_processed, debug_file, debug_id, code_file, code_id)"
+            " VALUES (%%s, %%s, %%s, %%s, %%s)"
         )
 
     #--------------------------------------------------------------------------
@@ -825,7 +825,13 @@ class MissingSymbolsRule(Rule):
                             (
                                 date,
                                 module['debug_file'],
-                                module['debug_id']
+                                module['debug_id'],
+                                # These two use .get() because the keys
+                                # were added later in history. If it's
+                                # non-existent (or existant and None), it
+                                # will proceed and insert as a nullable.
+                                module.get('code_file'),
+                                module.get('code_id'),
                             )
                         )
                 except self.database.ProgrammingError:

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1914,6 +1914,8 @@ class TestMissingSymbols(TestCase):
                     "debug_id": "ABCDEFG",
                     "debug_file": "some-file.pdb",
                     "missing_symbols": True,
+                    "code_id": "123",
+                    "code_file": "debug.py",
                 },
                 {
                     "debug_id": "BCDEFGH",
@@ -1924,6 +1926,9 @@ class TestMissingSymbols(TestCase):
                     "debug_id": "CDEFGHI",
                     "debug_file": "yet-another-file.pdb",
                     "missing_symbols": True,
+                    "code_id": None,
+                    # Note that this does not even have a key
+                    # called 'code_file'.
                 },
             ]
         }
@@ -1941,9 +1946,9 @@ class TestMissingSymbols(TestCase):
         eq_(config.transaction_executor_class.return_value.call_count, 2)
         expected_execute_args = [
             call(execute_no_results, expected_sql,
-                ('2014-12-31', 'some-file.pdb', 'ABCDEFG')),
+                ('2014-12-31', 'some-file.pdb', 'ABCDEFG', 'debug.py', '123')),
             call(execute_no_results, expected_sql,
-                ('2014-12-31', 'yet-another-file.pdb', 'CDEFGHI'))
+                ('2014-12-31', 'yet-another-file.pdb', 'CDEFGHI', None, None))
         ]
         config.transaction_executor_class.return_value.assert_has_calls(
                 expected_execute_args
@@ -1955,13 +1960,13 @@ class TestMissingSymbols(TestCase):
         eq_(config.transaction_executor_class.return_value.call_count, 4)
         expected_execute_args = [
             call(execute_no_results, expected_sql,
-                ('2014-12-31', 'some-file.pdb', 'ABCDEFG')),
+                ('2014-12-31', 'some-file.pdb', 'ABCDEFG', 'debug.py', '123')),
             call(execute_no_results, expected_sql,
-                ('2014-12-31', 'yet-another-file.pdb', 'CDEFGHI')),
+                ('2014-12-31', 'yet-another-file.pdb', 'CDEFGHI', None, None)),
             call(execute_no_results, expected_sql,
-                ('2014-12-31', 'some-file.pdb', 'ABCDEFG')),
+                ('2014-12-31', 'some-file.pdb', 'ABCDEFG', 'debug.py', '123')),
             call(execute_no_results, expected_sql,
-                ('2014-12-31', 'yet-another-file.pdb', 'CDEFGHI')),
+                ('2014-12-31', 'yet-another-file.pdb', 'CDEFGHI', None, None)),
         ]
         config.transaction_executor_class.return_value.assert_has_calls(
                 expected_execute_args


### PR DESCRIPTION
DO NOT MERGE UNTIL PROD ADMIN ALEMBIC MIGRATIONS HAVE BEEN RUN. 
It is my intention to do to prod [what I did to stage](https://bugzilla.mozilla.org/show_bug.cgi?id=1140937#c11) after the next pending prod deployment. 