### PR TITLE
1295206 boto fakes3

### DIFF
--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -12,6 +12,7 @@ import boto.s3.connection
 import boto.exception
 
 from configman import Namespace, RequiredConfig, class_converter
+from configman.converters import str_to_boolean
 
 from socorrolib.lib.converters import change_default
 from socorrolib.lib.ooid import dateFromOoid
@@ -406,7 +407,7 @@ class HostPortS3ConnectionContext(S3ConnectionContext):
         'secure',
         doc='Whether to connect securely or not (true/false)',
         reference_value_from='resource.boto',
-        from_string_converter=lambda x: x.lower().startswith('t'),
+        from_string_converter=str_to_boolean,
         default=True,
     )
 

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -411,7 +411,6 @@ class HostPortS3ConnectionContext(S3ConnectionContext):
     )
 
     def _get_credentials(self):
-        print repr((self.config.secure, self.config.host, self.config.port))
         return {
             'aws_access_key_id': self.config.access_key,
             'aws_secret_access_key': self.config.secret_access_key,

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -379,3 +379,44 @@ class RegionalS3ConnectionContext(S3ConnectionContext):
                 **self._get_credentials()
             )
             return self.connection
+
+
+class HostPortS3ConnectionContext(S3ConnectionContext):
+    """Connection context for connecting to an S3-like service at a specified
+    host/port
+
+    This is useful if you're connecting to a fake s3 or minio or some other
+    non-S3 thing.
+
+    """
+
+    required_config = Namespace()
+    required_config.add_option(
+        'host',
+        doc='The hostname to connect to',
+        reference_value_from='resource.boto',
+    )
+    required_config.add_option(
+        'port',
+        doc='The network port',
+        reference_value_from='resource.boto',
+        from_string_converter=int
+    )
+    required_config.add_option(
+        'secure',
+        doc='Whether to connect securely or not (true/false)',
+        reference_value_from='resource.boto',
+        from_string_converter=lambda x: x.lower().startswith('t'),
+        default=True,
+    )
+
+    def _get_credentials(self):
+        print repr((self.config.secure, self.config.host, self.config.port))
+        return {
+            'aws_access_key_id': self.config.access_key,
+            'aws_secret_access_key': self.config.secret_access_key,
+            'is_secure': self.config.secure,
+            'calling_format': self._calling_format(),
+            'host': self.config.host,
+            'port': self.config.port,
+        }

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -315,26 +315,6 @@ class ConnectionContextBase(RequiredConfig):
 
 
 #==============================================================================
-class ConnectionContextWithHostAndPortBase(RequiredConfig):
-    """an alternative base class that specific implementations of Boto
-    connection can derive.  It adds "host" and "port" to the configuration"""
-
-    required_config = Namespace()
-    required_config.add_option(
-        'host',
-        doc="The hostname (leave empty for AWS)",
-        default="",
-        reference_value_from='resource.boto',
-    )
-    required_config.add_option(
-        'port',
-        doc="The network port (leave at 0 for AWS)",
-        default=0,
-        reference_value_from='resource.boto',
-    )
-
-
-#==============================================================================
 class S3ConnectionContext(ConnectionContextBase):
     """This derived class includes the specifics for connection to S3"""
     required_config = Namespace()

--- a/socorro/unittest/external/boto/test_connection_context.py
+++ b/socorro/unittest/external/boto/test_connection_context.py
@@ -240,8 +240,8 @@ class ConnectionContextTestCase(socorro.unittest.testbase.TestCase):
         conn = self.setup_mocked_s3_storage(
             resource_class=HostPortS3ConnectionContext,
             host='localhost',
-            port='4569',
-            secure='True',
+            port=4569,
+            secure=True,
         )
         conn.fetch(
             'name_of_thing',
@@ -250,7 +250,7 @@ class ConnectionContextTestCase(socorro.unittest.testbase.TestCase):
         kwargs = {
             'aws_access_key_id': conn.config.access_key,
             'aws_secret_access_key': conn.config.secret_access_key,
-            'calling_format': conn.config._calling_format.return_value,
+            'calling_format': conn._calling_format.return_value,
             'host': 'localhost',
             'port': 4569,
             'is_secure': True,
@@ -263,8 +263,8 @@ class ConnectionContextTestCase(socorro.unittest.testbase.TestCase):
         conn = self.setup_mocked_s3_storage(
             resource_class=HostPortS3ConnectionContext,
             host='localhost',
-            port='4569',
-            secure='False',
+            port=4569,
+            secure=False,
         )
         conn.fetch(
             'name_of_thing',
@@ -273,7 +273,7 @@ class ConnectionContextTestCase(socorro.unittest.testbase.TestCase):
         kwargs = {
             'aws_access_key_id': conn.config.access_key,
             'aws_secret_access_key': conn.config.secret_access_key,
-            'calling_format': conn.config._calling_format.return_value,
+            'calling_format': conn._calling_format.return_value,
             'host': 'localhost',
             'port': 4569,
             'is_secure': False,

--- a/socorro/unittest/external/boto/test_connection_context.py
+++ b/socorro/unittest/external/boto/test_connection_context.py
@@ -16,6 +16,7 @@ from socorro.external.boto.connection_context import (
     KeyNotFound,
     S3ConnectionContext,
     RegionalS3ConnectionContext,
+    HostPortS3ConnectionContext,
 )
 from socorro.database.transaction_executor import (
     TransactionExecutor,
@@ -232,6 +233,53 @@ class ConnectionContextTestCase(socorro.unittest.testbase.TestCase):
         self.assert_regional_s3_connection_parameters(
             'us-south-3',
             connection_source
+        )
+
+    def test_HostPortS3ConnectionContext_host_port_secure(self):
+        # Test with secure=True
+        conn = self.setup_mocked_s3_storage(
+            resource_class=HostPortS3ConnectionContext,
+            host='localhost',
+            port='4569',
+            secure='True',
+        )
+        conn.fetch(
+            'name_of_thing',
+            'this_is_an_id'
+        )
+        kwargs = {
+            'aws_access_key_id': conn.config.access_key,
+            'aws_secret_access_key': conn.config.secret_access_key,
+            'calling_format': conn.config._calling_format.return_value,
+            'host': 'localhost',
+            'port': 4569,
+            'is_secure': True,
+        }
+        conn._connect_to_endpoint.assert_called_with(
+            **kwargs
+        )
+
+        # Test with secure=False
+        conn = self.setup_mocked_s3_storage(
+            resource_class=HostPortS3ConnectionContext,
+            host='localhost',
+            port='4569',
+            secure='False',
+        )
+        conn.fetch(
+            'name_of_thing',
+            'this_is_an_id'
+        )
+        kwargs = {
+            'aws_access_key_id': conn.config.access_key,
+            'aws_secret_access_key': conn.config.secret_access_key,
+            'calling_format': conn.config._calling_format.return_value,
+            'host': 'localhost',
+            'port': 4569,
+            'is_secure': False,
+        }
+        conn._connect_to_endpoint.assert_called_with(
+            **kwargs
         )
 
 


### PR DESCRIPTION
Implements boto HostPortS3ConnectionContext so that we can connect to a local fake s3. This will make it easier to do development work without requiring that we have S3 buckets and a network connection.

r?