### PR TITLE
bug 1283285 - careful with request.user in context processor

### DIFF
--- a/webapp-django/crashstats/authentication/context_processors.py
+++ b/webapp-django/crashstats/authentication/context_processors.py
@@ -8,7 +8,7 @@ def oauth2(request):
     # By default we don't want to encourage the client-side code to
     # sign out, so set this to a falsy value.
     signout = False
-    if request.user.is_authenticated():
+    if getattr(request, 'user', None) and request.user.is_authenticated():
         # NOTE On the future; If we *had* a way to check if a member of
         # staff has ceased to be member of staff, here would be a
         # good place to ask that question. Then we could stop bothering

--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -165,7 +165,7 @@
         <div class="login">
             <ul>
                 <li>
-                {% if request.user.is_authenticated() %}
+                {% if request.user and request.user.is_authenticated() %}
                     <a href="{{ url('profile:profile') }}"
                       title="You are signed in as {{ request.user.email }}"
                     >

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -21,7 +21,6 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.utils import timezone
 from django.contrib.auth.models import (
     User,
-    AnonymousUser,
     Group,
     Permission
 )
@@ -549,8 +548,6 @@ class TestViews(BaseTestViews):
         # to make a mock call to the django view functions you need a request
         fake_request = RequestFactory().request(**{'wsgi.input': None})
         fake_request.session = {}
-        # Need a fake user for the persona bits on crashstats_base
-        fake_request.user = AnonymousUser()
 
         # the reason for first causing an exception to be raised is because
         # the handler500 function is only called by django when an exception


### PR DESCRIPTION
This just avoids the exception happening in the context processor if there's ever a `WSGIRequest` object that doesn't have a `user` attribute. 
I still don't know how that could happen but it's easy to write a test for at least. 