### PR TITLE
Bug 1287548 migrate users by ldap alias email

### DIFF
--- a/webapp-django/crashstats/authentication/management/commands/migrate-users-csv.py
+++ b/webapp-django/crashstats/authentication/management/commands/migrate-users-csv.py
@@ -1,0 +1,42 @@
+import csv
+
+from django.core.management.base import BaseCommand
+
+from crashstats.authentication.migration import migrate_users
+
+
+class Command(BaseCommand):
+    help = """Parsing a CSV file where the first column is the
+    ALIAS email and the second column is the CORRECT email.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument('csvfile')
+
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            default=False,
+            help='Print instead of actually merging'
+        )
+
+        parser.add_argument(
+            '--include-first-row',
+            action='store_true',
+            default=False,
+            help='Set if the first row is NOT a header'
+        )
+
+    def handle(self, **options):
+        first = True
+        combos = []
+        with open(options['csvfile']) as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if first and not options['include_first_row']:
+                    first = False
+                else:
+                    assert len(row) == 2, len(row)
+                    combos.append(row)
+
+        migrate_users(combos, dry_run=options['dry_run'])

--- a/webapp-django/crashstats/authentication/migration.py
+++ b/webapp-django/crashstats/authentication/migration.py
@@ -1,0 +1,53 @@
+from django.contrib.auth import get_user_model
+from django.db.models import Q
+
+User = get_user_model()
+
+
+def migrate_users(combos, dry_run=False):
+    # Because the list of comboes is possibly very large, we don't want
+    # to query the ORM for each and every one since most of the emails
+    # we expect to search for are not going to be found.
+    size = 100
+    groups = [
+        combos[i:i + size] for i in range(0, len(combos), size)
+    ]
+    for group in groups:
+        transform = dict((x.lower(), y) for x, y in group)
+
+        q = Q()
+        for email in transform:
+            q = q | Q(email__iexact=email)
+        # Most likely the list of emails we search for is MUCH larger
+        # than the number of users we find. For those few found,
+        # we'll deal with it one at a time.
+        users = User.objects.filter(q)
+        for user in users:
+            print 'NEED TO MIGRATE', user.email.ljust(30),
+            print 'TO', transform[user.email]
+            try:
+                destination = User.objects.get(
+                    email__iexact=transform[user.email]
+                )
+                if user.is_staff:
+                    print "\tTransferring 'is_staff'"
+                    destination.is_staff = True
+                if user.is_superuser:
+                    print "\tTransferring 'is_superuser'"
+                    destination.is_superuser = True
+                for group in user.groups.all():
+                    print '\tTransferring group membership %r' % group.name
+                    destination.groups.add(group)
+                user.is_active = False
+                if not dry_run:
+                    user.save()
+                    destination.save()
+            except User.DoesNotExist:
+                # then it's easy peasy!
+                print '\tSimply changing email from %r to %r' % (
+                    user.email,
+                    transform[user.email]
+                )
+                user.email = transform[user.email]
+                if not dry_run:
+                    user.save()

--- a/webapp-django/crashstats/authentication/migration.py
+++ b/webapp-django/crashstats/authentication/migration.py
@@ -56,8 +56,8 @@ def migrate_users(combos, dry_run=False):
                 # then it's easy peasy!
                 print '\tSimply changing email from %r to %r' % (
                     user.email,
-                    transform[user.email]
+                    transform[user.email.lower()]
                 )
-                user.email = transform[user.email]
+                user.email = transform[user.email.lower()]
                 if not dry_run:
                     user.save()

--- a/webapp-django/crashstats/authentication/migration.py
+++ b/webapp-django/crashstats/authentication/migration.py
@@ -38,6 +38,16 @@ def migrate_users(combos, dry_run=False):
                 for group in user.groups.all():
                     print '\tTransferring group membership %r' % group.name
                     destination.groups.add(group)
+                if (
+                    user.last_login and destination.last_login and
+                    user.last_login > destination.last_login
+                ):
+                    destination.last_login = user.last_login
+                if (
+                    user.date_joined and destination.date_joined and
+                    user.date_joined > destination.date_joined
+                ):
+                    destination.date_joined = user.date_joined
                 user.is_active = False
                 if not dry_run:
                     user.save()

--- a/webapp-django/crashstats/authentication/migration.py
+++ b/webapp-django/crashstats/authentication/migration.py
@@ -24,10 +24,10 @@ def migrate_users(combos, dry_run=False):
         users = User.objects.filter(q)
         for user in users:
             print 'NEED TO MIGRATE', user.email.ljust(30),
-            print 'TO', transform[user.email]
+            print 'TO', transform[user.email.lower()]
             try:
                 destination = User.objects.get(
-                    email__iexact=transform[user.email]
+                    email__iexact=transform[user.email.lower()]
                 )
                 if user.is_staff:
                     print "\tTransferring 'is_staff'"

--- a/webapp-django/crashstats/authentication/tests/test_migration.py
+++ b/webapp-django/crashstats/authentication/tests/test_migration.py
@@ -65,7 +65,7 @@ class TestMigrateUsersCSV(DjangoTestCase):
         # just one group
         real.groups.add(not_cool)
 
-        alias2 = User.objects.create(username='a2', email='alias2@example.com')
+        alias2 = User.objects.create(username='a2', email='Alias2@example.com')
 
         combos = (
             [alias.email.upper(), real.email.capitalize()],
@@ -82,7 +82,7 @@ class TestMigrateUsersCSV(DjangoTestCase):
             out.getvalue()
         ))
         ok_(re.findall(
-            'NEED TO MIGRATE alias2@example.com\s+TO corrected@example.com',
+            'NEED TO MIGRATE Alias2@example.com\s+TO corrected@example.com',
             out.getvalue()
         ))
 

--- a/webapp-django/crashstats/authentication/tests/test_migration.py
+++ b/webapp-django/crashstats/authentication/tests/test_migration.py
@@ -1,0 +1,96 @@
+import contextlib
+import csv
+import os
+import re
+import tempfile
+
+from nose.tools import ok_
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+from django.utils.six import StringIO
+
+from crashstats.base.tests.testbase import DjangoTestCase
+from crashstats.authentication.migration import migrate_users
+
+User = get_user_model()
+
+
+@contextlib.contextmanager
+def redirect_stdout(stream):
+    import sys
+    sys.stdout = stream
+    yield
+    sys.stdout = sys.__stdout__
+
+
+class TestMigrateUsersCSV(DjangoTestCase):
+
+    def test_basic_call(self):
+        out = StringIO()
+        tmp_csv_file = os.path.join(tempfile.gettempdir(), 'file.csv')
+        with open(tmp_csv_file, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerow(['alias', 'correct'])
+            writer.writerow(['alias@example.com', 'flastname@example.com'])
+        try:
+            call_command('migrate-users-csv', tmp_csv_file, stdout=out)
+            ok_(not out.getvalue())
+        finally:
+            os.remove(tmp_csv_file)
+
+    def test_migrate_users(self):
+        cool = Group.objects.create(name='Cool People')
+        not_cool = Group.objects.create(name='Not So Cool')
+
+        # create a user with "an alias email"
+        alias = User.objects.create(username='a', email='alias@example.com')
+        # and give it some fancy permissions
+        alias.is_staff = True
+        alias.is_superuser = True
+        alias.save()
+        alias.groups.add(cool)
+        alias.groups.add(not_cool)
+
+        real = User.objects.create(username='r', email='flastname@example.com')
+        # just one group
+        real.groups.add(not_cool)
+
+        alias2 = User.objects.create(username='a2', email='alias2@example.com')
+
+        combos = (
+            [alias.email.upper(), real.email.capitalize()],
+            [alias2.email, 'corrected@example.com'],
+            ['other@example.com', 'notfound@example.com'],
+        )
+        out = StringIO()
+        with redirect_stdout(out):
+            migrate_users(combos)
+
+        # Check the stdout blather
+        ok_(re.findall(
+            'NEED TO MIGRATE alias@example.com\s+TO Flastname@example.com',
+            out.getvalue()
+        ))
+        ok_(re.findall(
+            'NEED TO MIGRATE alias2@example.com\s+TO corrected@example.com',
+            out.getvalue()
+        ))
+
+        # Should still only be 3 users
+        assert User.objects.all().count() == 3
+
+        # It should have now "copied" all the good stuff of `alias`
+        # over to `real`.
+        alias = User.objects.get(id=alias.id)  # reload
+        ok_(not alias.is_active)
+        real = User.objects.get(id=real.id)
+        ok_(real.is_staff)
+        ok_(real.is_superuser)
+        ok_(cool in real.groups.all())
+        ok_(not_cool in real.groups.all())
+
+        # And the `alias2` user should just simply have its email changed.
+        ok_(not User.objects.filter(email__iexact='alias2@example.com'))
+        ok_(User.objects.filter(email__iexact='corrected@example.com'))

--- a/webapp-django/crashstats/authentication/tests/test_migration.py
+++ b/webapp-django/crashstats/authentication/tests/test_migration.py
@@ -50,7 +50,7 @@ class TestMigrateUsersCSV(DjangoTestCase):
         not_cool = Group.objects.create(name='Not So Cool')
 
         # create a user with "an alias email"
-        alias = User.objects.create(username='a', email='alias@example.com')
+        alias = User.objects.create(username='a', email='Alias@example.com')
         # and give it some fancy permissions
         alias.is_staff = True
         alias.is_superuser = True
@@ -59,7 +59,7 @@ class TestMigrateUsersCSV(DjangoTestCase):
         alias.groups.add(cool)
         alias.groups.add(not_cool)
 
-        real = User.objects.create(username='r', email='flastname@example.com')
+        real = User.objects.create(username='r', email='Flastname@example.com')
         real.last_login = yesterday
         real.save()
         # just one group
@@ -78,7 +78,7 @@ class TestMigrateUsersCSV(DjangoTestCase):
 
         # Check the stdout blather
         ok_(re.findall(
-            'NEED TO MIGRATE alias@example.com\s+TO Flastname@example.com',
+            'NEED TO MIGRATE Alias@example.com\s+TO Flastname@example.com',
             out.getvalue()
         ))
         ok_(re.findall(


### PR DESCRIPTION
cc @adngdb 

When we switch from Persona to Google Sign-in, people who used to sign in with `alias@example.com` will no longer be able to do so. They simply HAVE to use `flastname@example.com`. If they used to use `alias@...` their permissions etc would be lost. So we'll "merge" those and transfer all the goodies that `alias@...` had to `flastname@...`. 

The day we switch over from Persona to Google Sign-in we need to generate a CSV file that looks like this:
```
ALIAS,CORRECT
alias@example.com,flastname@example.com
alias2@example.com,flastname2@example.com
aliasN@example.com,flastnameN@example.com
```
Then we need to scp that file into any of the webheads and run this command:

```
$ envconsul -prefix socorro/common -prefix socorro/webapp-django \
./manage.py migrate-alias-users --dry-run test.csv
```
(If it works, remove the `--dry-run`)

The CSV file I'll generate using my Mozilla LDAP certificate. 

Once we've done this we can decommission all of this code. 