### PR TITLE
document to only use ./manage.py migrate

### DIFF
--- a/docs/development/build-from-source.rst
+++ b/docs/development/build-from-source.rst
@@ -103,7 +103,6 @@ Django needs to write its ORM tables:
 ::
   export SECRET_KEY="..."
   cd webapp-django
-  ./manage.py syncdb --noinput
   ./manage.py migrate
 
 Run Socorro in dev mode

--- a/docs/development/build-from-source.rst
+++ b/docs/development/build-from-source.rst
@@ -103,6 +103,7 @@ Django needs to write its ORM tables:
 ::
   export SECRET_KEY="..."
   cd webapp-django
+  ./manage.py migrate auth
   ./manage.py migrate
 
 Run Socorro in dev mode

--- a/docs/development/webapp.rst
+++ b/docs/development/webapp.rst
@@ -56,6 +56,7 @@ This file is executed when you run:
 ::
   cd webapp-django
   export SECRET_KEY="..."
+  ./manage.py migrate auth
   ./manage.py migrate
 
 This should be done automatically on every release. Because it's idempotent

--- a/docs/development/webapp.rst
+++ b/docs/development/webapp.rst
@@ -56,7 +56,6 @@ This file is executed when you run:
 ::
   cd webapp-django
   export SECRET_KEY="..."
-  ./manage.py syncdb --noinput
   ./manage.py migrate
 
 This should be done automatically on every release. Because it's idempotent
@@ -74,8 +73,8 @@ permission for being allowed to save searches could be::
     code name: save_search
     verbose name: Save User Searches
 
-Then, once that's added to the file run ``./manage.py syncdb
---noinput`` and it will be ready to depend on in the code.
+Then, once that's added to the file run ``./manage.py migrate``
+and it will be ready to depend on in the code.
 
 Here's for example how you use this permission in a view::
 


### PR DESCRIPTION
`./manage.py syncdb` doesn't do anything any more. If it does, it's just doing the same as `migrate`. 