### PR TITLE
fixes bug 1292143 - Bad escape on bug_ids to SignaturesByBug

### DIFF
--- a/socorro/external/postgresql/bugs.py
+++ b/socorro/external/postgresql/bugs.py
@@ -17,14 +17,18 @@ logger = logging.getLogger("webapi")
 class Bugs(PostgreSQLBase):
     """Implement the /bugs service with PostgreSQL. """
     filters = [
-        ("signatures", None, ["list", "str"]),
-        ("bug_ids", None, ["list", "str"]),
+        ("signatures", None, [str]),
+        ("bug_ids", None, [int]),
     ]
 
     def get(self, **kwargs):
         """Return a list of signatures-to-bug_ids or bug_ids-to-signatures
            associations. """
-        params = external_common.parse_arguments(self.filters, kwargs)
+        params = external_common.parse_arguments(
+            self.filters,
+            kwargs,
+            modern=True
+        )
 
         if not params['signatures'] and not params['bug_ids']:
             raise MissingArgumentError('specify one of signatures or bug_ids')

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -1340,7 +1340,7 @@ class SignaturesByBugs(SocorroMiddleware):
     implementation = socorro.external.postgresql.bugs.Bugs
 
     required_params = (
-        'bug_ids',
+        ('bug_ids', list),
     )
 
     API_WHITELIST = {

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -832,7 +832,7 @@ class TestModels(DjangoTestCase):
         api = model()
 
         def mocked_get(**options):
-            assert options == {'bug_ids': '123456789'}
+            assert options == {'bug_ids': ['123456789']}
             return {'hits': {'signatures': 'Pickle::ReadBytes'}}
 
         models.SignaturesByBugs.implementation().get.side_effect = mocked_get


### PR DESCRIPTION
Now you can type multiple bug IDs and if you type some non-integer junk it doesn't barf. 
<img width="1948" alt="screen shot 2016-08-04 at 9 13 09 am" src="https://cloud.githubusercontent.com/assets/26739/17403148/76b1b32c-5a24-11e6-8bc4-be606c2384ed.png">

<img width="1955" alt="screen shot 2016-08-04 at 9 17 51 am" src="https://cloud.githubusercontent.com/assets/26739/17403155/7d0a1138-5a24-11e6-808b-706db46997a2.png">

On prod you can only pass in one bug ID. The other ones are ignored:
<img width="907" alt="screen shot 2016-08-04 at 9 20 14 am" src="https://cloud.githubusercontent.com/assets/26739/17403195/bbf66fa4-5a24-11e6-895f-30b79d1e61df.png">
