### PR TITLE
nobug -- hide the injected google iFrame

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/screen.less
@@ -1311,6 +1311,11 @@ table.initially-hidden {
     }
 }
 
+/* hide google ssIFrame */
+#ssIFrame_google {
+    display: none;
+}
+
 /* truncated frames */
 table.data-table {
     tbody {


### PR DESCRIPTION
google SSI injects a small iframe that is absolutely positioned and causes a 4 px high box to appear below the sticky footer. This removes it from display and prevents a vertical scroll from showing up.