### PR TITLE
fixes bug 1061371 - UI to download memory file from crash reports

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -4684,6 +4684,36 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 200)
         ok_('bla bla bla' in response.content)  # still. good.
 
+    def test_raw_data_memory_report(self):
+
+        crash_id = '176bcd6c-c2ec-4b0c-9d5f-dadea2120531'
+
+        def mocked_get(**params):
+            assert params['name'] == 'memory_report'
+            assert params['uuid'] == crash_id
+            assert params['datatype'] == 'raw'
+            return "binary stuff"
+
+        models.RawCrash.implementation().get.side_effect = mocked_get
+
+        dump_url = reverse(
+            'crashstats:raw_data_named',
+            args=(crash_id, 'memory_report', 'json.gz')
+        )
+        response = self.client.get(dump_url)
+        eq_(response.status_code, 302)
+        assert 'login' in response['Location']
+
+        user = self._login()
+        group = self._create_group_with_permission('view_rawdump')
+        user.groups.add(group)
+        assert user.has_perm('crashstats.view_rawdump')
+
+        response = self.client.get(dump_url)
+        eq_(response.status_code, 200)
+        eq_(response['Content-Type'], 'application/octet-stream')
+        ok_('binary stuff' in response.content, response.content)
+
     @mock.patch('requests.get')
     def test_correlations_json(self, rget):
         url = reverse('crashstats:correlations_json')

--- a/webapp-django/crashstats/crashstats/urls.py
+++ b/webapp-django/crashstats/crashstats/urls.py
@@ -107,7 +107,7 @@ urlpatterns = patterns(
         views.signature_summary,
         name='signature_summary'),
     url(r'^rawdumps/(?P<crash_id>[\w-]{36})-(?P<name>\w+)\.'
-        r'(?P<extension>json|dmp)$',
+        r'(?P<extension>json|dmp|json\.gz)$',
         views.raw_data,
         name='raw_data_named'),
     url(r'^rawdumps/(?P<crash_id>[\w-]{36}).(?P<extension>json|dmp)$',

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1457,7 +1457,11 @@ def report_index(request, crash_id, default_context=None):
                         args=(crash_id, name, 'dmp')
                     )
                 )
-        if context['raw'].get('ContainsMemoryReport'):
+        if (
+            context['raw'].get('ContainsMemoryReport') and
+            context['report'].get('memory_report') and
+            not context['report'].get('memory_report_error')
+        ):
             context['raw_dump_urls'].append(
                 reverse(
                     'crashstats:raw_data_named',

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -1457,6 +1457,13 @@ def report_index(request, crash_id, default_context=None):
                         args=(crash_id, name, 'dmp')
                     )
                 )
+        if context['raw'].get('ContainsMemoryReport'):
+            context['raw_dump_urls'].append(
+                reverse(
+                    'crashstats:raw_data_named',
+                    args=(crash_id, 'memory_report', 'json.gz')
+                )
+            )
 
     # On the report_index template, we have a piece of JavaScript
     # that triggers an AJAX query to find out if there are correlations
@@ -2351,12 +2358,19 @@ def raw_data(request, crash_id, extension, name=None):
     elif extension == 'dmp':
         format = 'raw'
         content_type = 'application/octet-stream'
+    elif extension == 'json.gz' and name == 'memory_report':
+        # Note, if the name is 'memory_report' it will fetch a raw
+        # crash with name and the files in the memory_report bucket
+        # are already gzipped.
+        # This is important because it means we don't need to gzip
+        # the HttpResponse below.
+        format = 'raw'
+        content_type = 'application/octet-stream'
     else:
         raise NotImplementedError(extension)
 
     data = api.get(crash_id=crash_id, format=format, name=name)
     response = http.HttpResponse(content_type=content_type)
-
     if extension == 'json':
         response.write(json.dumps(data))
     else:


### PR DESCRIPTION
Here's how to test it:

Make a search like this: https://crash-stats.allizom.org/search/?contains_memory_report=%21__null__&product=Firefox&_sort=-date&_facets=signature&_columns=date&_columns=signature&_columns=product&_columns=version&_columns=build_id&_columns=platform#facet-signature

Click on one of the crash IDs and load the Raw Dumps tab. There should NOT be a third link at the bottom of that tab until after you've signed in. 
When you sign in and try again it should present you with a third link at looks something like this: `/rawdumps/7e99cdee-6148-4ae5-a5bc-81b9c2160915-memory_report.json.gz`

When you click it, it should make you save the file. Save it. Then then go to `about:memory` and click the "Load..." button. Should work. 