### PR TITLE
Fixes bug 1277301 - Added error messages in home and daily when shard…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -262,3 +262,5 @@ functools32==3.2.3-2 \
 requests-mock==1.0.0 \
     --hash=sha256:c6c659e50a312eb5cf0191ae33d6b232909e4a248551e79cef11c3c93497923d \
     --hash=sha256:3d58070a781befed02036f9359ddc193d7227d04d53d3f6bccfbc3d2d0662638
+isoweek==1.3.0 \
+    --hash=sha256:e7c7625e093df53a37321f98d9d6ea08e7a78d977e7db0933eb66569eda1a179

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
@@ -17,6 +17,21 @@ Crashes per Day for {{ product }}
     <h2>Crashes per Day for {{ product }}</h2>
 </div>
 
+{% if errors %}
+<div class="message error">
+    <p>
+        <b>Warning:</b>
+        Our database is experiencing troubles, the data you see might
+        be wrong. We have been notified of the issue.
+    </p>
+
+    <ul>
+        {% for error in errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+    </ul>
+</div>
+{% endif %}
 
 <div class="panel daily_search">
     <div class="title daily_search_title">

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
@@ -22,7 +22,7 @@ Crashes per Day for {{ product }}
     <p>
         <b>Warning:</b>
         Our database is experiencing troubles, the data you see might
-        be wrong. We have been notified of the issue.
+        be wrong. The team has been notified of the issue.
     </p>
 
     <ul>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1127,7 +1127,7 @@ def crashes_per_day(request, default_context=None):
         week = int(error['index'][-2:])
         year = int(error['index'][-6:-2])
         day = isoweek.Week(year, week).monday()
-        percent = error['shards_count'] * 100 / 5
+        percent = error['shards_count'] * 100 / settings.ES_SHARDS_PER_INDEX
         errors.append(
             'The data for the week of {} is ~{}% lower than expected.'.format(
                 day, percent

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 from io import BytesIO
 
 import isodate
+import isoweek
 
 from django import http
 from django.conf import settings
@@ -1117,6 +1118,22 @@ def crashes_per_day(request, default_context=None):
     context['data_table'] = data_table
     context['graph_data'] = graph_data
     context['report'] = 'daily'
+
+    errors = []
+    for error in results.get('errors', []):
+        if not error['type'] == 'shards':
+            continue
+
+        week = int(error['index'][-2:])
+        year = int(error['index'][-6:-2])
+        day = isoweek.Week(year, week).monday()
+        percent = error['shards_count'] * 100 / 5
+        errors.append(
+            'The data for the week of {} is ~{}% lower than expected.'.format(
+                day, percent
+            )
+        )
+    context['errors'] = errors
 
     # This 'Crashes per User' report replaces an older version
     # of the report that produces near identical output, but does

--- a/webapp-django/crashstats/home/jinja2/home/home.html
+++ b/webapp-django/crashstats/home/jinja2/home/home.html
@@ -51,6 +51,7 @@ Crash Data for {{ product }}
             data-versions="{{ versions | to_json }}"
             data-platforms="{{ platforms | to_json }}"
             data-duration="{{ days }}"
+            data-es-shards-per-index="{{ es_shards_per_index }}"
         >
             <div class="message error hide"></div>
             <div id="homepage-graph-graph"></div>

--- a/webapp-django/crashstats/home/static/home/js/home.js
+++ b/webapp-django/crashstats/home/static/home/js/home.js
@@ -16,6 +16,19 @@ $(function () {
         };
     }
 
+    // Get the date of the first day of a specified year and week.
+    // Source: https://stackoverflow.com/a/16591175
+    function getDateOfISOWeek(y, w) {
+        var simple = new Date(Date.UTC(y, 0, 1 + (w - 1) * 7));
+        var dow = simple.getDay();
+        var ISOweekStart = simple;
+        if (dow <= 4)
+            ISOweekStart.setDate(simple.getDate() - simple.getDay() + 1);
+        else
+            ISOweekStart.setDate(simple.getDate() + 8 - simple.getDay());
+        return ISOweekStart;
+    }
+
     var COLORS = ['#6a3d9a', '#e31a1c', '#008800', '#1f78b4'];
 
     var container = $('#homepage-graph-container');
@@ -201,6 +214,12 @@ $(function () {
      * what we will pass to the graph library.
      */
     function onSuperSearchData(data) {
+        // If there are shards errors, show a warning to the user that the
+        // data is incorrect.
+        if (data.errors && data.errors.length) {
+            showShardsErrors(data.errors);
+        }
+
         // dataStruct is a temporary data structure that makes it easy to
         // add up crash counts and handle the special cases of beta versions.
         var dataStruct = {};
@@ -357,6 +376,35 @@ $(function () {
             .show()
             .empty()
             .append('Error validating argument "' + arg + '": ' + message);
+    }
+
+    function showShardsErrors(errors) {
+        $('.message', container)
+            .show()
+            .append(
+                $('<p><b>Warning:</b> Our database is experiencing troubles, the data you see might be wrong. We have been notified of the issue. </p>')
+            );
+
+        errors.forEach(function (error) {
+            if (error.type === 'shards') {
+                addShardWarning(error);
+            }
+        });
+    }
+
+    /**
+     * Show a warning when a shard is failing in the database.
+     */
+    function addShardWarning(error) {
+        var week = error.index.slice(-2);
+        var year = error.index.slice(-6, error.index.length - 2);
+        var firstDay = getDateOfISOWeek(year, week);
+        var percent = error.shards_count / 5 * 100; // because we have 5 shards per index
+
+        $('.message', container)
+            .append(
+                $('<p>The data for the week of ' + firstDay.toDateString() + ' is ~' + percent + '% lower than expected.</p>')
+            );
     }
 
     /**

--- a/webapp-django/crashstats/home/static/home/js/home.js
+++ b/webapp-django/crashstats/home/static/home/js/home.js
@@ -383,7 +383,7 @@ $(function () {
         $('.message', container)
             .show()
             .append(
-                $('<p><b>Warning:</b> Our database is experiencing troubles, the data you see might be wrong. We have been notified of the issue. </p>')
+                $('<p><b>Warning:</b> Our database is experiencing troubles, the data you see might be wrong. The team has been notified of the issue. </p>')
             );
 
         errors.forEach(function (error) {

--- a/webapp-django/crashstats/home/static/home/js/home.js
+++ b/webapp-django/crashstats/home/static/home/js/home.js
@@ -40,6 +40,7 @@ $(function () {
     var versions = container.data('versions');
     var platforms = container.data('platforms');
     var duration = container.data('duration');
+    var esShardsPerIndex = container.data('es-shards-per-index');
 
     var pageTitle = $('title').text();
 
@@ -399,7 +400,7 @@ $(function () {
         var week = error.index.slice(-2);
         var year = error.index.slice(-6, error.index.length - 2);
         var firstDay = getDateOfISOWeek(year, week);
-        var percent = error.shards_count / 5 * 100; // because we have 5 shards per index
+        var percent = error.shards_count * 100 / esShardsPerIndex;
 
         $('.message', container)
             .append(

--- a/webapp-django/crashstats/home/views.py
+++ b/webapp-django/crashstats/home/views.py
@@ -5,6 +5,7 @@ from django.views.generic.base import RedirectView
 
 from crashstats.crashstats.decorators import pass_default_context
 from crashstats.crashstats import models
+
 from . import forms
 
 
@@ -33,6 +34,8 @@ def home(request, product, default_context=None):
     platforms_api = models.Platforms()
     platforms = platforms_api.get()
     context['platforms'] = [x['name'] for x in platforms if x.get('display')]
+
+    context['es_shards_per_index'] = settings.ES_SHARDS_PER_INDEX
 
     return render(request, 'home/home.html', context)
 

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -349,6 +349,9 @@ BZAPI_BASE_URL = 'https://bugzilla.mozilla.org/rest'
 # Super Search Custom Query page.
 ELASTICSEARCH_INDEX_SCHEMA = 'socorro%Y%W'
 
+# Number of shards per index in our Elasticsearch database.
+ES_SHARDS_PER_INDEX = 5
+
 # Valid type for correlations reports
 CORRELATION_REPORT_TYPES = (
     'core-counts',


### PR DESCRIPTION
…s are failing.

This adds a big red warning to the home page and the crashes per day page when shards are failing in Elasticsearch. It requires #3400 to work. 

Here's what it looks like: 

![](http://adrian.gaudebert.fr/downloads/mozilla/shards-failure-msg-home.png)
![](http://adrian.gaudebert.fr/downloads/mozilla/shards-failure-msg-daily.png)

The simplest way to test it is to edit the ``supersearch.py`` middleware file and manually add errors right before returning the results. 