### PR TITLE
Fixes bug 1303250 - Use a JSON-serializable DotDict object.

### DIFF
--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -71,7 +71,7 @@ class BotoCrashStorage(CrashStorageBase):
     )
     required_config.add_option(
         'json_object_hook',
-        default='configman.dotdict.DotDict',
+        default='socorrolib.lib.util.DotDict',
         from_string_converter=class_converter,
     )
 


### PR DESCRIPTION
The default value of `configman.dotdict.DotDict` broke processing, because configman DotDict cannot be JSON-serialized. The DotDict object from socorrolib is a very simple extension of the default dict type, so it is what we should use for our crash documents.