### PR TITLE
Fixes bug 1290326 - Do not truncate signatures in Topcrashers.

### DIFF
--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -163,7 +163,7 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
                                     date=['<' + query.end_date.isoformat(), '>=' + query.start_date.isoformat()],
                                 ) }}" title="{{ crash.signature }}"
                             >
-                                {{ crash.signature | truncate(length=80, killwords=True) }}
+                                {{ crash.signature }}
                             </a>
                             <div class="sig-history-container hide">
                                 <input type="hidden" class='ajax-signature' name="ajax-signature-1" value="{{ crash.signature }}" />


### PR DESCRIPTION
@peterbe this doesn't break layout for me locally, using stage data. Does it for you? I think that's what we want to do anyway. It's simple and solves the problem. I don't think we care too much if sometimes the data overflows to the right. 