### PR TITLE
fixes bug 1300921 - TypError on time_tag() with unicode

### DIFF
--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -94,10 +94,13 @@ def timestamp_to_date(
 def time_tag(dt, format='%a, %b %d %H:%M %Z', future=False):
     if not isinstance(dt, (datetime.date, datetime.datetime)):
         try:
+            if isinstance(dt, unicode):
+                # isodate struggles to convert unicode strings with
+                # its parse_datetime() if the input string is unicode.
+                dt = dt.encode('utf-8')
             dt = isodate.parse_datetime(dt)
         except isodate.ISO8601Error:
             return dt
-
     return jinja2.Markup(
         '<time datetime="{}" class="{}">{}</time>'
         .format(

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -97,7 +97,7 @@ def time_tag(dt, format='%a, %b %d %H:%M %Z', future=False):
             if isinstance(dt, unicode):
                 # isodate struggles to convert unicode strings with
                 # its parse_datetime() if the input string is unicode.
-                dt = dt.encode('utf-8')
+                dt = dt.encode('ascii')
             dt = isodate.parse_datetime(dt)
         except isodate.ISO8601Error:
             return dt

--- a/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/templatetags/jinja_helpers.py
@@ -15,6 +15,7 @@ from django.template import engines
 from django.utils.safestring import mark_safe
 
 from crashstats import scrubber
+from crashstats.crashstats.utils import parse_isodate
 
 
 @library.filter
@@ -94,11 +95,7 @@ def timestamp_to_date(
 def time_tag(dt, format='%a, %b %d %H:%M %Z', future=False):
     if not isinstance(dt, (datetime.date, datetime.datetime)):
         try:
-            if isinstance(dt, unicode):
-                # isodate struggles to convert unicode strings with
-                # its parse_datetime() if the input string is unicode.
-                dt = dt.encode('ascii')
-            dt = isodate.parse_datetime(dt)
+            dt = parse_isodate(dt)
         except isodate.ISO8601Error:
             return dt
     return jinja2.Markup(
@@ -116,7 +113,7 @@ def human_readable_iso_date(dt):
     """ Python datetime to a human readable ISO datetime. """
     if not isinstance(dt, (datetime.date, datetime.datetime)):
         try:
-            dt = isodate.parse_datetime(dt)
+            dt = parse_isodate(dt)
         except isodate.ISO8601Error:
             # Because we're paranoid, we don't want to fail
             # the whole template rendering just because one date

--- a/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_jinja_helpers.py
@@ -71,6 +71,16 @@ class TestTimeTag(TestCase):
         output = time_tag('junk')
         eq_(output, 'junk')
 
+    def test_parse_with_unicode_with_timezone(self):
+        # See https://bugzilla.mozilla.org/show_bug.cgi?id=1300921
+        date = u'2016-09-07T00:38:42.630775+00:00'
+        output = time_tag(date)
+
+        eq_(output, '<time datetime="{}" class="ago">{}</time>'.format(
+            '2016-09-07T00:38:42.630775+00:00',
+            'Wed, Sep 07 00:38 +00:00'
+        ))
+
 
 class TestRecursiveStateFilter(TestCase):
 

--- a/webapp-django/crashstats/crashstats/utils.py
+++ b/webapp-django/crashstats/crashstats/utils.py
@@ -32,14 +32,15 @@ def unixtime(value, millis=False, format='%Y-%m-%d'):
         return epoch_seconds
 
 
-def parse_isodate(ds, format_string="%b %d %Y %H:%M:%S"):
+def parse_isodate(ds):
     """
-    parses iso8601 date string and returns a truncated
-    string representation suitable for display on the status page
+    return a datetime object from a date string
     """
-    if not ds:
-        return ""
-    return isodate.parse_datetime(ds).strftime(format_string)
+    if isinstance(ds, unicode):
+        # isodate struggles to convert unicode strings with
+        # its parse_datetime() if the input string is unicode.
+        ds = ds.encode('ascii')
+    return isodate.parse_datetime(ds)
 
 
 def daterange(start_date, end_date, format='%Y-%m-%d'):

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from operator import itemgetter
 from io import BytesIO
 
-import isodate
 import isoweek
 
 from django import http
@@ -1779,7 +1778,7 @@ def report_list(request, partial=None, default_context=None):
 
             counts[(product, os_name, version)] += 1
 
-            report['date_processed'] = isodate.parse_datetime(
+            report['date_processed'] = utils.parse_isodate(
                 report['date_processed']
             ).strftime('%b %d, %Y %H:%M')
 
@@ -1794,9 +1793,7 @@ def report_list(request, partial=None, default_context=None):
                         )
                     else:
                         # old style, middleware returned a formatted string
-                        install_time = isodate.parse_datetime(
-                            install_time
-                        )
+                        install_time = utils.parse_isodate(install_time)
                 # put it back into the report
                 report['install_time'] = install_time.strftime(
                     '%Y-%m-%d %H:%M:%S'

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -2,8 +2,6 @@ import datetime
 import functools
 import math
 
-import isodate
-
 from django import http
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -433,17 +431,17 @@ def signature_graph_data(request, params, channel):
             # Set the earliest given start date as the start date
             if date.startswith('>'):
                 if date.startswith('>='):
-                    d = isodate.parse_date(date.lstrip('>='))
+                    d = utils.parse_isodate(date.lstrip('>='))
                 else:
-                    d = isodate.parse_date(date.lstrip('>')) + one_day
+                    d = utils.parse_isodate(date.lstrip('>')) + one_day
                 if not start_date or d < start_date:
                     start_date = d
             # Set the latest given end date as the end date
             elif date.startswith('<'):
                 if date.startswith('<='):
-                    d = isodate.parse_date(date.lstrip('<='))
+                    d = utils.parse_isodate(date.lstrip('<='))
                 else:
-                    d = isodate.parse_date(date.lstrip('<')) - one_day
+                    d = utils.parse_isodate(date.lstrip('<')) - one_day
                 if not end_date or d > end_date:
                     end_date = d
 

--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -5,6 +5,8 @@ import isodate
 from django import forms
 from django.utils.timezone import utc
 
+from crashstats.crashstats.utils import parse_isodate
+
 
 OPERATORS = (
     '__true__', '__null__', '$', '~', '^', '@', '=', '<=', '>=', '<', '>',
@@ -146,7 +148,7 @@ class IsoDateTimeField(forms.DateTimeField):
     def to_python(self, value):
         if value:
             try:
-                return isodate.parse_datetime(value).replace(tzinfo=utc)
+                return parse_isodate(value).replace(tzinfo=utc)
             except (ValueError, isodate.isoerror.ISO8601Error):
                 # let the super method deal with that
                 pass


### PR DESCRIPTION
I wrote the test before I wrote the `.encode()` fix. 