### PR TITLE
fixes bug 1298969

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -215,6 +215,7 @@ html.production {
 }
 .page-header {
     position: relative;
+    min-height: 64px;
     height: 64px;
     background-color: #0a2533;
     background-image: url(../../img/2.0/header-bg.png);

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -35,6 +35,11 @@ a, a:link, a:hover, a:active {
 a:visited {
     color: #800080;
 }
+body {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
 body > h1 {
     font-size: 200%;
 }
@@ -584,8 +589,8 @@ div#message {
 #mainbody {
      position: relative;
      margin: 1em 2em;
-     min-height: 50em;
      text-align: left;
+     flex: 1;
 }
 /* Admin */
 div.admin {

--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -39,6 +39,7 @@ body {
     height: 100%;
     display: flex;
     flex-direction: column;
+    height: 100vh;
 }
 body > h1 {
     font-size: 200%;


### PR DESCRIPTION
removes the earlier attempt to use min-height and replaces it with a flexbox based approach that ensures the footer appears either below the content or at the bottom of the page

My local env is hosed so this needs a little extra testing. I've checked this change against the main page and search page using dev tools. If something is broken it will not be subtle -- after landing, load the main page, search, topcrasher, daily, report list, and report index to check. You may want to use devtools to remove a div panel or two in order to make room.

Before:
<img width="852" alt="screenshot 2016-08-29 15 05 03-2" src="https://cloud.githubusercontent.com/assets/21467/18076667/be6bcbde-6e34-11e6-82de-02027dfea1a4.png">


After:
<img width="950" alt="screenshot 2016-08-29 15 09 52" src="https://cloud.githubusercontent.com/assets/21467/18076618/7165538c-6e34-11e6-9d7e-310884b3a3cf.png">
