### PR TITLE
fixes bug 1137376 - symbols upload page public

### DIFF
--- a/webapp-django/crashstats/symbols/jinja2/symbols/api_upload.html
+++ b/webapp-django/crashstats/symbols/jinja2/symbols/api_upload.html
@@ -24,12 +24,23 @@
         <h2>Scripted API Upload</h2>
     </div>
     <div class="body">
-        {% if has_possible_token %}
-        <p>
-            Now that you have an actively working
-            <a href="{{ url('tokens:home') }}">API Token</a> that has the
-            <code>{{ required_permission.name }}</code> permission you can use the API to upload your symbols files.
-        </p>
+        {% if has_possible_token or not request.user.is_active %}
+            {% if has_possible_token %}
+                <!-- Signed in, has a possible API token to use -->
+                <p>
+                    Now that you have an actively working
+                    <a href="{{ url('tokens:home') }}">API Token</a> that has the
+                    <code>{{ required_permission.name }}</code> permission you can use the API to upload your symbols files.
+                </p>
+            {% else %}
+                <!-- Not signed in -->
+                <p>
+                    <b>Note!</b>
+                    To be able to upload symbols you need to have an
+                    <a href="{{ url('tokens:home') }}"><b>API Token</b></a>.
+                    To generate one you need to have the <code>{{ required_permission.name }}</code> permission.
+                </p>
+            {% endif %}
         <p>
             The URL you need to HTTP POST to is:
             <br>
@@ -76,16 +87,34 @@ curl -X POST -H "Auth-Token: XXXYOURAPITOKENXXX" --form myfile.zip=@path/to/myfi
             <code>OK</code>.
         </p>
         {% else %}
-        <p>
-            To be able to upload by a script, using the API, you need to generate an
-            <a href="{{ url('tokens:home') }}">API Token</a> that has the permission
-            <code>{{ required_permission.name }}</code>.
-            <br> Once you have that set up, return here to read about how to use it.
-        </p>
+            {% if has_necessary_permission %}
+                <!-- Signed in, no possible token, has permission to make one -->
+                <p>
+                    To be able to upload by a script, using the API, you need to generate an
+                    <a href="{{ url('tokens:home') }}">API Token</a> that has the permission
+                    <code>{{ required_permission.name }}</code>.
+                    <br> Once you have that set up, return here to read about how to use it.
+                </p>
+            {% elif request.user.is_active %}
+                <!-- Signed in, no possible token, does not have permission to make one -->
+                <p>
+                    You do not have permission to generate an API Token for
+                    uploading symbols.
+                </p>
+                <p>
+                    To get this permission, you need to
+                    <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&amp;component=Symbols">file a bug</a>
+                    and ask to have your
+                    user account elevated with the <code>{{ required_permission.name }}</code> permission.
+                </p>
+            {% endif %}
         {% endif %}
+
+        {% if request.user.is_active %}
         <p>
             <a href="{{ url('symbols:home') }}">Go back to Symbols Upload page</a>
         </p>
+        {% endif %}
     </div>
 </div>
 

--- a/webapp-django/crashstats/symbols/jinja2/symbols/api_upload.html
+++ b/webapp-django/crashstats/symbols/jinja2/symbols/api_upload.html
@@ -41,6 +41,7 @@
                     To generate one you need to have the <code>{{ required_permission.name }}</code> permission.
                 </p>
             {% endif %}
+        {% endif %}
         <p>
             The URL you need to HTTP POST to is:
             <br>
@@ -86,28 +87,27 @@ curl -X POST -H "Auth-Token: XXXYOURAPITOKENXXX" --form myfile.zip=@path/to/myfi
         <p>If the file you posted could be accepted and opened, the API will respond with the error code <b>201 Created</b> and the response body
             <code>OK</code>.
         </p>
-        {% else %}
-            {% if has_necessary_permission %}
-                <!-- Signed in, no possible token, has permission to make one -->
-                <p>
-                    To be able to upload by a script, using the API, you need to generate an
-                    <a href="{{ url('tokens:home') }}">API Token</a> that has the permission
-                    <code>{{ required_permission.name }}</code>.
-                    <br> Once you have that set up, return here to read about how to use it.
-                </p>
-            {% elif request.user.is_active %}
-                <!-- Signed in, no possible token, does not have permission to make one -->
-                <p>
-                    You do not have permission to generate an API Token for
-                    uploading symbols.
-                </p>
-                <p>
-                    To get this permission, you need to
-                    <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&amp;component=Symbols">file a bug</a>
-                    and ask to have your
-                    user account elevated with the <code>{{ required_permission.name }}</code> permission.
-                </p>
-            {% endif %}
+
+        {% if has_necessary_permission %}
+            <!-- Signed in, no possible token, has permission to make one -->
+            <p>
+                To be able to upload by a script, using the API, you need to generate an
+                <a href="{{ url('tokens:home') }}">API Token</a> that has the permission
+                <code>{{ required_permission.name }}</code>.
+                <br> Once you have that set up, return here to read about how to use it.
+            </p>
+        {% elif request.user.is_active %}
+            <!-- Signed in, no possible token, does not have permission to make one -->
+            <p>
+                You do not have permission to generate an API Token for
+                uploading symbols.
+            </p>
+            <p>
+                To get this permission, you need to
+                <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Socorro&amp;component=Symbols">file a bug</a>
+                and ask to have your
+                user account elevated with the <code>{{ required_permission.name }}</code> permission.
+            </p>
         {% endif %}
 
         {% if request.user.is_active %}

--- a/webapp-django/crashstats/symbols/tests/test_views.py
+++ b/webapp-django/crashstats/symbols/tests/test_views.py
@@ -641,24 +641,35 @@ class TestViews(BaseTestViews):
     def test_api_upload_about(self):
         url = reverse('symbols:api_upload')
         response = self.client.get(url)
-        eq_(response.status_code, 302)
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
+        eq_(response.status_code, 200)
+        # When you're anonymous it talks about you needing to have a
+        # an API Token to upload.
+        ok_(
+            'To be able to upload symbols you need to have an' in
+            response.content
         )
+
         user = self._login()
         response = self.client.get(url)
-        eq_(response.status_code, 302)
-        self.assertRedirects(
-            response,
-            reverse('crashstats:login') + '?next=%s' % url
+        eq_(response.status_code, 200)
+
+        # If you're viewing the page, authenticated but without the
+        # necessary permission to generate an API Token with this
+        # permission.
+        ok_(
+            'You do not have permission to generate an API Token' in
+            response.content
         )
         self._add_permission(user, 'upload_symbols')
 
         response = self.client.get(url)
         eq_(response.status_code, 200)
-        ok_('you need to generate' in response.content)
-
+        # You now have the permission to do so but you haven't generated
+        # an API token yet. Encourge them to do so.
+        ok_(
+            'To be able to upload by a script, using the API, '
+            'you need to generate an' in response.content
+        )
         token = Token.objects.create(
             user=user,
         )
@@ -668,7 +679,7 @@ class TestViews(BaseTestViews):
 
         response = self.client.get(url)
         eq_(response.status_code, 200)
-        ok_('you need to generate' not in response.content)
+        ok_('Now that you have an actively working' in response.content)
 
     def test_upload(self):
         user = User.objects.create(username='user')

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -259,17 +259,19 @@ def web_upload(request):
     return render(request, 'symbols/web_upload.html', context)
 
 
-@login_required
-@permission_required('crashstats.upload_symbols')
 def api_upload(request):
     """The page about doing an upload via things like curl"""
     context = {}
     has_possible_token = False
     required_permission = Permission.objects.get(codename='upload_symbols')
-    for token in Token.objects.active().filter(user=request.user):
-        if token.permissions.filter(codename='upload_symbols'):
-            has_possible_token = True
+    if request.user.is_active:
+        for token in Token.objects.active().filter(user=request.user):
+            if token.permissions.filter(codename='upload_symbols'):
+                has_possible_token = True
     context['has_possible_token'] = has_possible_token
+    context['has_necessary_permission'] = request.user.has_perm(
+        'crashstats.upload_symbols'
+    )
     context['required_permission'] = required_permission
     context['absolute_base_url'] = (
         '%s://%s' % (


### PR DESCRIPTION
cc @luser 

Sorry that this is a bit messy Adrian. I even had to put in html comments. 
There are a bunch of difference states but ultimately this PR is about being able to visit `http://socorro.dev/symbols/upload/api/` without being signed in. That way the documentation can be available for people who have an auth token but just aren't signed in on the webapp. 
![screen shot 2016-08-26 at 3 56 17 pm](https://cloud.githubusercontent.com/assets/26739/18018589/c2f34506-6ba5-11e6-8506-edae520af6ad.png)

Beyond that, there are states that try to guide the user. 
1. You're signed in but haven't generated a API Token valid for symbol uploads
2. You have an API Token valid for symbol uploads
3. You're signed in but don't even have permission to generate an API Token for the necessary permission. 