### PR TITLE
fixes bug 1282582 - Upgrade node packages to support Node v6

### DIFF
--- a/webapp-django/package.json
+++ b/webapp-django/package.json
@@ -9,7 +9,8 @@
   "license": "MPL-2.0",
   "dependencies": {
     "cssmin": "0.4.3",
-    "less": "2.5.3",
+    "graceful-fs": "4.1.4",
+    "less": "2.7.1",
     "uglify-js": "2.6.1"
   }
 }


### PR DESCRIPTION
CC @willkg Can you try this branch too in your local django-webapp. 

Pull my branch, then `rm -fr ./node_modules` then `npm install`. 

To test that it works, run `./manage.py collectstatic --noinput --clear` and  also start your `runserver` to make sure that works too. 

What version of node do you have installed? If `<6` does usage of `graceful-fs@>=4` break things?