### PR TITLE
fixes bug 1289833 - Cache-Control on API responses

### DIFF
--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1822,6 +1822,8 @@ class ADI(SocorroMiddleware):
 
 class ProductBuildTypes(SocorroMiddleware):
 
+    cache_seconds = 60 * 60 * 24
+
     implementation = (
         socorro.external.postgresql.product_build_types.ProductBuildTypes
     )


### PR DESCRIPTION
First load of the home page (or refreshing the page):
<img width="1243" alt="screen shot 2016-07-27 at 12 53 49 pm" src="https://cloud.githubusercontent.com/assets/26739/17184237/324457de-53f9-11e6-8025-5de5e063ace2.png">

Second load of the home page (by click, not reloading):
<img width="1245" alt="screen shot 2016-07-27 at 12 54 55 pm" src="https://cloud.githubusercontent.com/assets/26739/17184267/59183fec-53f9-11e6-8aa2-709e09cbab1f.png">
