### PR TITLE
bug 1278498 - don't write to missing_symbols unless debug_id & debug_file

### DIFF
--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -818,7 +818,15 @@ class MissingSymbolsRule(Rule):
             sql = self.sql % datestring_to_weekly_partition(date)
             for module in processed_crash['json_dump']['modules']:
                 try:
-                    if module['missing_symbols']:
+                    # First of all, only bother if there are
+                    # missing_symbols in this module.
+                    # And because it's not useful if either of debug_file
+                    # or debug_id are empty, we filter on that here too.
+                    if (
+                        module['missing_symbols'] and
+                        module['debug_file'] and
+                        module['debug_id']
+                    ):
                         self.transaction(
                             execute_no_results,
                             sql,

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -1930,6 +1930,11 @@ class TestMissingSymbols(TestCase):
                     # Note that this does not even have a key
                     # called 'code_file'.
                 },
+                {
+                    "debug_id": "",
+                    "debug_file": None,
+                    "missing_symbols": True,
+                },
             ]
         }
 


### PR DESCRIPTION
Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1278498#c5 and https://bugzilla.mozilla.org/show_bug.cgi?id=1278498#c7