### PR TITLE
Update platforms for Android

### DIFF
--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -164,7 +164,7 @@ class ScrapersMixin(object):
 
         possible_platforms = (
             'linux', 'mac', 'win', 'debug',  # for Firefox
-            'android-api-11', 'android-api-9', 'android-x86',  # for mobile
+            'android-api-15', 'android-x86',  # for mobile
         )
 
         for platform in possible_platforms:


### PR DESCRIPTION
Firefox 48.0 dropped android-api-9, and 46.0 changed api-11 to api-15, so look for those when scraping. 

We may have been mis-identifying crashes - eg https://crash-stats.mozilla.com/report/index/b8b4676f-64af-497f-84c2-73e0f2160804 is '48.0 fennec on release', but report a buildID of 20160727164219 instead of 20160726133114. Meanwhile other crashes are fine - eg https://crash-stats.mozilla.com/report/index/99f5e6ce-f435-4e09-8953-baa122160804