### PR TITLE
fixes bug 1290967

### DIFF
--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -678,7 +678,7 @@ class SignatureRunWatchDog(SignatureGenerationRule):
 
     #--------------------------------------------------------------------------
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        return '::RunWatchdog' in processed_crash['signature']
+        return 'RunWatchdog' in processed_crash['signature']
 
     #--------------------------------------------------------------------------
     def _get_crashing_thread(self, processed_crash):


### PR DESCRIPTION
Some linux crashes are crashing in RunWatchdog without calling it from or otherwise including the '::' operator in the frame, so these crashes are not triggering the appropriate processor rule.

This fixes it by removing the '::' requirement from the predicate. There are no Firefox crashes in super search at the time of this writing that will be adversely caught by this -- it should catch the same crashes as the previous rule plus the missing reports.

We may need to reprocess after this. Check the bug.