### PR TITLE
fixes bug 1290329 - add spacing between sumo links on report index

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/css/report_index.css
+++ b/webapp-django/crashstats/crashstats/static/crashstats/css/report_index.css
@@ -10,3 +10,7 @@
     text-decoration: underline;
     text-decoration-style: dotted;
 }
+
+#sumo-link a {
+    margin-left: 5px;
+}


### PR DESCRIPTION
After:
<img width="582" alt="screen shot 2016-09-19 at 3 07 28 pm" src="https://cloud.githubusercontent.com/assets/26739/18645345/cef47a4a-7e7a-11e6-9845-484eb9856d5e.png">
