### PR TITLE
Fixes bug 1275799 - Added a title with a description of each field in report/index/.

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -92,20 +92,20 @@
                 <div id="details" class="ui-tabs-panel ui-widget-content ui-corner-bottom">
                     <table class="record data-table vertical">
                         <tbody>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.signature'] }}">Signature</th>
+                            <tr title="{{ fields_desc['processed_crash.signature'] }}">
+                                <th scope="row">Signature</th>
                                 <td>
                                     {{ report.signature }}
                                     <a href="{{ url('signature:signature_report') }}?{{ make_query_string(product=report.product, signature=report.signature) }}" class="sig-overview" title="View more reports of this type">More Reports</a>
                                     <a href="{{ url('supersearch.search') }}?{{ make_query_string(product=report.product, signature='=' + report.signature) }}" class="sig-search" title="Search for more reports of this type">Search</a>
                                 </td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.uuid'] }}">UUID</th>
+                            <tr title="{{ fields_desc['processed_crash.uuid'] }}">
+                                <th scope="row">UUID</th>
                                 <td>{{ report.uuid }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.date_processed'] }}">Date Processed</th>
+                            <tr title="{{ fields_desc['processed_crash.date_processed'] }}">
+                                <th scope="row">Date Processed</th>
                                 <td>
                                     {% if report.date_processed %}
                                         {{ report.date_processed | human_readable_iso_date }}
@@ -113,8 +113,8 @@
                                 </td>
                             </tr>
                             {% if report.process_type %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.process_type'] }}">Process Type</th>
+                            <tr title="{{ fields_desc['processed_crash.process_type'] }}">
+                                <th scope="row">Process Type</th>
                                 <td>{{ report.process_type }}
                                     {% if report.PluginName %}
                                     <strong class="name">{{ report.PluginName }}</strong>
@@ -130,101 +130,101 @@
                                 </td>
                             </tr>
                             {% endif %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.uptime'] }}">Uptime</th>
+                            <tr title="{{ fields_desc['processed_crash.uptime'] }}">
+                                <th scope="row">Uptime</th>
                                 <td>
                                     {{ show_duration(report.get('uptime')) }}
                                 </td>
                             </tr>
                             {% if report.last_crash %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.last_crash'] }}">Last Crash</th>
+                            <tr title="{{ fields_desc['processed_crash.last_crash'] }}">
+                                <th scope="row">Last Crash</th>
                                 <td>
                                     {{ show_duration(report.get('last_crash'), 'seconds before submission') }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if report.install_age %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.install_age'] }}">Install Age</th>
+                            <tr title="{{ fields_desc['processed_crash.install_age'] }}">
+                                <th scope="row">Install Age</th>
                                 <td>
                                     {{ show_duration(report.get('install_age'), 'seconds since version was first installed') }}
                                 </td>
                             </tr>
                             {% endif %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.InstallTime'] }}">Install Time</th>
+                            <tr title="{{ fields_desc['raw_crash.InstallTime'] }}">
+                                <th scope="row">Install Time</th>
                                 <td>
                                     {% if raw.InstallTime %}
                                         {{ raw.InstallTime | timestamp_to_date }}
                                     {% endif %}
                                 </td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.product'] }}">Product</th>
+                            <tr title="{{ fields_desc['processed_crash.product'] }}">
+                                <th scope="row">Product</th>
                                 <td>{{ report.product }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.version'] }}">Version</th>
+                            <tr title="{{ fields_desc['processed_crash.version'] }}">
+                                <th scope="row">Version</th>
                                 <td>{{ report.version }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.build'] }}">Build ID</th>
+                            <tr title="{{ fields_desc['processed_crash.build'] }}">
+                                <th scope="row">Build ID</th>
                                 <td>{{ report.build }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.release_channel'] }}">Release Channel</th>
+                            <tr title="{{ fields_desc['processed_crash.release_channel'] }}">
+                                <th scope="row">Release Channel</th>
                                 <td>{{ report.release_channel }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.os_pretty_version'] }}">OS</th>
+                            <tr title="{{ fields_desc['processed_crash.os_pretty_version'] }}">
+                                <th scope="row">OS</th>
                                 <td>{{ report.os_pretty_version or report.os_name }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.os_version'] }}">OS Version</th>
+                            <tr title="{{ fields_desc['processed_crash.os_version'] }}">
+                                <th scope="row">OS Version</th>
                                 <td>{{ report.os_version }}</td>
                             </tr>
                             {% if raw.B2G_OS_Version %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.B2G_OS_Version'] }}">B2G OS Version</th>
+                            <tr title="{{ fields_desc['raw_crash.B2G_OS_Version'] }}">
+                                <th scope="row">B2G OS Version</th>
                                 <td>
                                     <pre>{{ raw.B2G_OS_Version }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.cpu_arch'] }}">Build Architecture</th>
+                            <tr title="{{ fields_desc['processed_crash.cpu_arch'] }}">
+                                <th scope="row">Build Architecture</th>
                                 <td>{{ report.cpu_name }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.cpu_info'] }}">Build Architecture Info</th>
+                            <tr title="{{ fields_desc['processed_crash.cpu_info'] }}">
+                                <th scope="row">Build Architecture Info</th>
                                 <td>{{ report.cpu_info }}</td>
                             </tr>
                             {% if raw.MozCrashReason %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.MozCrashReason'] }}">MOZ_CRASH Reason</th>
+                            <tr title="{{ fields_desc['raw_crash.MozCrashReason'] }}">
+                                <th scope="row">MOZ_CRASH Reason</th>
                                 <td>{{ raw.MozCrashReason }}</td>
                             </tr>
                             {% endif %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.reason'] }}">Crash Reason</th>
+                            <tr title="{{ fields_desc['processed_crash.reason'] }}">
+                                <th scope="row">Crash Reason</th>
                                 <td>{{ report.reason }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.address'] }}">Crash Address</th>
+                            <tr title="{{ fields_desc['processed_crash.address'] }}">
+                                <th scope="row">Crash Address</th>
                                 <td>{{ report.address }}</td>
                             </tr>
                             {% if request.user.has_perm('crashstats.view_pii') %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.email'] }}">Email Address</th>
+                            <tr title="{{ fields_desc['processed_crash.email'] }}">
+                                <th scope="row">Email Address</th>
                                 <td>
                                     {% if raw.Email %}
                                     <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a> - This is super sensitive data! Be careful how you use it!
                                     {% endif %}
                                 </td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.url'] }}">URL</th>
+                            <tr title="{{ fields_desc['processed_crash.url'] }}">
+                                <th scope="row">URL</th>
                                 <td>
                                     {% if raw.URL %}
                                     <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a> - This is super sensitive data! Be careful how you use it!
@@ -233,8 +233,8 @@
                             </tr>
                             {% endif %}
                             {% if request.user.has_perm('crashstats.view_exploitability') %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.exploitability'] }}">Exploitability</th>
+                            <tr title="{{ fields_desc['processed_crash.exploitability'] }}">
+                                <th scope="row">Exploitability</th>
                                 <td>
                                     {% if report.exploitability %}
                                     {{ report.exploitability }} - This is super sensitive data! Be careful how you use it!
@@ -242,8 +242,8 @@
                                 </td>
                             </tr>
                             {% endif %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.user_comments'] }}">User Comments</th>
+                            <tr title="{{ fields_desc['processed_crash.user_comments'] }}">
+                                <th scope="row">User Comments</th>
                                 <td>
                                     {% if report.user_comments %}
                                     {% if request.user.has_perm('crashstats.view_pii') %}
@@ -255,144 +255,144 @@
                                 </td>
                             </tr>
                             {% if report.app_notes %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.app_notes'] }}">App Notes</th>
+                            <tr title="{{ fields_desc['processed_crash.app_notes'] }}">
+                                <th scope="row">App Notes</th>
                                 <td>
                                     <pre>{{ report.app_notes }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if report.processor_notes %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.processor_notes'] }}">Processor Notes</th>
+                            <tr title="{{ fields_desc['processed_crash.processor_notes'] }}">
+                                <th scope="row">Processor Notes</th>
                                 <td>
                                     <code>{{ report.processor_notes }}</code>
                                 </td>
                             </tr>
                             {% endif %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.addons_checked'] }}">EMCheckCompatibility</th>
+                            <tr title="{{ fields_desc['processed_crash.addons_checked'] }}">
+                                <th scope="row">EMCheckCompatibility</th>
                                 <td>
                                     <pre>{% if report.addons_checked %}True{% else %}False{% endif %}</pre>
                                 </td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.Winsock_LSP'] }}">Winsock LSP</th>
+                            <tr title="{{ fields_desc['processed_crash.Winsock_LSP'] }}">
+                                <th scope="row">Winsock LSP</th>
                                 <td>
                                     <pre>{{ report.Winsock_LSP }}</pre>
                                 </td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.AdapterVendorID'] }}">Adapter Vendor ID</th>
+                            <tr title="{{ fields_desc['raw_crash.AdapterVendorID'] }}">
+                                <th scope="row">Adapter Vendor ID</th>
                                 <td>
                                     <pre>{{ raw.AdapterVendorID }}</pre>
                                 </td>
                             </tr>
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.AdapterDeviceID'] }}">Adapter Device ID</th>
+                            <tr title="{{ fields_desc['raw_crash.AdapterDeviceID'] }}">
+                                <th scope="row">Adapter Device ID</th>
                                 <td>
                                     <pre>{{ raw.AdapterDeviceID }}</pre>
                                 </td>
                             </tr>
                             {% if raw.JavaStackTrace %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['processed_crash.java_stack_trace'] }}">Java Stack Trace</th>
+                            <tr title="{{ fields_desc['processed_crash.java_stack_trace'] }}">
+                                <th scope="row">Java Stack Trace</th>
                                 <td>
                                     <pre>{{ raw.JavaStackTrace }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.TotalVirtualMemory %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.TotalVirtualMemory'] }}">Total Virtual Memory</th>
+                            <tr title="{{ fields_desc['raw_crash.TotalVirtualMemory'] }}">
+                                <th scope="row">Total Virtual Memory</th>
                                 <td>
                                     {{ show_filesize(raw.get('TotalVirtualMemory')) }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.AvailableVirtualMemory %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.AvailableVirtualMemory'] }}">Available Virtual Memory</th>
+                            <tr title="{{ fields_desc['raw_crash.AvailableVirtualMemory'] }}">
+                                <th scope="row">Available Virtual Memory</th>
                                 <td>
                                     {{ show_filesize(raw.get('AvailableVirtualMemory')) }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.SystemMemoryUsePercentage %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.SystemMemoryUsePercentage'] }}">System Memory Use Percentage</th>
+                            <tr title="{{ fields_desc['raw_crash.SystemMemoryUsePercentage'] }}">
+                                <th scope="row">System Memory Use Percentage</th>
                                 <td>
                                     {{ raw.SystemMemoryUsePercentage }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.AvailablePageFile %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.AvailablePageFile'] }}">Available Page File</th>
+                            <tr title="{{ fields_desc['raw_crash.AvailablePageFile'] }}">
+                                <th scope="row">Available Page File</th>
                                 <td>
                                     {{ show_filesize(raw.get('AvailablePageFile')) }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.AvailablePhysicalMemory %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.AvailablePhysicalMemory'] }}">Available Physical Memory</th>
+                            <tr title="{{ fields_desc['raw_crash.AvailablePhysicalMemory'] }}">
+                                <th scope="row">Available Physical Memory</th>
                                 <td>
                                     {{ show_filesize(raw.get('AvailablePhysicalMemory')) }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.OOMAllocationSize %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.OOMAllocationSize'] }}">OOM Allocation Size</th>
+                            <tr title="{{ fields_desc['raw_crash.OOMAllocationSize'] }}">
+                                <th scope="row">OOM Allocation Size</th>
                                 <td>
                                     {{ show_filesize(raw.get('OOMAllocationSize')) }}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.FlashProcessDump %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.FlashProcessDump'] }}">Flash Process Dump</th>
+                            <tr title="{{ fields_desc['raw_crash.FlashProcessDump'] }}">
+                                <th scope="row">Flash Process Dump</th>
                                 <td>
                                     <pre>{{ raw.FlashProcessDump }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.Accessibility %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.Accessibility'] }}">Accessibility</th>
+                            <tr title="{{ fields_desc['raw_crash.Accessibility'] }}">
+                                <th scope="row">Accessibility</th>
                                 <td>
                                     <pre>{{ raw.Accessibility }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.Android_CPU_ABI%}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.Android_CPU_ABI'] }}">Android CPU ABI</th>
+                            <tr title="{{ fields_desc['raw_crash.Android_CPU_ABI'] }}">
+                                <th scope="row">Android CPU ABI</th>
                                 <td>
                                     <pre>{{ raw.Android_CPU_ABI}}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.Android_Manufacturer %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.Android_Manufacturer'] }}">Android Manufacturer</th>
+                            <tr title="{{ fields_desc['raw_crash.Android_Manufacturer'] }}">
+                                <th scope="row">Android Manufacturer</th>
                                 <td>
                                     <pre>{{ raw.Android_Manufacturer }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.Android_Model %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.Android_Model'] }}">Android Model</th>
+                            <tr title="{{ fields_desc['raw_crash.Android_Model'] }}">
+                                <th scope="row">Android Model</th>
                                 <td>
                                     <pre>{{ raw.Android_Model }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             {% if raw.Android_Version %}
-                            <tr>
-                                <th scope="row" title="{{ fields_desc['raw_crash.Android_Version'] }}">Android Version</th>
+                            <tr title="{{ fields_desc['raw_crash.Android_Version'] }}">
+                                <th scope="row">Android Version</th>
                                 <td>
                                     <pre>{{ raw.Android_Version }}</pre>
                                 </td>
@@ -514,10 +514,8 @@
                     <table class="record data-table vertical">
                         <tbody>
                             {% for key in raw_keys %}
-                            <tr>
-                                <th scope="row"
-                                    title="{{ fields_desc.get('raw_crash.{}'.format(key), empty_desc) }}"
-                                >{{ key }}</th>
+                            <tr title="{{ fields_desc.get('raw_crash.{}'.format(key), empty_desc) }}">
+                                <th scope="row">{{ key }}</th>
                                 {% if key == 'Comments' %}
                                 <td><pre>{{ raw[key] | scrub_pii }}</pre></td>
                                 {% else %}

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -93,7 +93,7 @@
                     <table class="record data-table vertical">
                         <tbody>
                             <tr>
-                                <th scope="row">Signature</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.signature'] }}">Signature</th>
                                 <td>
                                     {{ report.signature }}
                                     <a href="{{ url('signature:signature_report') }}?{{ make_query_string(product=report.product, signature=report.signature) }}" class="sig-overview" title="View more reports of this type">More Reports</a>
@@ -101,16 +101,20 @@
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">UUID</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.uuid'] }}">UUID</th>
                                 <td>{{ report.uuid }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">Date Processed</th>
-                                <td>{{ report.date_processed }}</td>
+                                <th scope="row" title="{{ fields_desc['processed_crash.date_processed'] }}">Date Processed</th>
+                                <td>
+                                    {% if report.date_processed %}
+                                        {{ report.date_processed | human_readable_iso_date }}
+                                    {% endif %}
+                                </td>
                             </tr>
                             {% if report.process_type %}
                             <tr>
-                                <th scope="row">Process Type</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.process_type'] }}">Process Type</th>
                                 <td>{{ report.process_type }}
                                     {% if report.PluginName %}
                                     <strong class="name">{{ report.PluginName }}</strong>
@@ -127,14 +131,14 @@
                             </tr>
                             {% endif %}
                             <tr>
-                                <th scope="row">Uptime</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.uptime'] }}">Uptime</th>
                                 <td>
                                     {{ show_duration(report.get('uptime')) }}
                                 </td>
                             </tr>
                             {% if report.last_crash %}
                             <tr>
-                                <th scope="row">Last Crash</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.last_crash'] }}">Last Crash</th>
                                 <td>
                                     {{ show_duration(report.get('last_crash'), 'seconds before submission') }}
                                 </td>
@@ -142,14 +146,14 @@
                             {% endif %}
                             {% if report.install_age %}
                             <tr>
-                                <th scope="row">Install Age</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.install_age'] }}">Install Age</th>
                                 <td>
                                     {{ show_duration(report.get('install_age'), 'seconds since version was first installed') }}
                                 </td>
                             </tr>
                             {% endif %}
                             <tr>
-                                <th scope="row">Install Time</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.InstallTime'] }}">Install Time</th>
                                 <td>
                                     {% if raw.InstallTime %}
                                         {{ raw.InstallTime | timestamp_to_date }}
@@ -157,79 +161,89 @@
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">Product</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.product'] }}">Product</th>
                                 <td>{{ report.product }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">Version</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.version'] }}">Version</th>
                                 <td>{{ report.version }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">Build ID</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.build'] }}">Build ID</th>
                                 <td>{{ report.build }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">Release Channel</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.release_channel'] }}">Release Channel</th>
                                 <td>{{ report.release_channel }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">OS</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.os_pretty_version'] }}">OS</th>
                                 <td>{{ report.os_pretty_version or report.os_name }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">OS Version</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.os_version'] }}">OS Version</th>
                                 <td>{{ report.os_version }}</td>
                             </tr>
                             {% if raw.B2G_OS_Version %}
                             <tr>
-                                <th scope="row">B2G OS Version</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.B2G_OS_Version'] }}">B2G OS Version</th>
                                 <td>
                                     <pre>{{ raw.B2G_OS_Version }}</pre>
                                 </td>
                             </tr>
                             {% endif %}
                             <tr>
-                                <th scope="row">Build Architecture</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.cpu_arch'] }}">Build Architecture</th>
                                 <td>{{ report.cpu_name }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">Build Architecture Info</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.cpu_info'] }}">Build Architecture Info</th>
                                 <td>{{ report.cpu_info }}</td>
                             </tr>
+                            {% if raw.MozCrashReason %}
                             <tr>
-                                <th scope="row">Crash Reason</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.MozCrashReason'] }}">MOZ_CRASH Reason</th>
+                                <td>{{ raw.MozCrashReason }}</td>
+                            </tr>
+                            {% endif %}
+                            <tr>
+                                <th scope="row" title="{{ fields_desc['processed_crash.reason'] }}">Crash Reason</th>
                                 <td>{{ report.reason }}</td>
                             </tr>
                             <tr>
-                                <th scope="row">Crash Address</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.address'] }}">Crash Address</th>
                                 <td>{{ report.address }}</td>
                             </tr>
                             {% if request.user.has_perm('crashstats.view_pii') %}
                             <tr>
-                                <th scope="row">Email Address</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.email'] }}">Email Address</th>
                                 <td>
                                     {% if raw.Email %}
-                                    <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a> - Super Sensitive! Don't mess around! {% endif %}
+                                    <a href="mailto:{{ raw.Email }}">{{ raw.Email }}</a> - This is super sensitive data! Be careful how you use it!
+                                    {% endif %}
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">URL</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.url'] }}">URL</th>
                                 <td>
                                     {% if raw.URL %}
-                                    <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a> - Super Sensitive! Don't mess around! {% endif %}
+                                    <a href="{{ raw.URL }}" title="{{ raw.URL }}">{{ raw.URL }}</a> - This is super sensitive data! Be careful how you use it!
+                                    {% endif %}
                                 </td>
                             </tr>
                             {% endif %}
                             {% if request.user.has_perm('crashstats.view_exploitability') %}
                             <tr>
-                                <th scope="row">Exploitability</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.exploitability'] }}">Exploitability</th>
                                 <td>
-                                    {% if report.exploitability %} {{ report.exploitability }} {% endif %}
+                                    {% if report.exploitability %}
+                                    {{ report.exploitability }} - This is super sensitive data! Be careful how you use it!
+                                    {% endif %}
                                 </td>
                             </tr>
                             {% endif %}
                             <tr>
-                                <th scope="row">User Comments</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.user_comments'] }}">User Comments</th>
                                 <td>
                                     {% if report.user_comments %}
                                     {% if request.user.has_perm('crashstats.view_pii') %}
@@ -242,7 +256,7 @@
                             </tr>
                             {% if report.app_notes %}
                             <tr>
-                                <th title="Notes added by the application's code during crash" scope="row">App Notes</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.app_notes'] }}">App Notes</th>
                                 <td>
                                     <pre>{{ report.app_notes }}</pre>
                                 </td>
@@ -250,55 +264,39 @@
                             {% endif %}
                             {% if report.processor_notes %}
                             <tr>
-                                <th title="Notes added by Socorro when accepting the crash report" scope="row">Processor Notes</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.processor_notes'] }}">Processor Notes</th>
                                 <td>
                                     <code>{{ report.processor_notes }}</code>
                                 </td>
                             </tr>
                             {% endif %}
-                            {% if report.distributor %}
                             <tr>
-                                <th>
-                                    <td>
-                                        <pre>{{ report.distributor }}</pre>
-                                    </td>
-                            </tr>
-                            {% endif %}
-                            {% if report.distributor_version %}
-                            <tr>
-                                <th>
-                                    <td>
-                                        <pre>{{ report.distributor_version }}</pre>
-                                    </td>
-                            </tr>
-                            {% endif %}
-                            <tr>
-                                <th scope="row">EMCheckCompatibility</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.addons_checked'] }}">EMCheckCompatibility</th>
                                 <td>
                                     <pre>{% if report.addons_checked %}True{% else %}False{% endif %}</pre>
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">Winsock LSP</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.Winsock_LSP'] }}">Winsock LSP</th>
                                 <td>
                                     <pre>{{ report.Winsock_LSP }}</pre>
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">Adapter Vendor ID</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.AdapterVendorID'] }}">Adapter Vendor ID</th>
                                 <td>
                                     <pre>{{ raw.AdapterVendorID }}</pre>
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">Adapter Device ID</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.AdapterDeviceID'] }}">Adapter Device ID</th>
                                 <td>
                                     <pre>{{ raw.AdapterDeviceID }}</pre>
                                 </td>
                             </tr>
                             {% if raw.JavaStackTrace %}
                             <tr>
-                                <th scope="row">Java Stack Trace</th>
+                                <th scope="row" title="{{ fields_desc['processed_crash.java_stack_trace'] }}">Java Stack Trace</th>
                                 <td>
                                     <pre>{{ raw.JavaStackTrace }}</pre>
                                 </td>
@@ -306,7 +304,7 @@
                             {% endif %}
                             {% if raw.TotalVirtualMemory %}
                             <tr>
-                                <th scope="row">Total Virtual Memory</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.TotalVirtualMemory'] }}">Total Virtual Memory</th>
                                 <td>
                                     {{ show_filesize(raw.get('TotalVirtualMemory')) }}
                                 </td>
@@ -314,7 +312,7 @@
                             {% endif %}
                             {% if raw.AvailableVirtualMemory %}
                             <tr>
-                                <th scope="row">Available Virtual Memory</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.AvailableVirtualMemory'] }}">Available Virtual Memory</th>
                                 <td>
                                     {{ show_filesize(raw.get('AvailableVirtualMemory')) }}
                                 </td>
@@ -322,7 +320,7 @@
                             {% endif %}
                             {% if raw.SystemMemoryUsePercentage %}
                             <tr>
-                                <th scope="row">System Memory Use Percentage</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.SystemMemoryUsePercentage'] }}">System Memory Use Percentage</th>
                                 <td>
                                     {{ raw.SystemMemoryUsePercentage }}
                                 </td>
@@ -330,7 +328,7 @@
                             {% endif %}
                             {% if raw.AvailablePageFile %}
                             <tr>
-                                <th scope="row">Available Page File</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.AvailablePageFile'] }}">Available Page File</th>
                                 <td>
                                     {{ show_filesize(raw.get('AvailablePageFile')) }}
                                 </td>
@@ -338,7 +336,7 @@
                             {% endif %}
                             {% if raw.AvailablePhysicalMemory %}
                             <tr>
-                                <th scope="row">Available Physical Memory</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.AvailablePhysicalMemory'] }}">Available Physical Memory</th>
                                 <td>
                                     {{ show_filesize(raw.get('AvailablePhysicalMemory')) }}
                                 </td>
@@ -346,7 +344,7 @@
                             {% endif %}
                             {% if raw.OOMAllocationSize %}
                             <tr>
-                                <th scope="row">OOM Allocation Size</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.OOMAllocationSize'] }}">OOM Allocation Size</th>
                                 <td>
                                     {{ show_filesize(raw.get('OOMAllocationSize')) }}
                                 </td>
@@ -354,7 +352,7 @@
                             {% endif %}
                             {% if raw.FlashProcessDump %}
                             <tr>
-                                <th scope="row">Flash Process Dump</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.FlashProcessDump'] }}">Flash Process Dump</th>
                                 <td>
                                     <pre>{{ raw.FlashProcessDump }}</pre>
                                 </td>
@@ -362,7 +360,7 @@
                             {% endif %}
                             {% if raw.Accessibility %}
                             <tr>
-                                <th scope="row">Accessibility</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.Accessibility'] }}">Accessibility</th>
                                 <td>
                                     <pre>{{ raw.Accessibility }}</pre>
                                 </td>
@@ -370,7 +368,7 @@
                             {% endif %}
                             {% if raw.Android_CPU_ABI%}
                             <tr>
-                                <th scope="row">Android CPU ABI</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.Android_CPU_ABI'] }}">Android CPU ABI</th>
                                 <td>
                                     <pre>{{ raw.Android_CPU_ABI}}</pre>
                                 </td>
@@ -378,7 +376,7 @@
                             {% endif %}
                             {% if raw.Android_Manufacturer %}
                             <tr>
-                                <th scope="row">Android Manufacturer</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.Android_Manufacturer'] }}">Android Manufacturer</th>
                                 <td>
                                     <pre>{{ raw.Android_Manufacturer }}</pre>
                                 </td>
@@ -386,7 +384,7 @@
                             {% endif %}
                             {% if raw.Android_Model %}
                             <tr>
-                                <th scope="row">Android Model</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.Android_Model'] }}">Android Model</th>
                                 <td>
                                     <pre>{{ raw.Android_Model }}</pre>
                                 </td>
@@ -394,7 +392,7 @@
                             {% endif %}
                             {% if raw.Android_Version %}
                             <tr>
-                                <th scope="row">Android Version</th>
+                                <th scope="row" title="{{ fields_desc['raw_crash.Android_Version'] }}">Android Version</th>
                                 <td>
                                     <pre>{{ raw.Android_Version }}</pre>
                                 </td>
@@ -517,7 +515,9 @@
                         <tbody>
                             {% for key in raw_keys %}
                             <tr>
-                                <th scope="row">{{ key }}</th>
+                                <th scope="row"
+                                    title="{{ fields_desc.get('raw_crash.{}'.format(key), empty_desc) }}"
+                                >{{ key }}</th>
                                 {% if key == 'Comments' %}
                                 <td><pre>{{ raw[key] | scrub_pii }}</pre></td>
                                 {% else %}

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -252,7 +252,7 @@ def show_duration(seconds, unit='seconds'):
         # escaped.
         return seconds
 
-    humanized = humanfriendly.format_timespan(int(seconds))
+    humanized = humanfriendly.format_timespan(seconds)
     return mark_safe(template.render({
         'seconds_str': format(seconds, ','),
         'seconds': seconds,

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -232,17 +232,17 @@ def show_duration(seconds, unit='seconds'):
     If we can't do it, just return as is.
     """
     template = engines['backend'].from_string(
-        '{{ seconds }} {{ unit }} '
+        '{{ seconds_str }} {{ unit }} '
         '{% if seconds > 60 %}'
-        '<span class="humanized" title="{{ seconds }} {{ unit }}">'
+        '<span class="humanized" title="{{ seconds_str }} {{ unit }}">'
         '({{ humanized }})</span>'
         '{% endif %}'
     )
 
     try:
-        humanized = humanfriendly.format_timespan(int(seconds))
+        seconds = int(seconds)
     except (ValueError, TypeError):
-        # ValueErrors happen when `seconds` is not a number`.
+        # ValueErrors happen when `seconds` is not a number.
         # TypeErrors happen when you try to convert a None to an integer.
 
         # Bail, but note how it's NOT marked as safe.
@@ -252,7 +252,9 @@ def show_duration(seconds, unit='seconds'):
         # escaped.
         return seconds
 
+    humanized = humanfriendly.format_timespan(int(seconds))
     return mark_safe(template.render({
+        'seconds_str': format(seconds, ','),
         'seconds': seconds,
         'unit': unit,
         'humanized': humanized,
@@ -269,16 +271,19 @@ def show_filesize(bytes, unit='bytes'):
     If we can't do it, just return as is.
     """
     template = engines['backend'].from_string(
-        '{{ bytes }} {{ unit }} '
+        '{{ bytes_str }} {{ unit }} '
         '{% if bytes > 1024 %}'
-        '<span class="humanized" title="{{ bytes }} {{ unit }}">'
+        '<span class="humanized" title="{{ bytes_str }} {{ unit }}">'
         '({{ humanized }})</span>'
         '{% endif %}'
     )
 
     try:
-        humanized = humanfriendly.format_size(int(bytes))
+        bytes = int(bytes)
     except (ValueError, TypeError):
+        # ValueErrors happen when `bytes` is not a number.
+        # TypeErrors happen when you try to convert a None to an integer.
+
         # Bail but note how it's NOT marked as safe.
         # That means that if `bytes` is literally '<script>'
         # it will be sent to the template rendering engine to be
@@ -286,7 +291,9 @@ def show_filesize(bytes, unit='bytes'):
         # escaped.
         return bytes
 
+    humanized = humanfriendly.format_size(bytes)
     return mark_safe(template.render({
+        'bytes_str': format(bytes, ','),
         'bytes': bytes,
         'unit': unit,
         'humanized': humanized,

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -214,11 +214,11 @@ class TestHumanizers(TestCase):
         )
 
         # if the number is digit but a string it should work too
-        html = show_duration('150')
+        html = show_duration('1500')
         eq_(
             html,
-            '150 seconds <span class="humanized" title="150 seconds">'
-            '(2 minutes and 30 seconds)</span>'
+            '1,500 seconds <span class="humanized" title="1,500 seconds">'
+            '(25 minutes)</span>'
         )
 
     def test_show_duration_different_unit(self):
@@ -263,8 +263,8 @@ class TestHumanizers(TestCase):
         ok_(isinstance(html, SafeText))
         eq_(
             html,
-            '10000 bytes '
-            '<span class="humanized" title="10000 bytes">'
+            '10,000 bytes '
+            '<span class="humanized" title="10,000 bytes">'
             '(9.77 KB)</span>'
         )
 
@@ -272,8 +272,8 @@ class TestHumanizers(TestCase):
         ok_(isinstance(html, SafeText))
         eq_(
             html,
-            '10000 bytes '
-            '<span class="humanized" title="10000 bytes">'
+            '10,000 bytes '
+            '<span class="humanized" title="10,000 bytes">'
             '(9.77 KB)</span>'
         )
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -2433,6 +2433,10 @@ class TestViews(BaseTestViews):
         ok_('&#34;exploitability&#34;' in response.content)
         eq_(response.status_code, 200)
 
+        # Ensure fields have their description in title.
+        ok_('No description for this field.' in response.content)
+        ok_('Description of the signature field' in response.content)
+
     @mock.patch('crashstats.crashstats.models.Bugs.get')
     @mock.patch('requests.get')
     def test_report_index_with_additional_raw_dump_links(self, rget, rpost):
@@ -2920,7 +2924,7 @@ class TestViews(BaseTestViews):
             args=['11cb72f5-eb28-41e1-a8e4-849982120611']
         )
         response = self.client.get(url)
-        ok_('<th scope="row">Install Time</th>' in response.content)
+        ok_('Install Time</th>' in response.content)
         # This is what 1461170304 is in human friendly format.
         ok_('2016-04-20 16:38:24' in response.content)
 
@@ -2978,7 +2982,6 @@ class TestViews(BaseTestViews):
         )
         response = self.client.get(url)
         # The heading is there but there should not be a value for it
-        ok_('<th scope="row">Install Time</th>' in response.content)
         doc = pyquery.PyQuery(response.content)
         # Look for a <tr> whose <th> is 'Install Time', then
         # when we've found the row, we look at the text of its <td> child.

--- a/webapp-django/crashstats/supersearch/tests/common.py
+++ b/webapp-django/crashstats/supersearch/tests/common.py
@@ -15,6 +15,7 @@ SUPERSEARCH_FIELDS_MOCKED_RESULTS = {
         'is_returned': True,
         'is_mandatory': False,
         'in_database_name': 'signature',
+        'description': 'Description of the signature field',
     },
     'product': {
         'name': 'product',


### PR DESCRIPTION
This adds a title to each ``<th>`` with the description of the field and the name of that field in Super Search. It also formats numbers a bit better. It removes ``distributor`` and ``distributor_version`` because I think they are deprecated (these fields haven't had a value in a while). 

cc @nnethercote, I hopefully took everything you did in #3360 and added some of the other things you wanted. Note that I moved the descriptions you wrote to our Super Search Fields list on production, you can see that here: http://crash-stats.mozilla.com/api/SuperSearchFields/ If you want to be able to edit those descriptions yourself, you will have to be made a superuser of crash-stats, but considering your involvement with us I think that would make sense. Let's discuss it in London if you're interested. 