### PR TITLE
fixes bug 1296008 - Create bucket with region

### DIFF
--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -381,6 +381,17 @@ class RegionalS3ConnectionContext(S3ConnectionContext):
             )
             return self.connection
 
+    #--------------------------------------------------------------------------
+    def _get_or_create_bucket(self, conn, bucket_name):
+        try:
+            return self._get_bucket(conn, bucket_name)
+        except self.ResponseError:
+            self._bucket_cache[bucket_name] = conn.create_bucket(
+                bucket_name,
+                location=self._region,
+            )
+            return self._bucket_cache[bucket_name]
+
 
 class HostPortS3ConnectionContext(S3ConnectionContext):
     """Connection context for connecting to an S3-like service at a specified


### PR DESCRIPTION
Here's why I'm confident this works (and is necessary!):

```
>>> conn = boto.s3.connect_to_region('us-west-2', aws_access_key_id='AKI....)  # personal credentials
>>> bucket = conn.create_bucket('peterbe-test-bucket-delete-me')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/boto/s3/connection.py", line 590, in create_bucket
    response.status, response.reason, body)
boto.exception.S3ResponseError: S3ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>IllegalLocationConstraintException</Code><Message>The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.</Message><RequestId>18E674025CAD633F</RequestId><HostId>m9B9tQ13Sez6OaWrbwvh28cBenVD/YfvjC+bq1Xp6iVyLXagDKmTcIBXot6laR2avWrEs1wAX9w=</HostId></Error>
>>> bucket = conn.create_bucket('peterbe-test-bucket-delete-me', location='us-west-2')
```
the last line worked. And I logged in and check that the bucket did get created. 
