### PR TITLE
Fixes bug 1282529 - Removed field name from truthy Elasticsearch operator.

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -310,7 +310,6 @@ class SuperSearch(SearchBase):
                 elif param.operator == '__true__':
                     filter_type = 'term'
                     filter_value = True
-                    args['field'] = name
                 elif param.operator == '@':
                     filter_type = 'regexp'
                     if field_data['has_full_version']:


### PR DESCRIPTION
@peterbe Don't ask me why this works, because I have no clue. The current code works for fields like ``accessibility`` but not for ``submitted_from_infobar``, and I do not have the slightest idea as to why. But, I have confirmed in my testing that removing this (unneeded and buggy) line fixed the problem. 

Of course, since I don't understand the problem, I have no idea how to reproduce it in unit tests. :(