### PR TITLE
Bug 1293776 initial pass on StatsdMetrics

### DIFF
--- a/socorro/collector/collector_app.py
+++ b/socorro/collector/collector_app.py
@@ -81,6 +81,17 @@ class CollectorApp(BaseCollectorApp):
         from_string_converter=class_converter
     )
     #--------------------------------------------------------------------------
+    # metrics namespace
+    #     the namespace is for config parameters for the metrics system
+    #--------------------------------------------------------------------------
+    required_config.namespace('metrics')
+    required_config.metrics.add_option(
+        'metrics_class',
+        default='socorro.external.metrics_base.MetricsBase',
+        doc='the class that implements metrics; no value means no metrics',
+        from_string_converter=class_converter
+    )
+    #--------------------------------------------------------------------------
     # storage namespace
     #     the namespace is for config parameters crash storage
     #--------------------------------------------------------------------------
@@ -106,6 +117,9 @@ class CollectorApp(BaseCollectorApp):
         )
         self.config.throttler = self.config.throttler.throttler_class(
             self.config.throttler
+        )
+        self.config.metrics = self.config.metrics.metrics_class(
+            self.config.metrics
         )
         self.web_server = self.config.web_server.wsgi_server_class(
             self.config,  # needs the whole config not the local namespace

--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -91,14 +91,15 @@ class BreakpadCollectorBase(GenericCollectorBase):
         else:
             raw_crash.legacy_processing = int(raw_crash.legacy_processing)
 
-        # We want to capture the crash report size, but need to differentiate
-        # between compressed vs. uncompressed data as well as accepted vs.
-        # rejected data.
-        crash_report_size = self._get_content_length()
-        is_compressed = self._is_content_gzipped()
-        is_accepted = (raw_crash.legacy_processing in (ACCEPT, DEFER))
 
         try:
+            # We want to capture the crash report size, but need to
+            # differentiate between compressed vs. uncompressed data as well as
+            # accepted vs. rejected data.
+            crash_report_size = self._get_content_length()
+            is_compressed = self._is_content_gzipped()
+            is_accepted = (raw_crash.legacy_processing in (ACCEPT, DEFER))
+
             metrics_data = {}
             size_key = '_'.join([
                 'crash_report_size',
@@ -109,12 +110,11 @@ class BreakpadCollectorBase(GenericCollectorBase):
                 size_key: crash_report_size
             }
             self.metrics.capture_stats(metrics_data)
-        except Exception as exc:
+        except Exception:
             # We *never* want metrics reporting to prevent saving a crash, so
             # we catch everything and log an error.
             self.logger.error(
-                'metrics kicked up exception: %s',
-                str(exc),
+                'metrics kicked up exception',
                 exc_info=True
             )
 

--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -191,6 +191,17 @@ class BreakpadCollector2015(BreakpadCollectorBase):
         from_string_converter=class_converter
     )
     #--------------------------------------------------------------------------
+    # metrics namespace
+    #     the namespace is for config parameters for the metrics system
+    #--------------------------------------------------------------------------
+    required_config.namespace('metrics')
+    required_config.metrics.add_option(
+        'metrics_class',
+        default='socorro.external.metrics_base.MetricsBase',
+        doc='the class that implements metrics; no value means no metrics',
+        from_string_converter=class_converter
+    )
+    #--------------------------------------------------------------------------
     # storage namespace
     #     the namespace is for config parameters crash storage
     #--------------------------------------------------------------------------
@@ -211,6 +222,15 @@ class BreakpadCollector2015(BreakpadCollectorBase):
             self.config.throttler.throttler_instance = \
                 self.config.throttler.throttler_class(self.config.throttler)
             return self.config.throttler.throttler_instance
+
+    #--------------------------------------------------------------------------
+    def _get_metrics(self):
+        try:
+            return self.config.metrics.metrics_instance
+        except KeyError:
+            self.config.metrics.metrics_instance = \
+                self.config.metrics.metrics_class(self.config.metrics)
+            return self.config.metrics.metrics_instance
 
     #--------------------------------------------------------------------------
     def _get_crash_storage(self):

--- a/socorro/collector/wsgi_generic_collector.py
+++ b/socorro/collector/wsgi_generic_collector.py
@@ -64,10 +64,18 @@ class GenericCollectorBase(RequiredConfig):
             return fs
 
     #--------------------------------------------------------------------------
+    def _is_content_gzipped(self):
+        return web.ctx.env.get('HTTP_CONTENT_ENCODING') == 'gzip'
+
+    #--------------------------------------------------------------------------
+    def _get_content_length(self):
+        return web.ctx.env.get('CONTENT_LENGTH', 0)
+
+    #--------------------------------------------------------------------------
     def _form_as_mapping(self):
         """this method returns the POST form mapping with any gzip
         decompression automatically handled"""
-        if web.ctx.env.get('HTTP_CONTENT_ENCODING') == 'gzip':
+        if self._is_content_gzipped():
             # Handle gzipped form posts
             gzip_header = 16 + zlib.MAX_WBITS
             data = zlib.decompress(web.webapi.data(), gzip_header)

--- a/socorro/external/metrics_base.py
+++ b/socorro/external/metrics_base.py
@@ -18,7 +18,7 @@ class MetricsBase(RequiredConfig):
 
     Subclasses should implement::
 
-        def capture_data(self, raw_crash, dumps, crash_id)
+        def capture_stats(self, data_items):
 
 
     This method should never throw an exception. This method should return

--- a/socorro/external/metrics_base.py
+++ b/socorro/external/metrics_base.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module holds the metrics base class. This is used in the collector.
+
+"""
+
+from configman import RequiredConfig, Namespace
+
+
+class MetricsBase(RequiredConfig):
+    """Base class for Metrics as well as a no-op default
+
+    This is used by the collector on incoming crashes so that we can collect
+    metrics on them. This data can be logged, sent to statsd,
+    etc--functionality implemented by subclasses of this class.
+
+    Subclasses should implement::
+
+        def capture_data(self, raw_crash, dumps, crash_id)
+
+
+    This method should never throw an exception. This method should return
+    nothing.
+
+    """
+
+    required_config = Namespace()
+
+    def __init__(self, config):
+        super(MetricsBase, self).__init__()
+        self.config = config
+
+    def capture_stats(self, data_items):
+        """Takes a dict of values to capture
+
+        This is for measuring the statistical distribution of a set of values
+        over time. For example, crash sizes or db query durations.
+
+        :arg data_items: dict of key/value pairs; values are always ints
+
+        """
+        pass

--- a/socorro/external/statsd/dogstatsd.py
+++ b/socorro/external/statsd/dogstatsd.py
@@ -22,6 +22,11 @@ class StatsClient(object):
         return statsd.increment(name)
 
     #--------------------------------------------------------------------------
+    def histogram(self, name, value):
+        # histogram is a datadog statsd extension. It's kind of like timing,
+        # but operates on values other than durations.
+        return statsd.histogram(name, value)
+
+    #--------------------------------------------------------------------------
     def __getattr__(self, attr):
         return getattr(statsd, attr)
-

--- a/socorro/external/statsd/metrics.py
+++ b/socorro/external/statsd/metrics.py
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module holds statsd metrics classes. Currently these are used in the
+collector.
+
+"""
+
+from configman import Namespace, class_converter
+from socorro.external.metrics_base import MetricsBase
+
+
+class StatsdMetrics(MetricsBase):
+    """Metrics component that sends data to statsd
+
+    """
+    required_config = Namespace()
+    required_config.add_option(
+        'statsd_class',
+        doc='the fully qualified name of the statsd client',
+        default='socorro.external.statsd.dogstatsd.StatsClient',
+        reference_value_from='resource.statsd',
+        from_string_converter=class_converter,
+    )
+    required_config.add_option(
+        'statsd_host',
+        doc='the hostname of statsd',
+        default='',
+        reference_value_from='resource.statsd',
+    )
+    required_config.add_option(
+        'statsd_port',
+        doc='the port number for statsd',
+        default=8125,
+        reference_value_from='resource.statsd',
+    )
+    required_config.add_option(
+        'statsd_prefix',
+        doc='a string to be used as the prefix for statsd names',
+        default='save_processed',
+        reference_value_from='resource.statsd',
+    )
+
+    def __init__(self, config):
+        super(StatsdMetrics, self).__init__(config)
+
+        if config.statsd_prefix:
+            self.prefix = config.statsd_prefix
+        else:
+            self.prefix = ''
+
+        self.statsd = self.config.statsd_class(
+            config.statsd_host,
+            config.statsd_port,
+            self.prefix
+        )
+
+        # Cache whether the statds client has a .histogram() method or not.
+        self._has_histogram = hasattr(self.statsd, 'histogram')
+
+    def capture_stats(self, data_items):
+        for key, val in sorted(data_items.items()):
+            if self._has_histogram:
+                # .histogram() is a dogstatsd enhancement to statsd, so we can
+                # only use it with dogstatsd.
+                self.statsd.histogram(key, val)
+            else:
+                # .timing() takes a value which is a duration in milliseconds,
+                # but we're going to use it for non duration type values, too.
+                self.statsd.timing(key, int(val))

--- a/socorro/unittest/collector/test_collector_app.py
+++ b/socorro/unittest/collector/test_collector_app.py
@@ -30,6 +30,12 @@ class TestCollectorApp(TestCase):
             return_value=self.mocked_throttler
         )
 
+        config.metrics = DotDict()
+        self.mocked_metrics = mock.MagicMock()
+        config.metrics.metrics_class = mock.MagicMock(
+            return_value=self.mocked_metrics
+        )
+
         config.storage = mock.MagicMock()
         self.mocked_crash_storage = mock.MagicMock()
         config.storage.crashstorage_class = mock.MagicMock(

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -34,6 +34,7 @@ class TestWSGIBreakpadCollector(TestCase):
         config.logger = mock.MagicMock()
 
         config.throttler = mock.MagicMock()
+        config.metrics = mock.MagicMock()
 
         config.collector = DotDict()
         config.collector.collector_class = BreakpadCollector
@@ -112,6 +113,11 @@ class TestWSGIBreakpadCollector(TestCase):
         erc.type_tag = 'bp'
         erc = dict(erc)
 
+        mocked_web.ctx.configure_mock(
+            env={
+                'CONTENT_LENGTH': 1000
+            }
+        )
         mocked_web.input.return_value = form
         mocked_webapi.rawinput.return_value = rawform
         mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
@@ -126,6 +132,9 @@ class TestWSGIBreakpadCollector(TestCase):
             {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
             r[11:-1]
         )
+
+        # Verify metrics were captured and .capture_stats() was called.
+        config.metrics.capture_stats.assert_called_with({'size': 1000})
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
     @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
@@ -477,6 +486,7 @@ aux_dump contents
         mocked_web_ctx.configure_mock(
             env={
                 'HTTP_CONTENT_ENCODING': 'gzip',
+                'CONTENT_LENGTH': 1000,
                 'CONTENT_ENCODING': 'gzip',
                 'CONTENT_TYPE':
                     'multipart/form-data; boundary="socorro1234567"',
@@ -496,6 +506,7 @@ aux_dump contents
             {'dump':'fake dump', 'aux_dump':'aux_dump contents'},
             r[11:-1]
         )
+        config.metrics.capture_stats.assert_called_with({'size_compressed': 1000})
 
     def test_no_x00_character(self):
         config = self.get_standard_config()
@@ -504,6 +515,68 @@ aux_dump contents
         eq_(c._no_x00_character('\x00hello'), 'hello')
         eq_(c._no_x00_character(u'\u0000bye'), 'bye')
         eq_(c._no_x00_character(u'\u0000\x00bye'), 'bye')
+
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
+    @mock.patch('socorro.collector.wsgi_breakpad_collector.utc_now')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web.webapi')
+    @mock.patch('socorro.collector.wsgi_generic_collector.web')
+    def test_bad_capture_stats(self, mocked_web, mocked_webapi, mocked_utc_now, mocked_time):
+        """Verify that a misbehaving capture_stats doesn't prevent collection"""
+        config = self.get_standard_config()
+
+        class MisbehavingMetrics(object):
+            def __init__(self, config):
+                self.capture_stats_calls = 0
+
+            def capture_stats(self, stats):
+                # Register that this was called
+                self.capture_stats_calls += 1
+                # Throw an exception because we're a misbehaving metrics
+                raise Exception('ou812')
+
+        config.metrics = MisbehavingMetrics(config)
+
+        c = BreakpadCollector(config)
+        rawform = DotDict()
+        rawform.ProductName = '\x00FireSquid'
+        rawform.Version = '99'
+        rawform.dump = DotDict({'value': 'fake dump', 'file': 'faked file'})
+
+        form = DotDict(rawform)
+        form.dump = rawform.dump.value
+
+        erc = DotDict()
+        erc.ProductName = 'FireSquid'
+        erc.Version = '99'
+        # erc.some_field = '23'
+        # erc.some_other_field = 'XYZ'
+        erc.legacy_processing = ACCEPT
+        erc.timestamp = 3.0
+        erc.submitted_timestamp = '2012-05-04T15:10:00'
+        erc.throttle_rate = 100
+        erc.dump_checksums = {
+            'dump': '2036fd064f93a0d086cf236c5f0fd8d4',
+            'aux_dump': 'aa2e5bf71df8a4730446b2551d29cb3a',
+        }
+        erc.type_tag = 'bp'
+        erc = dict(erc)
+
+        mocked_web.ctx.configure_mock(
+            env={
+                'CONTENT_LENGTH': 1000
+            }
+        )
+        mocked_web.input.return_value = form
+        mocked_webapi.rawinput.return_value = rawform
+        mocked_utc_now.return_value = datetime(2012, 5, 4, 15, 10)
+        mocked_time.time.return_value = 3.0
+        c.throttler.throttle.return_value = (ACCEPT, 100)
+        r = c.POST()
+
+        # Verify capture_stats was called
+        eq_(config.metrics.capture_stats_calls, 1)
+        ok_(r.startswith('CrashID=bp-'))
+
 
 
 class TestWSGIBreakpadCollector2015(TestCase):
@@ -514,6 +587,7 @@ class TestWSGIBreakpadCollector2015(TestCase):
         config.logger = mock.MagicMock()
 
         config.throttler = mock.MagicMock()
+        config.metrics = mock.MagicMock()
 
         config.collector_class = BreakpadCollector2015
         config.dump_id_prefix = 'bp-'

--- a/socorro/unittest/external/statsd/test_metrics.py
+++ b/socorro/unittest/external/statsd/test_metrics.py
@@ -1,0 +1,73 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from mock import patch, call, Mock
+from nose.tools import eq_, ok_, assert_raises
+from socorro.unittest.testbase import TestCase
+
+from datetime import datetime
+
+from configman.dotdict import DotDict
+import statsd
+
+from socorro.external.statsd.crashstorage import (
+    StatsdCrashStorage,
+    StatsdBenchmarkingCrashStorage,
+)
+from socorro.external.statsd import dogstatsd
+from socorro.external.statsd.metrics import StatsdMetrics
+
+
+class TestStatsdMetrics(TestCase):
+    def setup_config(self, statsd_class):
+        config = DotDict()
+        config.statsd_class = statsd_class
+        config.statsd_host = 'localhost'
+        config.statsd_port = 3333
+        config.statsd_prefix = 'prefix'
+        return config
+
+    def test_capture_stats_with_dogstatsd(self):
+        """Tests with dogstatsd StatsClient.
+
+        Verifies .histogram() is called once for every key/val pair.
+
+        """
+        config = self.setup_config(statsd_class=dogstatsd.StatsClient)
+
+        with patch('socorro.external.statsd.dogstatsd.statsd') as statsd_obj:
+            statsd_metrics = StatsdMetrics(config)
+            statsd_metrics.capture_stats(
+                {'foo': 5, 'bar': 10}
+            )
+
+            statsd_obj.histogram.assert_has_calls([
+                call('bar', 10),
+                call('foo', 5),
+            ])
+
+    def test_capture_stats_with_statsd(self):
+        """Tests with statsd StatsClient
+
+        Verifies:
+
+        * that .timing() gets called once for every key/val pair
+        * that non-ints are converted to ints
+
+        """
+        config = self.setup_config(statsd_class=statsd.StatsClient)
+
+        statsd_mock = Mock()
+        statsd_metrics = StatsdMetrics(config)
+
+        # Swap out the statsd client instance with a mock
+        statsd_metrics.statsd = statsd_mock
+        statsd_metrics.capture_stats(
+            {'foo': 5, 'bar': 5.0}
+        )
+
+        statsd_mock.timing.assert_has_calls([
+            call('bar', 5),
+            call('foo', 5),
+        ])

--- a/socorro/unittest/external/test_metrics_base.py
+++ b/socorro/unittest/external/test_metrics_base.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from configman import Namespace, ConfigurationManager
+
+from socorro.unittest.testbase import TestCase
+from socorro.external.metrics_base import MetricsBase
+
+
+class TestMetricsBase(TestCase):
+    def test_init(self):
+        # This is a really basic test to make sure initialization works since
+        # it can be used as a no-op class.
+        required_config = Namespace()
+        required_config.update(MetricsBase.required_config)
+
+        config_manager = ConfigurationManager(
+            [required_config],
+            app_name='testapp',
+            app_version='1.0',
+            app_description='app description',
+            values_source_list=[],
+            argv_source=[]
+        )
+
+        with config_manager.context() as config:
+            # Does it initialize without errors?
+            metrics = MetricsBase(config)
+
+            # Does it run capture_stats without errors?
+            data_items = {'foo': 5}
+            metrics.capture_stats(data_items)


### PR DESCRIPTION
This creates a new kind of external component called Metrics. It gets used in the breakpad collector after saving the crash to log data about the incoming crash at the point we've collected it.

r?