### PR TITLE
fixes bug 1289196 - observe user.is_active

### DIFF
--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -1627,6 +1627,12 @@ class TestViews(BaseTestViews):
         response = self.client.get(url, params, HTTP_AUTH_TOKEN=token.key)
         eq_(response.status_code, 200)
 
+        # But if you stop being active, it should break
+        user.is_active = False
+        user.save()
+        response = self.client.get(url, params, HTTP_AUTH_TOKEN=token.key)
+        eq_(response.status_code, 403)
+
     def test_hit_or_not_hit_ratelimit(self):
 
         def mocked_get(**options):

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -239,7 +239,10 @@ def model_wrapper(request, model_name):
         required_permissions = [required_permissions]
     if (
         required_permissions and
-        not has_permissions(request.user, required_permissions)
+        (
+            not request.user.is_active or
+            not has_permissions(request.user, required_permissions)
+        )
     ):
         permission_names = []
         for permission in required_permissions:
@@ -470,7 +473,7 @@ def documentation(request):
         '%s://%s' % (request.is_secure() and 'https' or 'http',
                      RequestSite(request).domain)
     )
-    if request.user.is_authenticated():
+    if request.user.is_active:
         your_tokens = Token.objects.active().filter(user=request.user)
     else:
         your_tokens = Token.objects.none()

--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -165,7 +165,7 @@
         <div class="login">
             <ul>
                 <li>
-                {% if request.user and request.user.is_authenticated() %}
+                {% if request.user and request.user.is_active %}
                     <a href="{{ url('profile:profile') }}"
                       title="You are signed in as {{ request.user.email }}"
                     >

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -4,9 +4,38 @@ import urlparse
 from django.http import HttpResponseBadRequest, Http404
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse
+from django.contrib.auth.decorators import (
+    REDIRECT_FIELD_NAME,
+    user_passes_test,
+)
 
 from . import utils
 from crashstats.base import ga
+
+
+def login_required(
+    function=None,
+    redirect_field_name=REDIRECT_FIELD_NAME,
+    login_url=None
+):
+    """This is a re-implementation of the ever useful default decorator
+    in django.contrib.auth.decorators which is exactly the same except
+    that it also requires the user to be active.
+
+    In other words, if you use this decorator you're saying that
+    being logged in AND being active is required.
+
+    The usefulness of this is that super users can revoke a user being
+    active and halt the user's access even after the user has signed in.
+    """
+    actual_decorator = user_passes_test(
+        lambda u: u.is_authenticated() and u.is_active,
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        return actual_decorator(function)
+    return actual_decorator
 
 
 _marker = object()

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -29,7 +29,7 @@ def login_required(
     active and halt the user's access even after the user has signed in.
     """
     actual_decorator = user_passes_test(
-        lambda u: u.is_authenticated() and u.is_active,
+        lambda u: u.is_active,
         login_url=login_url,
         redirect_field_name=redirect_field_name
     )

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -346,13 +346,13 @@ def ratelimit_rate(group, request):
     https://django-ratelimit.readthedocs.org/en/latest/rates.html#rates-chapter
     """
     if group == 'crashstats.api.views.model_wrapper':
-        if request.user.is_authenticated():
+        if request.user.is_active:
             return settings.API_RATE_LIMIT_AUTHENTICATED
         else:
             return settings.API_RATE_LIMIT
     elif group.startswith('crashstats.supersearch.views.search'):
         # this applies to both the web view and ajax views
-        if request.user.is_authenticated():
+        if request.user.is_active:
             return settings.RATELIMIT_SUPERSEARCH_AUTHENTICATED
         else:
             return settings.RATELIMIT_SUPERSEARCH

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1159,7 +1159,6 @@ def exploitable_crashes(
     """This function is now deprecated in favor of the new one called
     exploitability_report"""
     context = default_context or {}
-
     if product is None:
         return redirect(
             'crashstats:exploitable_crashes',
@@ -2542,7 +2541,7 @@ def graphics_report(request):
     """Return a CSV output of all crashes for a specific date for a
     particular day and a particular product."""
     if (
-        not request.user.is_authenticated() or
+        not request.user.is_active or
         not request.user.has_perm('crashstats.run_long_queries')
     ):
         return http.HttpResponseForbidden(

--- a/webapp-django/crashstats/manage/tests/test_views.py
+++ b/webapp-django/crashstats/manage/tests/test_views.py
@@ -57,12 +57,13 @@ class TestViews(BaseTestViews):
         models.ProductVersions().get(active=True)
 
     def _login(self, is_superuser=True):
-        self.user = User.objects.create_user('kairo', 'kai@ro.com', 'secret')
-        self.user.is_superuser = is_superuser
-        # django doesn't set this unless the user has actually signed in
-        self.user.last_login = datetime.datetime.utcnow()
-        self.user.save()
-        assert self.client.login(username='kairo', password='secret')
+        user = super(TestViews, self)._login(
+            username='kairo',
+            email='kai@ro.com',
+        )
+        user.is_superuser = is_superuser
+        user.save()
+        return user
 
     def _create_permission(self, name='Mess Around', codename='mess_around'):
         ct, __ = ContentType.objects.get_or_create(
@@ -94,7 +95,7 @@ class TestViews(BaseTestViews):
         ok_('You need to be a superuser to access this' in response.content)
 
     def test_home_page_signed_in(self):
-        self._login()
+        user = self._login()
         # at the moment it just redirects
         home_url = reverse('manage:home')
         response = self.client.get(home_url)
@@ -112,7 +113,8 @@ class TestViews(BaseTestViews):
         releases_url = reverse('manage:releases')
         ok_(releases_url in response.content)
 
-        User.objects.filter(id=self.user.id).update(is_active=False)
+        user.is_active = False
+        user.save()
         home_url = reverse('manage:home')
         response = self.client.get(home_url)
         eq_(response.status_code, 302)
@@ -120,7 +122,7 @@ class TestViews(BaseTestViews):
     @mock.patch('requests.put')
     @mock.patch('requests.get')
     def test_featured_versions(self, rget, rput):
-        self._login()
+        user = self._login()
         url = reverse('manage:featured_versions')
 
         put_calls = []  # some mutable
@@ -205,7 +207,7 @@ class TestViews(BaseTestViews):
 
         # check that it got logged
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'featured_versions.update')
         eq_(event.extra['success'], True)
         eq_(event.extra['data'], {'WaterWolf': ['18.0.1']})
@@ -279,19 +281,19 @@ class TestViews(BaseTestViews):
         url = reverse('manage:users_data')
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        self._login()
+        user = self._login()
         response = self.client.get(url)
         eq_(response.status_code, 200)
         data = json.loads(response.content)
         eq_(data['count'], 1)
-        eq_(data['users'][0]['email'], self.user.email)
-        eq_(data['users'][0]['id'], self.user.pk)
+        eq_(data['users'][0]['email'], user.email)
+        eq_(data['users'][0]['id'], user.pk)
         eq_(data['users'][0]['is_superuser'], True)
         eq_(data['users'][0]['is_active'], True)
         eq_(data['users'][0]['groups'], [])
 
         austrians = Group.objects.create(name='Austrians')
-        self.user.groups.add(austrians)
+        user.groups.add(austrians)
 
         response = self.client.get(url)
         eq_(response.status_code, 200)
@@ -305,9 +307,9 @@ class TestViews(BaseTestViews):
         url = reverse('manage:users_data')
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        self._login()
-        self.user.last_login -= datetime.timedelta(days=365)
-        self.user.save()
+        user = self._login()
+        user.last_login -= datetime.timedelta(days=365)
+        user.save()
         now = timezone.now()
         for i in range(1, 101):  # 100 times, 1-100
             User.objects.create(
@@ -341,7 +343,7 @@ class TestViews(BaseTestViews):
         data = json.loads(response.content)
         eq_(data['count'], 101)
         # because it's sorted by last_login
-        eq_(data['users'][0]['email'], self.user.email)
+        eq_(data['users'][0]['email'], user.email)
         eq_(len(data['users']), 1)
         eq_(data['page'], 11)
         eq_(data['batch_size'], settings.USERS_ADMIN_BATCH_SIZE)
@@ -445,7 +447,7 @@ class TestViews(BaseTestViews):
         url = reverse('manage:user', args=(bob.pk,))
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        self._login()
+        user = self._login()
         response = self.client.get(url)
         eq_(response.status_code, 200)
         ok_('bob@example.com' in response.content)
@@ -465,7 +467,7 @@ class TestViews(BaseTestViews):
 
         # check that the event got logged
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'user.edit')
         eq_(event.extra['id'], bob.pk)
         change = event.extra['change']
@@ -493,7 +495,7 @@ class TestViews(BaseTestViews):
 
     def test_group(self):
         url = reverse('manage:groups')
-        self._login()
+        user = self._login()
         ct = ContentType.objects.create(
             model='',
             app_label='crashstats.crashstats',
@@ -525,7 +527,7 @@ class TestViews(BaseTestViews):
 
         # check that it got logged
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'group.add')
         eq_(event.extra, {
             'id': group.id,
@@ -547,7 +549,7 @@ class TestViews(BaseTestViews):
         eq_(list(group.permissions.all()), [p1])
 
         event, = Log.objects.all()[:1]
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'group.edit')
         eq_(event.extra['change']['name'], ['New Group', 'New New Group'])
         eq_(event.extra['change']['permissions'], [
@@ -561,7 +563,7 @@ class TestViews(BaseTestViews):
         ok_(not Group.objects.filter(name=data['name']))
 
         event, = Log.objects.all()[:1]
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'group.delete')
         eq_(event.extra['name'], data['name'])
 
@@ -628,7 +630,7 @@ class TestViews(BaseTestViews):
         )
 
     def test_graphics_devices_edit(self):
-        self._login()
+        user = self._login()
         url = reverse('manage:graphics_devices')
 
         def mocked_post(**payload):
@@ -659,13 +661,13 @@ class TestViews(BaseTestViews):
         ok_(url in response['location'])
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'graphicsdevices.add')
         eq_(event.extra['payload'], [data])
         eq_(event.extra['success'], True)
 
     def test_graphics_devices_csv_upload_pcidatabase_com(self):
-        self._login()
+        user = self._login()
         url = reverse('manage:graphics_devices')
 
         def mocked_post(**payload):
@@ -699,14 +701,14 @@ class TestViews(BaseTestViews):
             ok_(url in response['location'])
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'graphicsdevices.post')
         eq_(event.extra['success'], True)
         eq_(event.extra['database'], 'pcidatabase.com')
         eq_(event.extra['no_lines'], 7)
 
     def test_graphics_devices_csv_upload_pci_ids(self):
-        self._login()
+        user = self._login()
         url = reverse('manage:graphics_devices')
 
         def mocked_post(**payload):
@@ -740,7 +742,7 @@ class TestViews(BaseTestViews):
             ok_(url in response['location'])
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'graphicsdevices.post')
         eq_(event.extra['success'], True)
         eq_(event.extra['database'], 'pci.ids')
@@ -903,7 +905,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 400)
 
     def test_supersearch_field_create(self):
-        self._login()
+        user = self._login()
         url = reverse('manage:supersearch_field_create')
 
         def mocked_supersearchfields_get_fields(**params):
@@ -931,7 +933,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 302)
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'supersearch_field.post')
         eq_(event.extra['name'], 'something')
 
@@ -945,7 +947,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 400)
 
     def test_supersearch_field_update(self):
-        self._login()
+        user = self._login()
         url = reverse('manage:supersearch_field_update')
 
         # Create a permission to test permission validation.
@@ -1000,7 +1002,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 302)
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'supersearch_field.put')
         eq_(event.extra['name'], 'something')
 
@@ -1014,7 +1016,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 400)
 
     def test_supersearch_field_delete(self):
-        self._login()
+        user = self._login()
         url = reverse('manage:supersearch_field_delete')
 
         def mocked_supersearchfields_get_fields(**params):
@@ -1035,7 +1037,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 302)
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'supersearch_field.delete')
         eq_(event.extra['name'], 'signature')
 
@@ -1053,7 +1055,7 @@ class TestViews(BaseTestViews):
             mocked_post
         )
 
-        self._login()
+        user = self._login()
         url = reverse('manage:products')
         response = self.client.get(url)
         eq_(response.status_code, 200)
@@ -1075,7 +1077,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 302)
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'product.add')
         eq_(event.extra['product'], 'WaterCat')
 
@@ -1093,7 +1095,7 @@ class TestViews(BaseTestViews):
 
         rpost.side_effect = mocked_post
 
-        self._login()
+        user = self._login()
         url = reverse('manage:releases')
         response = self.client.get(url)
         eq_(response.status_code, 200)
@@ -1137,7 +1139,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 302)
 
         event, = Log.objects.all()
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'release.add')
         eq_(event.extra['product'], 'WaterCat')
 
@@ -1177,19 +1179,19 @@ class TestViews(BaseTestViews):
         url = reverse('manage:events')
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        self._login()
+        user = self._login()
 
         # this page will iterate over all unique possible Log actions
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='actionA'
         )
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='actionB'
         )
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='actionA'
         )
         response = self.client.get(url)
@@ -1202,10 +1204,10 @@ class TestViews(BaseTestViews):
         url = reverse('manage:events_data')
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        self._login()
+        user = self._login()
 
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='actionA',
             extra={'foo': True}
         )
@@ -1269,32 +1271,32 @@ class TestViews(BaseTestViews):
 
     def test_events_data_urls(self):
         """some logged events have a URL associated with them"""
-        self._login()
+        user = self._login()
 
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='user.edit',
-            extra={'id': self.user.id}
+            extra={'id': user.id}
         )
 
         group = Group.objects.create(name='Wackos')
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='group.add',
             extra={'id': group.id}
         )
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='group.edit',
             extra={'id': group.id}
         )
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='supersearch_field.post',
             extra={'name': 'sig1'}
         )
         Log.objects.create(
-            user=self.user,
+            user=user,
             action='supersearch_field.put',
             extra={'name': 'sig2'}
         )
@@ -1303,7 +1305,7 @@ class TestViews(BaseTestViews):
         data = json.loads(response.content)
         eq_(data['count'], 5)
         five, four, three, two, one = data['events']
-        eq_(one['url'], reverse('manage:user', args=(self.user.id,)))
+        eq_(one['url'], reverse('manage:user', args=(user.id,)))
         eq_(two['url'], reverse('manage:group', args=(group.id,)))
         eq_(three['url'], reverse('manage:group', args=(group.id,)))
         eq_(four['url'], reverse('manage:supersearch_field') + '?name=sig1')
@@ -1327,7 +1329,7 @@ class TestViews(BaseTestViews):
         )
 
     def test_create_api_token(self):
-        self._login()
+        superuser = self._login()
         user = User.objects.create_user(
             'user',
             'user@example.com',
@@ -1358,7 +1360,7 @@ class TestViews(BaseTestViews):
 
         event, = Log.objects.all()
 
-        eq_(event.user, self.user)
+        eq_(event.user, superuser)
         eq_(event.action, 'api_token.create')
         eq_(event.extra['notes'], 'Some notes')
         ok_(event.extra['expires'])
@@ -1454,7 +1456,7 @@ class TestViews(BaseTestViews):
         url = reverse('manage:api_tokens_data')
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        self._login()
+        user = self._login()
         response = self.client.get(url)
         eq_(response.status_code, 200)
         result = json.loads(response.content)
@@ -1468,7 +1470,7 @@ class TestViews(BaseTestViews):
             days=settings.TOKENS_DEFAULT_EXPIRATION_DAYS
         )
         token = Token.objects.create(
-            user=self.user,
+            user=user,
             notes='Some notes',
             expires=expires
         )
@@ -1485,7 +1487,7 @@ class TestViews(BaseTestViews):
             'id': token.id,
             'expired': False,
             'permissions': [permission.name],
-            'user': self.user.email,
+            'user': user.email,
             'key': token.key,
         }
         eq_(result['tokens'], [expected_token])
@@ -1499,7 +1501,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 400)
 
         # filter by email
-        response = self.client.get(url, {'email': self.user.email[:5]})
+        response = self.client.get(url, {'email': user.email[:5]})
         eq_(response.status_code, 200)
         result = json.loads(response.content)
         eq_(result['tokens'], [expected_token])
@@ -1549,7 +1551,7 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 405)
         response = self.client.post(url)
         eq_(response.status_code, 302)
-        self._login()
+        user = self._login()
         response = self.client.post(url)
         eq_(response.status_code, 400)
         response = self.client.post(url, {'id': '99999'})
@@ -1560,7 +1562,7 @@ class TestViews(BaseTestViews):
             days=settings.TOKENS_DEFAULT_EXPIRATION_DAYS
         )
         token = Token.objects.create(
-            user=self.user,
+            user=user,
             notes='Some notes',
             expires=expires
         )
@@ -1575,10 +1577,10 @@ class TestViews(BaseTestViews):
 
         event, = Log.objects.all()
 
-        eq_(event.user, self.user)
+        eq_(event.user, user)
         eq_(event.action, 'api_token.delete')
         eq_(event.extra['notes'], 'Some notes')
-        eq_(event.extra['user'], self.user.email)
+        eq_(event.extra['user'], user.email)
         eq_(event.extra['permissions'], permission.name)
 
     def test_crash_me_now(self):

--- a/webapp-django/crashstats/manage/tests/test_views.py
+++ b/webapp-django/crashstats/manage/tests/test_views.py
@@ -112,6 +112,11 @@ class TestViews(BaseTestViews):
         releases_url = reverse('manage:releases')
         ok_(releases_url in response.content)
 
+        User.objects.filter(id=self.user.id).update(is_active=False)
+        home_url = reverse('manage:home')
+        response = self.client.get(home_url)
+        eq_(response.status_code, 302)
+
     @mock.patch('requests.put')
     @mock.patch('requests.get')
     def test_featured_versions(self, rget, rput):

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -87,7 +87,7 @@ def notice_change(before, after):
 def superuser_required(view_func):
     @functools.wraps(view_func)
     def inner(request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        if not request.user.is_active:
             return redirect(settings.LOGIN_URL)
         elif not request.user.is_superuser:
             messages.error(

--- a/webapp-django/crashstats/profile/tests/test_views.py
+++ b/webapp-django/crashstats/profile/tests/test_views.py
@@ -2,7 +2,6 @@ import pyquery
 from nose.tools import eq_, ok_
 
 from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
 
 from crashstats.crashstats.management import PERMISSIONS
 from crashstats.supersearch.models import SuperSearchUnredacted
@@ -103,7 +102,8 @@ class TestViews(BaseTestViews):
                 eq_(cells[1], 'Yes!')
 
         # If the user ceases to be active, this page should redirect instead
-        User.objects.filter(id=user.id).update(is_active=False)
+        user.is_active = False
+        user.save()
         response = self.client.get(url)
         eq_(response.status_code, 302)
         self.assertRedirects(
@@ -128,7 +128,8 @@ class TestViews(BaseTestViews):
         ok_(profile_url in response.content)
 
         # Render again when no longer an active user
-        User.objects.filter(id=user.id).update(is_active=False)
+        user.is_active = False
+        user.save()
         response = self.client.get(url)
         eq_(response.status_code, 200)
         ok_(profile_url not in response.content)

--- a/webapp-django/crashstats/profile/tests/test_views.py
+++ b/webapp-django/crashstats/profile/tests/test_views.py
@@ -1,7 +1,8 @@
 import pyquery
-
 from nose.tools import eq_, ok_
+
 from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
 
 from crashstats.crashstats.management import PERMISSIONS
 from crashstats.supersearch.models import SuperSearchUnredacted
@@ -100,3 +101,34 @@ class TestViews(BaseTestViews):
                 eq_(cells[1], 'No')
             elif cells[0] == PERMISSIONS['view_exploitability']:
                 eq_(cells[1], 'Yes!')
+
+        # If the user ceases to be active, this page should redirect instead
+        User.objects.filter(id=user.id).update(is_active=False)
+        response = self.client.get(url)
+        eq_(response.status_code, 302)
+        self.assertRedirects(
+            response,
+            reverse('crashstats:login') + '?next=%s' % url
+        )
+
+    def test_homepage_profile_footer(self):
+        """This test isn't specifically for the profile page, because
+        it ultimately tests the crashstats_base.html template. But
+        that template has a link to the profile page."""
+        url = reverse('home:home', args=('WaterWolf',))
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+        profile_url = reverse('profile:profile')
+        ok_(profile_url not in response.content)
+
+        # Render again when signed in
+        user = self._login()
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+        ok_(profile_url in response.content)
+
+        # Render again when no longer an active user
+        User.objects.filter(id=user.id).update(is_active=False)
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+        ok_(profile_url not in response.content)

--- a/webapp-django/crashstats/profile/views.py
+++ b/webapp-django/crashstats/profile/views.py
@@ -1,10 +1,12 @@
 import datetime
 
-from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from django.contrib.auth.models import Permission
 
-from crashstats.crashstats.decorators import pass_default_context
+from crashstats.crashstats.decorators import (
+    pass_default_context,
+    login_required,
+)
 from crashstats.supersearch.models import SuperSearchUnredacted
 
 

--- a/webapp-django/crashstats/symbols/tests/test_views.py
+++ b/webapp-django/crashstats/symbols/tests/test_views.py
@@ -161,8 +161,9 @@ class TestViews(BaseTestViews):
             ok_(link['url'] in response.content)
             ok_(link['label'] in response.content)
 
-        # The access should disappar if you cease to be active
-        User.objects.filter(id=user.id).update(is_active=False)
+        # The access should disappear if you cease to be active
+        user.is_active = False
+        user.save()
         response = self.client.get(url)
         eq_(response.status_code, 302)
         self.assertRedirects(

--- a/webapp-django/crashstats/symbols/tests/test_views.py
+++ b/webapp-django/crashstats/symbols/tests/test_views.py
@@ -145,7 +145,7 @@ class TestViews(BaseTestViews):
             response,
             reverse('crashstats:login') + '?next=%s' % url
         )
-        self._login()
+        user = self._login()
         with self.settings(SYMBOLS_PERMISSION_HINT_LINK=None):
             response = self.client.get(url)
             eq_(response.status_code, 200)
@@ -160,6 +160,15 @@ class TestViews(BaseTestViews):
 
             ok_(link['url'] in response.content)
             ok_(link['label'] in response.content)
+
+        # The access should disappar if you cease to be active
+        User.objects.filter(id=user.id).update(is_active=False)
+        response = self.client.get(url)
+        eq_(response.status_code, 302)
+        self.assertRedirects(
+            response,
+            reverse('crashstats:login') + '?next=%s' % url
+        )
 
     def test_home_with_previous_uploads(self):
         url = reverse('symbols:home')

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -10,7 +10,7 @@ from django import http
 from django.conf import settings
 from django.views.decorators.http import require_POST
 from django.contrib.auth.models import Permission
-from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.decorators import permission_required
 from django.contrib.sites.requests import RequestSite
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
@@ -22,6 +22,7 @@ import boto
 import boto.s3.connection
 import boto.exception
 
+from crashstats.crashstats.decorators import login_required
 from crashstats.tokens.models import Token
 from . import models
 from . import forms
@@ -34,7 +35,7 @@ def api_login_required(view_func):
     authenticated."""
     @wraps(view_func)
     def inner(request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        if not request.user.is_active:
             return http.HttpResponseForbidden(
                 "This requires an Auth-Token to authenticate the request"
             )

--- a/webapp-django/crashstats/tokens/tests/test_views.py
+++ b/webapp-django/crashstats/tokens/tests/test_views.py
@@ -36,9 +36,16 @@ class TestViews(BaseTestViews):
             reverse('crashstats:login') + '?next=%s' % url
         )
 
-        self._login()
+        user = self._login()
         response = self.client.get(url)
         eq_(response.status_code, 200)
+
+        User.objects.filter(id=user.id).update(is_active=False)
+        response = self.client.get(url)
+        self.assertRedirects(
+            response,
+            reverse('crashstats:login') + '?next=%s' % url
+        )
 
     def test_generate_new_token_form(self):
         url = reverse('tokens:home')

--- a/webapp-django/crashstats/tokens/tests/test_views.py
+++ b/webapp-django/crashstats/tokens/tests/test_views.py
@@ -40,7 +40,8 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         eq_(response.status_code, 200)
 
-        User.objects.filter(id=user.id).update(is_active=False)
+        user.is_active = False
+        user.save()
         response = self.client.get(url)
         self.assertRedirects(
             response,

--- a/webapp-django/crashstats/tokens/views.py
+++ b/webapp-django/crashstats/tokens/views.py
@@ -1,10 +1,10 @@
 from django import http
 from django.contrib.auth.models import Permission
-from django.contrib.auth.decorators import login_required
 from django.contrib.sites.requests import RequestSite
 from django.shortcuts import render, get_object_or_404, redirect
 from django.db import transaction
 
+from crashstats.crashstats.decorators import login_required
 from . import models
 from . import forms
 


### PR DESCRIPTION
I know this one is huge but it's actually really simple. Lemme explain:

* `request.user.is_active` is better than `request.user.is_authenticated` when you want to decide if the user should be given something. If an anonymous user makes a request, django automatically sets `request.user = AnonymousUser()`. That user is [always `is_active=False`](https://github.com/django/django/blob/master/django/contrib/auth/models.py#L386) so by using `request.user.is_active` you're asking two questions at the same time. "Is the user  authenticated?" (I.e. does the user have a session cookie) AND "Is the user active?". 

* Some places we were using `django.contrib.auth.decorators.login_required` and that one relies only on `request.user.is_authenticated()`. I made a new one, with the only difference that it ALSO checks that the user is active. 

* A bunch of small extensions of existing view tests to see what would happen if the user ceases to be active AFTER they have logged in. 

Our site is difference because we might have an interest in centrally, ceasing someones access AFTER they have successfully signed in. E.g. ceasing to be a Mozilla LDAP staff member. 