### PR TITLE
fixes bug 1303853 - Error templates depend on request

### DIFF
--- a/webapp-django/crashstats/base/jinja2/400.html
+++ b/webapp-django/crashstats/base/jinja2/400.html
@@ -1,8 +1,6 @@
-{% extends "crashstats_base.html" %}
+{% extends "error.html" %}
 
 {% block page_title %}Bad Request{% endblock %}
-
-{% block product_nav_filter %}&nbsp;{% endblock %}
 
 {% block site_css %}
 {{ super() }}

--- a/webapp-django/crashstats/base/jinja2/404.html
+++ b/webapp-django/crashstats/base/jinja2/404.html
@@ -1,13 +1,11 @@
-{% extends "crashstats_base.html" %}
+{% extends "error.html" %}
 
 {% block page_title %}Page Not Found{% endblock %}
-
-{% block product_nav_filter %}&nbsp;{% endblock %}
 
 {% block content %}
 <div id="mainbody">
     <div class="page-heading">
-        <h2>Page not Found</h2>
+        <h2>Page Not Found</h2>
     </div>
     <div class="panel">
         <div class="title">
@@ -15,10 +13,9 @@
         </div>
         <div class="body">
             <p>If you followed a dead link on the website, please file an
-                <a href="https://bugzilla.mozilla.org/enter_bug.cgi?{{ make_query_string(
+                <a class="bugzilla-link" href="https://bugzilla.mozilla.org/enter_bug.cgi?{{ make_query_string(
                     product='Socorro',
                     component='Webapp',
-                    bug_file_loc=request.build_absolute_uri()
                 ) }}">issue in Bugzilla</a> describing
                 what happened, and please include the URL for this page.</p>
         </div>

--- a/webapp-django/crashstats/base/jinja2/500.html
+++ b/webapp-django/crashstats/base/jinja2/500.html
@@ -1,24 +1,19 @@
-{% extends "crashstats_base.html" %}
-
-{% block page_title %}
-Internal Server Error
-{% endblock %}
-
-{% block product_nav_filter %}&nbsp;{% endblock %}
-
+{% extends "error.html" %}
+{% block page_title %}Internal Server Error{% endblock %}</title>
 {% block content %}
 <div id="mainbody">
+    <div class="page-heading">
+        <h2>Internal Server Error</h2>
+    </div>
     <div class="panel">
         <div class="title">
-            <h2>Internal Server Error</h2>
+            <h2>Something went wrong, it is not you it's me.</h2>
         </div>
 
         <div class="body">
-            <p>Something went wrong, it is not you it's me</p>
-            <p>Please file an <a href="https://bugzilla.mozilla.org/enter_bug.cgi?{{ make_query_string(
+            <p>Please file an <a class="bugzilla-link" href="https://bugzilla.mozilla.org/enter_bug.cgi?{{ make_query_string(
                 product='Socorro',
                 component='Webapp',
-                bug_file_loc=request.build_absolute_uri(),
             ) }}">issue in Bugzilla</a> describing what happened, and please include the URL for this page.</p>
         </div>
     </div>

--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -32,12 +32,7 @@
     {{ browserid_info() }}
     {% endif %}
     <div class="page-header">
-        <h1>
-            <a href="/">
-                <span class="icon"></span>
-                <span class="title">Mozilla Crash Reports</span>
-            </a>
-        </h1>
+        {% include "header_title.html" %}
 
         <form id="simple_search" method="get" action="{{ url('crashstats:quick_search') }}">
             <label for="q" class="visually-hidden">Search</label>
@@ -159,17 +154,8 @@
     {% block content %}{% endblock %}
 
     <div id="footer" class="page-footer">
-        <div class="nav">
-            <div class="about">
-                <strong>Mozilla Crash Reports</strong> - Powered by <a href="https://github.com/mozilla/socorro">Socorro</a> - All dates are UTC
-            </div>
-            <ul>
-                <li><a href="{{ url('documentation:home') }}">User Documentation</a></li>
-                <li><a href="{{ url('api:documentation') }}">API</a></li>
-                <li><a href="https://github.com/mozilla/socorro">Source</a></li>
-                <li><a href="https://www.mozilla.org/privacy/websites/">Privacy Policy</a></li>
-            </ul>
-        </div>
+        {% include "footer_nav.html" %}
+
         <div class="login">
             <ul>
                 <li>

--- a/webapp-django/crashstats/base/jinja2/error.html
+++ b/webapp-django/crashstats/base/jinja2/error.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en-US" class="production">
+    <head>
+        <meta charset="UTF-8" />
+        <title>{% block page_title %}Error{% endblock %}</title>
+        {% block site_css %}
+        {% stylesheet 'crashstats_base' %}
+        {% endblock %}
+    </head>
+    <body>
+        <div class="page-header">
+            {% include "header_title.html" %}
+        </div>
+        {% block content %}
+
+        {% endblock %}
+        <div id="footer" class="page-footer">
+            {% include "footer_nav.html" %}
+        </div>
+        {% block site_js %}
+        {% javascript 'error' %}
+        {% endblock %}
+    </body>
+</html>

--- a/webapp-django/crashstats/base/jinja2/footer_nav.html
+++ b/webapp-django/crashstats/base/jinja2/footer_nav.html
@@ -1,0 +1,11 @@
+<div class="nav">
+    <div class="about">
+        <strong>Mozilla Crash Reports</strong> - Powered by <a href="https://github.com/mozilla/socorro">Socorro</a> - All dates are UTC
+    </div>
+    <ul>
+        <li><a href="{{ url('documentation:home') }}">User Documentation</a></li>
+        <li><a href="{{ url('api:documentation') }}">API</a></li>
+        <li><a href="https://github.com/mozilla/socorro">Source</a></li>
+        <li><a href="https://www.mozilla.org/privacy/websites/">Privacy Policy</a></li>
+    </ul>
+</div>

--- a/webapp-django/crashstats/base/jinja2/header_title.html
+++ b/webapp-django/crashstats/base/jinja2/header_title.html
@@ -1,0 +1,6 @@
+<h1>
+    <a href="/">
+        <span class="icon"></span>
+        <span class="title">Mozilla Crash Reports</span>
+    </a>
+</h1>

--- a/webapp-django/crashstats/base/static/js/error.js
+++ b/webapp-django/crashstats/base/static/js/error.js
@@ -1,0 +1,16 @@
+/*
+    This is loaded on any page that renders HTML errors for 500, 4xx errors.
+    Remember, there's no jQuery available in this context.
+ */
+
+
+// If the page as a bugzilla link, because we can't rely on the server
+// to figure out the current full URL, we have to use JavaScript to
+// append the current full URL to the bug_file_loc parameter link.
+window.onload = function() {
+    var link = document.querySelector('a.bugzilla-link');
+    if (link) {
+        link.href += '&bug_file_loc=' + encodeURIComponent(document.location.href);
+    }
+
+};

--- a/webapp-django/crashstats/base/views.py
+++ b/webapp-django/crashstats/base/views.py
@@ -1,5 +1,4 @@
 from django import http
-from django.conf import settings
 from django.shortcuts import render
 
 
@@ -13,7 +12,7 @@ def handler500(request):
             'path': request.path,
             'query_string': request.META.get('QUERY_STRING'),
         }, status=500)
-    context = {'product': settings.DEFAULT_PRODUCT}
+    context = {}
     return render(request, '500.html', context, status=500)
 
 
@@ -27,5 +26,5 @@ def handler404(request):
             'path': request.path,
             'query_string': request.META.get('QUERY_STRING'),
         }, status=404)
-    context = {'product': settings.DEFAULT_PRODUCT}
+    context = {}
     return render(request, '404.html', context, status=404)

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -592,7 +592,7 @@ class TestViews(BaseTestViews):
         url = reverse('home:home', args=('Unknown',))
         response = self.client.get(url)
         eq_(response.status_code, 404)
-        ok_('Page not Found' in response.content)
+        ok_('Page Not Found' in response.content)
         ok_('id="products_select"' not in response.content)
 
     def test_handler404_json(self):

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -464,6 +464,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/tokens.min.js',
     },
+    'error': {
+        'source_filenames': (
+            'js/error.js',
+        ),
+        'output_filename': 'js/error.min.js',
+    },
 }
 
 # This is sanity checks, primarily for developers. It checks that

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -15,6 +15,7 @@ patch()
 
 handler500 = 'crashstats.base.views.handler500'
 handler404 = 'crashstats.base.views.handler404'
+handler400 = 'crashstats.base.views.handler400'
 
 
 urlpatterns = patterns(

--- a/webapp-django/crashstats/urls.py
+++ b/webapp-django/crashstats/urls.py
@@ -15,7 +15,6 @@ patch()
 
 handler500 = 'crashstats.base.views.handler500'
 handler404 = 'crashstats.base.views.handler404'
-handler400 = 'crashstats.base.views.handler400'
 
 
 urlpatterns = patterns(


### PR DESCRIPTION
Check the [bug description](https://bugzilla.mozilla.org/show_bug.cgi?id=1303853#c0).

This patch totally simplifies how error template rendering happens. Now crashstats_base.html is left to healthy requests. No more subtle errors during rendering the `500.html`. 

To test this, make sure you have `DEBUG=False` and `DEBUG_PROPAGATE_EXCEPTIONS=False` and to trigger the `DisallowedHost` I use my nginx but under a domain that Django was not allowing. See:
<img width="2219" alt="screen shot 2016-09-19 at 4 23 15 pm" src="https://cloud.githubusercontent.com/assets/26739/18647730/688e5fea-7e85-11e6-82a4-c5516e6c25bb.png">

I also checked that it continues to work for other errors:
Page Not Found:
<img width="2219" alt="screen shot 2016-09-19 at 4 23 57 pm" src="https://cloud.githubusercontent.com/assets/26739/18647746/7e5d47dc-7e85-11e6-98e9-92561dfb5d22.png">

Bad Request:
<img width="2219" alt="screen shot 2016-09-19 at 4 24 25 pm" src="https://cloud.githubusercontent.com/assets/26739/18647762/91b9a78a-7e85-11e6-8112-7f8e963ef8ca.png">
(note how I messed with the `date_end` parameter in the URL)

JSON errors still work as expected:
<img width="2219" alt="screen shot 2016-09-19 at 4 24 59 pm" src="https://cloud.githubusercontent.com/assets/26739/18647784/a80643fe-7e85-11e6-9879-85342cc53432.png">

SuperSearch errors still work:
<img width="2219" alt="screen shot 2016-09-19 at 4 26 03 pm" src="https://cloud.githubusercontent.com/assets/26739/18647802/cab11b9a-7e85-11e6-860c-68641e7ff392.png">

It also continues to work when I put in a temporary `raise NameError('test!')` in one of the view functions:
<img width="2219" alt="screen shot 2016-09-19 at 4 27 01 pm" src="https://cloud.githubusercontent.com/assets/26739/18647828/f4ea922e-7e85-11e6-9a0c-4e8b794fb0ad.png">
