### PR TITLE
fixes bug 1283296 - Redirect back after sign-in

### DIFF
--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -38,6 +38,27 @@ def login_required(
     return actual_decorator
 
 
+def superuser_required(
+    function=None,
+    redirect_field_name=REDIRECT_FIELD_NAME,
+    login_url=None
+):
+    """Same logic as in login_required() (see doc string above) but with
+    the additional check that we require you to be superuser also.
+    """
+
+    def check_user(user):
+        return user.is_active and user.is_superuser
+
+    actual_decorator = user_passes_test(
+        check_user,
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        return actual_decorator(function)
+    return actual_decorator
+
 _marker = object()
 
 

--- a/webapp-django/crashstats/crashstats/decorators.py
+++ b/webapp-django/crashstats/crashstats/decorators.py
@@ -38,27 +38,6 @@ def login_required(
     return actual_decorator
 
 
-def superuser_required(
-    function=None,
-    redirect_field_name=REDIRECT_FIELD_NAME,
-    login_url=None
-):
-    """Same logic as in login_required() (see doc string above) but with
-    the additional check that we require you to be superuser also.
-    """
-
-    def check_user(user):
-        return user.is_active and user.is_superuser
-
-    actual_decorator = user_passes_test(
-        check_user,
-        login_url=login_url,
-        redirect_field_name=redirect_field_name
-    )
-    if function:
-        return actual_decorator(function)
-    return actual_decorator
-
 _marker = object()
 
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/login.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/login.html
@@ -1,13 +1,20 @@
 {% extends "crashstats_base.html" %}
 
 {% block page_title %}
-{% if request.user.is_authenticated() %}Insufficient Privileges{% else %}Login Required{% endif %}
+{% if request.user.is_active %}Insufficient Privileges{% else %}Login Required{% endif %}
 {% endblock %}
 
 {% block content %}
+
+{% if redirect_from %}
+    <div style="display:none">
+        <input type="hidden" name="redirect_from" value="{{ redirect_from }}"/>
+    </div>
+{% endif %}
+
 <div id="mainbody">
 <div class="page-heading">
-    {% if request.user.is_authenticated() %}
+    {% if request.user.is_active %}
     <h2>Insufficient Privileges</h2>
     {% else %}
     <h2>Login Required</h2>
@@ -16,15 +23,15 @@
 
 <div class="panel">
     <div class="body">
-        {% if request.user.is_authenticated() %}
-                <p>
-                  You are signed in but you do not have sufficient permissions to reach the resource you requested.
-                </p>
-	{% else %}
-            <p>
-              The page you requested requires authentication. Use the login button at the lower right to log in.
-            </p>
-	{% endif %}
+    {% if request.user.is_authenticated() %}
+        <p>
+          You are signed in but you do not have sufficient permissions to reach the resource you requested.
+        </p>
+    {% else %}
+        <p>
+          The page you requested requires authentication. Use the login button at the lower right to log in.
+        </p>
+    {% endif %}
     </div>
 </div>
 

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/login.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/login.html
@@ -6,12 +6,6 @@
 
 {% block content %}
 
-{% if redirect_from %}
-    <div style="display:none">
-        <input type="hidden" name="redirect_from" value="{{ redirect_from }}"/>
-    </div>
-{% endif %}
-
 <div id="mainbody">
 <div class="page-heading">
     {% if request.user.is_active %}

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
@@ -59,15 +59,21 @@ var OAuth2 = (function() {
     };
 
     /* http://stackoverflow.com/a/901144/205832 */
-    var getParameterByName = function getParameterByName(name, url) {
-        if (!url) url = window.location.href;
+    function getParameterByName(name, url) {
+        if (!url) {
+            url = window.location.href;
+        }
         name = name.replace(/[\[\]]/g, "\\$&");
-        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-            results = regex.exec(url);
-        if (!results) return null;
-        if (!results[2]) return '';
+        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)");
+        var results = regex.exec(url);
+        if (!results) {
+            return null;
+        }
+        if (!results[2]) {
+            return '';
+        }
         return decodeURIComponent(results[2].replace(/\+/g, " "));
-    };
+    }
 
     return {
         init: function() {

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
@@ -58,7 +58,6 @@ var OAuth2 = (function() {
         });
     };
 
-
     /* http://stackoverflow.com/a/901144/205832 */
     var getParameterByName = function getParameterByName(name, url) {
         if (!url) url = window.location.href;
@@ -123,12 +122,14 @@ var OAuth2 = (function() {
                         .done(function(response) {
                             // It worked!
                             var next = getParameterByName('next');
+                            // only if ?next=/... exists on the current URL
                             if (next) {
                                 // A specific URL exits.
                                 // This is most likely the case when you tried
                                 // to access a privileged URL whilst being
                                 // anonymous and being redirected.
-                                document.location.href = next;
+                                // Make sure it's on this server
+                                document.location.pathname = next;
                             } else {
                                 document.location.reload();
                             }

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
@@ -58,23 +58,6 @@ var OAuth2 = (function() {
         });
     };
 
-    /* http://stackoverflow.com/a/901144/205832 */
-    function getParameterByName(name, url) {
-        if (!url) {
-            url = window.location.href;
-        }
-        name = name.replace(/[\[\]]/g, "\\$&");
-        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)");
-        var results = regex.exec(url);
-        if (!results) {
-            return null;
-        }
-        if (!results[2]) {
-            return '';
-        }
-        return decodeURIComponent(results[2].replace(/\+/g, " "));
-    }
-
     return {
         init: function() {
             // The "signin" meta tag, and its value being "signout"
@@ -127,7 +110,9 @@ var OAuth2 = (function() {
                         $.post(url, data)
                         .done(function(response) {
                             // It worked!
-                            var next = getParameterByName('next');
+                            var next = Qs.parse(
+                                document.location.search.slice(1)
+                            ).next;
                             // only if ?next=/... exists on the current URL
                             if (next) {
                                 // A specific URL exits.

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/oauth2.js
@@ -58,6 +58,18 @@ var OAuth2 = (function() {
         });
     };
 
+
+    /* http://stackoverflow.com/a/901144/205832 */
+    var getParameterByName = function getParameterByName(name, url) {
+        if (!url) url = window.location.href;
+        name = name.replace(/[\[\]]/g, "\\$&");
+        var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+            results = regex.exec(url);
+        if (!results) return null;
+        if (!results[2]) return '';
+        return decodeURIComponent(results[2].replace(/\+/g, " "));
+    };
+
     return {
         init: function() {
             // The "signin" meta tag, and its value being "signout"
@@ -110,8 +122,16 @@ var OAuth2 = (function() {
                         $.post(url, data)
                         .done(function(response) {
                             // It worked!
-                            // TODO: https://bugzilla.mozilla.org/show_bug.cgi?id=1283296
-                            document.location.reload();
+                            var next = getParameterByName('next');
+                            if (next) {
+                                // A specific URL exits.
+                                // This is most likely the case when you tried
+                                // to access a privileged URL whilst being
+                                // anonymous and being redirected.
+                                document.location.href = next;
+                            } else {
+                                document.location.reload();
+                            }
                         })
                         .fail(function(xhr) {
                             console.error(xhr);

--- a/webapp-django/crashstats/manage/decorators.py
+++ b/webapp-django/crashstats/manage/decorators.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.decorators import (
+    REDIRECT_FIELD_NAME,
+    user_passes_test,
+)
+
+
+def superuser_required(
+    function=None,
+    redirect_field_name=REDIRECT_FIELD_NAME,
+    login_url=None
+):
+    """Same logic as in login_required() (see doc string above) but with
+    the additional check that we require you to be superuser also.
+    """
+
+    def check_user(user):
+        return user.is_active and user.is_superuser
+
+    actual_decorator = user_passes_test(
+        check_user,
+        login_url=login_url,
+        redirect_field_name=redirect_field_name
+    )
+    if function:
+        return actual_decorator(function)
+    return actual_decorator

--- a/webapp-django/crashstats/manage/tests/test_views.py
+++ b/webapp-django/crashstats/manage/tests/test_views.py
@@ -93,7 +93,10 @@ class TestViews(BaseTestViews):
         self._login(is_superuser=False)
         response = self.client.get(home_url, follow=True)
         assert response.status_code == 200
-        ok_('You need to be a superuser to access this' in response.content)
+        ok_(
+            'You are signed in but you do not have sufficient permissions '
+            'to reach the resource you requested.' in response.content
+        )
 
     def test_home_page_signed_in(self):
         user = self._login()

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -37,7 +37,7 @@ from crashstats.tokens.models import Token
 from crashstats.status.models import StatusMessage
 from crashstats.symbols.models import SymbolsUpload
 from crashstats.crashstats.utils import json_view
-from crashstats.crashstats.decorators import superuser_required
+from crashstats.manage.decorators import superuser_required
 
 from . import forms
 from . import utils

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -1,6 +1,5 @@
 import collections
 import copy
-import functools
 import hashlib
 import math
 import urllib
@@ -38,6 +37,7 @@ from crashstats.tokens.models import Token
 from crashstats.status.models import StatusMessage
 from crashstats.symbols.models import SymbolsUpload
 from crashstats.crashstats.utils import json_view
+from crashstats.crashstats.decorators import superuser_required
 
 from . import forms
 from . import utils
@@ -84,21 +84,6 @@ def notice_change(before, after):
                 changes[fieldname] = [v1, v2]
         return changes
     raise NotImplementedError(before.__class__.__name__)
-
-
-def superuser_required(view_func):
-    @functools.wraps(view_func)
-    def inner(request, *args, **kwargs):
-        if not request.user.is_active:
-            return redirect(settings.LOGIN_URL)
-        elif not request.user.is_superuser:
-            messages.error(
-                request,
-                'You need to be a superuser to access this.'
-            )
-            return redirect('home:home', settings.DEFAULT_PRODUCT)
-        return view_func(request, *args, **kwargs)
-    return inner
 
 
 @superuser_required


### PR DESCRIPTION
The two major changes here are:

1) The oauth2.js code now seeks out a `?next=/some/url` if available and redirects to that instead of doing `document.location.reload()`.

2) The `superuser_required` decorator is rewritten. One of the reasons we wrote our our (a long time ago) was to do two things: A) check that you're signed in AND superuser and B) if you're not a superuser store a flash message. By instead using the well-tested one in django.contrib.auth.dectorators we get the `?next=/admin/` for example when you try to access a superuser protected view. However the flash message is lost but the login page already has a message for those who are signed in but not allowed all the way in. 

