### PR TITLE
fixes bug 1297684 - force LocMemCache in tests

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -25,7 +25,6 @@ from django.contrib.auth.models import (
     Permission
 )
 from django.core.cache import cache
-from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
 

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -280,10 +280,8 @@ class BaseTestViews(DjangoTestCase):
     def setUp(self, rget):
         super(BaseTestViews, self).setUp()
 
-        if 'LocMemCache' not in settings.CACHES['default']['BACKEND']:
-            raise ImproperlyConfigured(
-                'The tests requires that you use LocMemCache when running'
-            )
+        # Tests assume and require a non-persistent cache backend
+        assert 'LocMemCache' in settings.CACHES['default']['BACKEND']
 
         def mocked_platforms_get(**options):
             return {

--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -32,6 +32,12 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}
+
 # Because this is for running tests, we use the simplest hasher possible.
 PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.MD5PasswordHasher',


### PR DESCRIPTION
@adngdb ,
what's neat about this is that you can now have memcache in your `.env` (or leave it out and let it be the default from `settings/base.py`) so that when you do a lot of runserver work it's able to cache things after runserver restarts. 

