### PR TITLE
Fixes bug 1304289 by add a link to the unredacted crash.

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -606,13 +606,22 @@
 
                 <div id="rawdump" class="ui-tabs-hide">
                     <div class="code">{{ raw_stackwalker_output }}</div>
-                    {% if request.user.has_perm('crashstats.view_rawdump') %}
+
                     <h3>Download the Raw Dump</h3>
-                    {% for url in raw_dump_urls %}
-                    <p><a href="{{ url }}">{{ url }}</a></p>
-                    {% endfor %}
+                    {% if request.user.has_perm('crashstats.view_rawdump') %}
+                        {% for url in raw_dump_urls %}
+                            <p><a href="{{ url }}">{{ url }}</a></p>
+                        {% endfor %}
                     {% else %}
-                    <p>You need to be signed in to be able to download raw dumps.</p>
+                        <p>You need to be signed in to download raw dumps.</p>
+                    {% endif %}
+
+                    <h3>View the Unredacted Crash</h3>
+                    {% if request.user.has_perm('crashstats.view_rawdump') %}
+                        {% set unredacted_url = url('api:model_wrapper', model_name='UnredactedCrash') + '?' + make_query_string(crash_id=report.uuid) %}
+                        <p><a href="{{ unredacted_url }}" target="_blank">{{ unredacted_url }}</a></p>
+                    {% else %}
+                        <p>You need to be signed in to view unredacted crashes.</p>
                     {% endif %}
                 </div>
                 <!-- /rawdump -->

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -2428,7 +2428,11 @@ class TestViews(BaseTestViews):
         ok_(_SAMPLE_META['Email'] not in response.content)
         ok_(_SAMPLE_META['URL'] not in response.content)
         ok_(
-            'You need to be signed in to be able to download raw dumps.'
+            'You need to be signed in to download raw dumps.'
+            in response.content
+        )
+        ok_(
+            'You need to be signed in to view unredacted crashes.'
             in response.content
         )
         # Should not be able to see sensitive key from stackwalker JSON


### PR DESCRIPTION
Here's an attempt. I'm pretty sure this line is not going to fly:
```
<p><a href="{{ '../../api/UnredactedCrash/?crash_id=' + report.uuid }}">{{ '/api/UnredactedCrash/?crash_id=' + report.uuid }}</a></p>
```
It works, but I figure this should probably be done in views.py. I tried to do it there but couldn't work out how to -- the raw dump URLs are done with calls like `reverse('crashstats:raw_data', args=(crash_id, 'dmp'))` which I don't understand.