### PR TITLE
Move e2e tests into Socorro's project repo

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -9,7 +9,7 @@ Continuous Integration
 
 This directory holds Socorro client-based end-to-end tests which is why they're different than the rest of the code in this repository.
 
-To review the specific Python packages the tests utilize, please review `e2e-tests/requirements.txt`.
+To review the specific Python packages the tests utilize, please review `requirements.txt`.
 
 Set up and run Socorro tests
 -----------------------------
@@ -21,19 +21,22 @@ We suggest using a different virtual environment for these tests than the
 rest of Socorro so you're not mixing requirements:
 
 	$ mkvirtualenv socorro-tests
+	$ # make sure you DON'T run the next command in 
+	$ # your dev virtualenv.
 	$ pip install -r requirements.txt
 
 An additional constraint for Firefox users, with the release of Firefox 48, Webdriver support is currently broken until GeckoDriver is out of Alpha. We suggest using an older version of Firefox which can be [downloaded here][firefoxdownloads].
 
 If you have multiple versions of Firefox installed, you can specifiy a specific one by using the `--firefox-path <path to firefox binary>` flag.
 
-___Running tests against localhost___
-
-	$ py.test --driver Firefox --base-url http://localhost:8000 tests/
-
 ___Running the tests on stage___
 
 	$ py.test --driver Firefox tests/
+
+___Running tests against localhost___
+
+	$ py.test --driver Firefox --base-url http://localhost:8000 tests/
+	$ py.test --driver Firefox --firefox-path /path/to/firefox/binary --base-url http://localhost:8000 tests/
 
 ___Running tests against production___
 
@@ -91,7 +94,12 @@ simply turn off the UI.
 
 __Use a different driver__
 
-[pytest-selenium] provides the ability to run tests against [many other][test envs] browser environments -- consider using a different driver executable or external provider.
+[pytest-selenium] provides the ability to run tests against [many other][test envs] browser environments -- consider using a different driver executable or external provider. 
+
+It is important to note that tests must pass with Firefox driver otherwise they will not be accepted for merging.
+
+    $ # tests must pass with Firefox driver before submitting a pull request
+    $ py.test --driver PhantomJS --driver-path `which phantomjs` ...
 
 __xvfb__
 
@@ -115,50 +123,6 @@ On Linux:
     up all the fiddly environment variables to get this working
     well. The tests will run as normal, and no windows will open, if
     all is working right.
-
-
-Getting involved as a contributor
----------------------------------
-
-We love working with contributors to improve the Selenium test coverage on
-Socorro but it does require a few skills.  You will need to be familiar
-with Python, Selenium, and have a working knowledge of GitHub.
-
-If you are comfortable with Python, it's worth having a look at the Selenium
-framework to understand the basic concepts of browser-based testing and the
-page objects pattern.
-
-If you need to brush up on programming but are eager to start contributing
-immediately, please consider helping out by doing manual testing.  You can
-help find bugs in Mozilla [Firefox][firefox] or find bugs in the Mozilla web
-sites tested by the [Firefox Test Engineering][firefoxtesteng] team.  We have many projects that would be
-thrilled to have your help!
-
-To brush up on Python skills before engaging with us, [Dive Into Python][dive]
-is an excellent resource.  MIT also has [lecture notes on Python][mit] available
-through their open courseware.  The programming concepts you will need to know
-include functions, working with classes, and the basics of object-oriented
-programming.
-
-Questions are always welcome
-----------------------------
-While we take great pains to keep our documentation updated, the best source of
-information is those of us who work on the project.  Don't be afraid to join us
-in irc.mozilla.org #fx-test to ask questions about our Selenium tests.  Mozilla
-also hosts the #breakpad chat room to answer your general questions about
-the Socorro project.
-
-Writing Tests
--------------
-
-If you want to get involved and add more tests, then there are just a few things
-we'd like to ask you to do:
-
-1. Use the [template files][GitHub Templates] for all new tests and page objects
-2. Follow our simple [style guide][Style Guide]
-3. Fork this project with your own GitHub account
-4. Make sure all tests are passing, and submit a pull request with your changes
-5. Always feel free to reach out to us and ask questions. We'll do our best to help get you started and unstuck.
 
 License
 -------

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -23,6 +23,10 @@ rest of Socorro so you're not mixing requirements:
 	$ mkvirtualenv socorro-tests
 	$ pip install -r requirements.txt
 
+An additional constraint for Firefox users, with the release of Firefox 48, Webdriver support is currently broken until GeckoDriver is out of Alpha. We suggest using an older version of Firefox which can be [downloaded here][firefoxdownloads].
+
+If you have multiple versions of Firefox installed, you can specifiy a specific one by using the `--firefox-path <path to firefox binary>` flag.
+
 ___Running tests against localhost___
 
 	$ py.test --driver Firefox --base-url http://localhost:8000 tests/
@@ -181,4 +185,5 @@ This software is licensed under the [MPL] 2.0:
 [Style Guide]: https://wiki.mozilla.org/QA/Execution/Web_Testing/Docs/Automation/StyleGuide
 [MPL]: http://www.mozilla.org/MPL/2.0/
 [pytest-selenium]: http://pytest-selenium.readthedocs.org/
+[firefoxdownloads]: https://ftp.mozilla.org/pub/firefox/releases/
 [test envs]: http://pytest-selenium.readthedocs.io/en/latest/user_guide.html#specifying-a-browser

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -21,8 +21,7 @@ We suggest using a different virtual environment for these tests than the
 rest of Socorro so you're not mixing requirements:
 
 	$ mkvirtualenv socorro-tests
-	$ pip install -r e2e-tests/requirements.txt
-
+	$ pip install -r requirements.txt
 
 ___Running tests against localhost___
 
@@ -31,6 +30,10 @@ ___Running tests against localhost___
 ___Running the tests on stage___
 
 	$ py.test --driver Firefox tests/
+
+___Running tests against production___
+
+	$ py.test --driver Firefox --base-url https://crash-stats.mozilla.com tests/
 
 ___Running specific tests___
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,181 @@
+End-to-End Tests for Socorro
+=============================
+
+Continuous Integration
+----------------------
+[![stage](https://img.shields.io/jenkins/s/https/webqa-ci.mozilla.com/socorro.stage.saucelabs.svg?label=stage)](https://webqa-ci.mozilla.com/job/socorro.stage.saucelabs/)
+[![prod](https://img.shields.io/jenkins/s/https/webqa-ci.mozilla.com/socorro.prod.saucelabs.svg?label=prod)](https://webqa-ci.mozilla.com/job/socorro.prod.saucelabs/)
+
+
+This directory holds Socorro client-based end-to-end tests which is why they're different than the rest of the code in this repository.
+
+To review the specific Python packages the tests utilize, please review `e2e-tests/requirements.txt`.
+
+Set up and run Socorro tests
+-----------------------------
+
+Review the documentation for [pytest-selenium][pytest-selenium] and decide which browser
+environment you wish to target.
+
+We suggest using a different virtual environment for these tests than the
+rest of Socorro so you're not mixing requirements:
+
+	$ mkvirtualenv socorro-tests
+	$ pip install -r e2e-tests/requirements.txt
+
+
+___Running tests against localhost___
+
+	$ py.test --driver Firefox --base-url http://localhost:8000 tests/
+
+___Running the tests on stage___
+
+	$ py.test --driver Firefox tests/
+
+___Running specific tests___
+
+You can run tests in a given file::
+
+    $ py.test --driver Firefox tests/desktop/test_search.py
+
+You can run tests that match a specific name:
+
+    $ py.test --driver Firefox -k test_search_for_unrealistic_data
+
+You can run tests whose names match a specific pattern:
+
+    $ py.test --driver Firefox -k test_search
+
+__Output__
+
+Output of a test run should look something like this:
+
+    ============================= test session starts ==============================
+    platform linux2 -- Python 2.7.3 -- pytest-2.2.4
+    collected 73 items
+
+    tests/test_crash_reports.py .........................xx..........x.xx....x.
+    tests/test_layout.py xx
+    tests/test_search.py .........x.x.
+    tests/test_smoke_tests.py ...........
+
+    ============== 63 passed, 10 xfailed in 970.27 seconds ===============
+
+__Note__
+"~" will not resolve to the home directory when used in the py.test command line.
+
+The pytest plugin that we use for running tests has a number of advanced
+command line options available. To see the options available, run
+`py.test --help`. The full documentation for the plugin can be found
+[here][pytest-selenium].
+
+__Troubleshooting__
+
+If the test run hangs with Firefox open but no URL gets entered in the address
+box, some combinations of the Firefox version, and the python Selenium bindings
+version may not be compatible. Upgrading each of them to latest often fixes it.
+
+Tips and tricks
+---------------
+
+Because Selenium opens real browser windows, it will steal focus and switch
+workspaces. Firefox doesn't have a headless mode of operation, so we can't
+simply turn off the UI.
+
+__Use a different driver__
+
+[pytest-selenium] provides the ability to run tests against [many other][test envs] browser environments -- consider using a different driver executable or external provider.
+
+__xvfb__
+
+Xvfb provides a fairly easily work around on Linux.
+
+
+On Linux:
+
+    Install Xvfb and run the tests with it's xvfb-run binary. For
+    example, if you run tests like::
+
+        $ py.test ...
+
+
+    You can switch to this to run with Xvfb::
+
+        $ xvfb-run py.test ...
+
+
+    This creates a virtual X session for Firefox to run in, and sets
+    up all the fiddly environment variables to get this working
+    well. The tests will run as normal, and no windows will open, if
+    all is working right.
+
+
+Getting involved as a contributor
+---------------------------------
+
+We love working with contributors to improve the Selenium test coverage on
+Socorro but it does require a few skills.  You will need to be familiar
+with Python, Selenium, and have a working knowledge of GitHub.
+
+If you are comfortable with Python, it's worth having a look at the Selenium
+framework to understand the basic concepts of browser-based testing and the
+page objects pattern.
+
+If you need to brush up on programming but are eager to start contributing
+immediately, please consider helping out by doing manual testing.  You can
+help find bugs in Mozilla [Firefox][firefox] or find bugs in the Mozilla web
+sites tested by the [Firefox Test Engineering][firefoxtesteng] team.  We have many projects that would be
+thrilled to have your help!
+
+To brush up on Python skills before engaging with us, [Dive Into Python][dive]
+is an excellent resource.  MIT also has [lecture notes on Python][mit] available
+through their open courseware.  The programming concepts you will need to know
+include functions, working with classes, and the basics of object-oriented
+programming.
+
+Questions are always welcome
+----------------------------
+While we take great pains to keep our documentation updated, the best source of
+information is those of us who work on the project.  Don't be afraid to join us
+in irc.mozilla.org #fx-test to ask questions about our Selenium tests.  Mozilla
+also hosts the #breakpad chat room to answer your general questions about
+the Socorro project.
+
+Writing Tests
+-------------
+
+If you want to get involved and add more tests, then there are just a few things
+we'd like to ask you to do:
+
+1. Use the [template files][GitHub Templates] for all new tests and page objects
+2. Follow our simple [style guide][Style Guide]
+3. Fork this project with your own GitHub account
+4. Make sure all tests are passing, and submit a pull request with your changes
+5. Always feel free to reach out to us and ask questions. We'll do our best to help get you started and unstuck.
+
+License
+-------
+This software is licensed under the [MPL] 2.0:
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+[mit]: http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-189-a-gentle-introduction-to-programming-using-python-january-iap-2011/
+[dive]: http://www.diveintopython.net/toc/index.html
+[firefoxtesteng]: https://quality.mozilla.org/teams/test-engineering/
+[firefox]: http://quality.mozilla.org/teams/desktop-firefox/
+[webdriver]: http://seleniumhq.org/docs/03_webdriver.html
+[mozwebqa]:http://02.chat.mibbit.com/?server=irc.mozilla.org&channel=#mozwebqa
+[GitWin]: http://help.github.com/win-set-up-git/
+[GitMacOSX]: http://help.github.com/mac-set-up-git/
+[GitLinux]: http://help.github.com/linux-set-up-git/
+[breakpad]:http://02.chat.mibbit.com/?server=irc.mozilla.org&channel=#breakpad
+[venv]: http://pypi.python.org/pypi/virtualenv
+[wrapper]: http://www.doughellmann.com/projects/virtualenvwrapper/
+[GitHub Templates]: https://github.com/mozilla/mozwebqa-examples
+[Style Guide]: https://wiki.mozilla.org/QA/Execution/Web_Testing/Docs/Automation/StyleGuide
+[MPL]: http://www.mozilla.org/MPL/2.0/
+[pytest-selenium]: http://pytest-selenium.readthedocs.org/
+[test envs]: http://pytest-selenium.readthedocs.io/en/latest/user_guide.html#specifying-a-browser

--- a/e2e-tests/pages/base_page.py
+++ b/e2e-tests/pages/base_page.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import urllib2
+
+from pypom import Page, Region
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support.select import Select
+
+
+class CrashStatsBasePage(Page):
+
+    _page_heading_locator = (By.CSS_SELECTOR, 'div.page-heading > h2')
+    _link_to_bugzilla_locator = (By.CSS_SELECTOR, '.panel a')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.is_element_present(*self._page_heading_locator))
+        return self
+
+    @property
+    def page_heading(self):
+        return self.find_element(*self._page_heading_locator).text
+
+    def get_random_indexes(self, item_list, max_indexes, start=0, end=-1):
+        """
+            Return a list of random indexes for a list of items
+            max_indexes is maximum # of indexes to return
+            'start' is start of index range, defaults to zero
+            'end' is end of index range, as used by range( ), defaults to length of item_list
+        """
+        import random
+        if end < 0:
+            end = len(item_list)
+        return [random.randrange(start, end) for _ in range(0, min(max_indexes, len(item_list)))]
+
+    @property
+    def link_to_bugzilla(self):
+        return self.find_element(*self._link_to_bugzilla_locator).get_attribute('href')
+
+    @property
+    def header(self):
+        return self.Header(self)
+
+    @property
+    def footer(self):
+        return self.Footer(self)
+
+    class Header(Region):
+
+        _find_crash_id_or_signature = (By.ID, 'q')
+        _product_select_locator = (By.ID, 'products_select')
+        _report_select_locator = (By.ID, 'report_select')
+        _all_versions_locator = (By.ID, 'product_version_select')
+        _current_versions_locator = (By.CSS_SELECTOR, 'optgroup:nth-of-type(2) option')
+        _versions_locator = (By.TAG_NAME, 'option')
+        _loader_locator = (By.CLASS_NAME, 'loader')
+        _super_search_locator = (By.LINK_TEXT, 'Super Search')
+
+        @property
+        def current_product(self):
+            element = self.find_element(*self._product_select_locator)
+            select = Select(element)
+            return select.first_selected_option.text
+
+        @property
+        def current_version(self):
+            element = self.find_element(*self._all_versions_locator)
+            select = Select(element)
+            return select.first_selected_option.text
+
+        @property
+        def current_versions(self):
+            from pages.version import FirefoxVersion
+            current_versions = []
+            for element in self.find_element(*self._all_versions_locator).find_elements(*self._current_versions_locator):
+                str(current_versions.append(FirefoxVersion(element.text)))
+            return current_versions
+
+        @property
+        def version_select_text(self):
+            '''
+                Return the text in the Version selector
+            '''
+            versions = []
+            for element in self.find_element(*self._all_versions_locator).find_elements(*self._versions_locator):
+                versions.append(element.text)
+            return versions
+
+        @property
+        def current_report(self):
+            element = self.find_element(*self._report_select_locator)
+            select = Select(element)
+            return select.first_selected_option.text
+
+        @property
+        def product_list(self):
+            element = self.find_element(*self._product_select_locator)
+            return [option.text for option in Select(element).options]
+
+        def select_product(self, application):
+            '''
+                Select the Mozilla Product you want to report on
+            '''
+            element = self.find_element(*self._product_select_locator)
+            select = Select(element)
+            return select.select_by_visible_text(application)
+
+        def select_version(self, version):
+            '''
+                Select the version of the application you want to report on
+            '''
+            version_dropdown = self.find_element(*self._all_versions_locator)
+            select = Select(version_dropdown)
+            select.select_by_visible_text(str(version))
+
+        def select_version_by_index(self, index):
+            '''
+                Select the version of the application you want to report on
+            '''
+            version_dropdown = self.find_element(*self._all_versions_locator)
+            select = Select(version_dropdown)
+            select.select_by_index(index)
+
+        def select_report(self, report_name):
+            '''
+                Select the report type from the drop down
+                and wait for the page to reload
+            '''
+            report_dropdown = self.find_element(*self._report_select_locator)
+            select = Select(report_dropdown)
+            select.select_by_visible_text(report_name)
+
+            if 'Top Crashers' == report_name:
+                from pages.crash_stats_top_crashers_page import CrashStatsTopCrashers
+                return CrashStatsTopCrashers(self.selenium, self.page.base_url).wait_for_page_to_load()
+            elif 'Top Crashers by TopSite' == report_name:
+                from pages.crash_stats_top_crashers_by_site_page import CrashStatsTopCrashersBySite
+                return CrashStatsTopCrashersBySite(self.selenium, self.page.base_url).wait_for_page_to_load()
+            elif 'Crashes per Day' == report_name:
+                from pages.crash_stats_per_day import CrashStatsPerDay
+                return CrashStatsPerDay(self.selenium, self.page.base_url).wait_for_page_to_load()
+            elif 'Nightly Builds' == report_name:
+                from pages.crash_stats_nightly_builds_page import CrashStatsNightlyBuilds
+                return CrashStatsNightlyBuilds(self.selenium, self.page.base_url).wait_for_page_to_load()
+
+        def search_for_crash(self, crash_id_or_signature):
+            '''
+                Type the signature or the id of a bug into the search bar and submit the form
+            '''
+            search_box = self.find_element(*self._find_crash_id_or_signature)
+            # explicitly only testing search and not the onfocus event which clears the
+            # search field
+            search_box.clear()
+            search_box.send_keys(crash_id_or_signature)
+            search_box.send_keys(Keys.RETURN)
+            self.wait.until(lambda s: not self.is_element_present(*self._loader_locator))
+
+            from pages.super_search_page import CrashStatsSuperSearch
+            return CrashStatsSuperSearch(self.selenium, self.page.base_url).wait_for_page_to_load()
+
+        @property
+        def report_list(self):
+            report_dropdown = self.find_element(*self._report_select_locator)
+            select = Select(report_dropdown)
+            return [opt.text for opt in select.options]
+
+        def click_super_search(self):
+            self.find_element(*self._super_search_locator).click()
+            from pages.super_search_page import CrashStatsSuperSearch
+            return CrashStatsSuperSearch(self.selenium, self.page.base_url).wait_for_page_to_load()
+
+    class Footer(Region):
+
+        _browserid_login_locator = (By.CSS_SELECTOR, 'div.login a.browserid-login')
+        _browserid_logout_locator = (By.CSS_SELECTOR, 'div.login a.browserid-logout')
+
+        @property
+        def is_logged_out(self):
+            return self.find_element(*self._browserid_login_locator).is_displayed()
+
+        @property
+        def is_logged_in(self):
+            return self.find_element(*self._browserid_logout_locator).is_displayed()
+
+        def login(self, email=None, password=None):
+            '''
+                Login using persona - if no email is specified a one time set of
+                verified persona credentials, email and password, are generated
+                and used.
+                :param email: verified BrowserID email
+                :param password: BrowserID password
+            '''
+            if email is None:
+                credentials = self.get_new_persona_credentials()
+                email = credentials['email']
+                password = credentials['password']
+
+            self.find_element(*self._browserid_login_locator).click()
+
+            from bidpom import BIDPOM
+            pop_up = BIDPOM(self.selenium, self.timeout)
+            pop_up.sign_in(email, password)
+            self.wait.until(lambda s: self.is_logged_in, message='Could not log in within %s seconds.' % self.timeout)
+
+        def logout(self):
+            self.find_element(*self._browserid_logout_locator).click()
+            self.wait.until(lambda s: self.is_logged_out, message='Could not log out within %s seconds.' % self.timeout)
+
+        def get_new_persona_credentials(self):
+            url = "http://personatestuser.org/email/"
+            response = urllib2.urlopen(url).read()
+            decode = json.loads(response)
+            credentials = {
+                'email': decode['email'],
+                'password': decode['pass']
+            }
+            return credentials

--- a/e2e-tests/pages/crash_report_page.py
+++ b/e2e-tests/pages/crash_report_page.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pypom import Region
+from selenium.webdriver.common.by import By
+
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashReport(CrashStatsBasePage):
+
+    _reports_tab_locator = (By.ID, 'reports')
+    _results_count_locator = (By.CSS_SELECTOR, 'span.totalItems')
+    _reports_row_locator = (By.CSS_SELECTOR, '#reports-list tbody tr')
+    _report_tab_button_locator = (By.CSS_SELECTOR, '#panels-nav .reports')
+    _summary_table_locator = (By.CSS_SELECTOR, '.content')
+
+    def wait_for_page_to_load(self):
+        super(CrashReport, self).wait_for_page_to_load()
+        self.wait.until(lambda s: self.is_element_displayed(*self._summary_table_locator))
+        return self
+
+    @property
+    def reports(self):
+        return [self.Report(self, el) for el in self.find_elements(*self._reports_row_locator)]
+
+    @property
+    def results_count_total(self):
+        return int(self.find_element(*self._results_count_locator).text.replace(",", ""))
+
+    def click_reports_tab(self):
+        self.find_element(*self._report_tab_button_locator).click()
+        self.wait.until(lambda s: len(self.reports))
+
+    class Report(Region):
+
+        _product_locator = (By.CSS_SELECTOR, 'td:nth-of-type(3)')
+        _version_locator = (By.CSS_SELECTOR, 'td:nth-of-type(4)')
+        _report_date_link_locator = (By.CSS_SELECTOR, '#reports-list a.external-link')
+
+        @property
+        def product(self):
+            return self.find_element(*self._product_locator).text
+
+        @property
+        def version(self):
+            return self.find_element(*self._version_locator).text
+
+        def click_report_date(self):
+            self.find_element(*self._report_date_link_locator).click()
+            from uuid_report import UUIDReport
+            return UUIDReport(self.selenium, self.page.base_url).wait_for_page_to_load()

--- a/e2e-tests/pages/crash_stats_nightly_builds_page.py
+++ b/e2e-tests/pages/crash_stats_nightly_builds_page.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashStatsNightlyBuilds(CrashStatsBasePage):
+
+    _link_to_ftp_locator = (By.CSS_SELECTOR, '.notitle > p > a')
+
+    @property
+    def link_to_ftp(self):
+        return self.find_element(*self._link_to_ftp_locator).get_attribute('href')
+
+    def click_link_to_ftp(self):
+        self.find_element(*self._link_to_ftp_locator).click()

--- a/e2e-tests/pages/crash_stats_per_day.py
+++ b/e2e-tests/pages/crash_stats_per_day.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
+
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashStatsPerDay(CrashStatsBasePage):
+
+    _product_select_locator = (By.ID, 'daily_search_version_form_products')
+    _date_start_locator = (By.CSS_SELECTOR, '.daily_search_body .date[name="date_start"]')
+    _generate_button_locator = (By.ID, 'daily_search_version_form_submit')
+    _table_locator = (By.ID, 'crash_data')
+    _row_table_locator = (By.CSS_SELECTOR, '#crash_data > tbody > tr')
+
+    @property
+    def product_select(self):
+        element = self.find_element(*self._product_select_locator)
+        select = Select(element)
+        return select.first_selected_option.text
+
+    def type_start_date(self, date):
+        date_element = self.find_element(*self._date_start_locator)
+        date_element.clear()
+        date_element.send_keys(date)
+
+    def click_generate_button(self):
+        self.find_element(*self._generate_button_locator).click()
+
+    @property
+    def is_table_visible(self):
+        return self.is_element_displayed(None, *self._table_locator)
+
+    @property
+    def table_row_count(self):
+        return len(self.find_elements(self._row_table_locator))
+
+    @property
+    def last_row_date_value(self):
+        return self.find_elements(*self._row_table_locator)[:1].text

--- a/e2e-tests/pages/crash_stats_top_crashers_by_site_page.py
+++ b/e2e-tests/pages/crash_stats_top_crashers_by_site_page.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashStatsTopCrashersBySite(CrashStatsBasePage):
+
+    _product_header_locator = (By.ID, 'tcburl-product')
+    _product_version_header_locator = (By.ID, 'tcburl-version')
+
+    @property
+    def product_header(self):
+        return self.find_element(*self._product_header_locator).text
+
+    @property
+    def product_version_header(self):
+        return self.find_element(self._product_version_header_locator).text

--- a/e2e-tests/pages/crash_stats_top_crashers_page.py
+++ b/e2e-tests/pages/crash_stats_top_crashers_page.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import random
+
+from pypom import Region
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashStatsTopCrashers(CrashStatsBasePage):
+
+    _page_heading_product_locator = (By.ID, 'current-product')
+    _page_heading_version_locator = (By.ID, 'current-version')
+
+    _filter_by_locator = (By.CSS_SELECTOR, '.tc-duration-type.tc-filter > li > a')
+    _filter_days_by_locator = (By.CSS_SELECTOR, '.tc-duration-days.tc-filter > li > a')
+    _filter_os_by_locator = (By.CSS_SELECTOR, '.tc-per-platform.tc-filter > li > a')
+    _current_filter_type_locator = (By.CSS_SELECTOR, 'ul.tc-duration-type li a.selected')
+    _current_days_filter_locator = (By.CSS_SELECTOR, 'ul.tc-duration-days li a.selected')
+    _current_os_filter_locator = (By.CSS_SELECTOR, 'ul.tc-per-platform li a.selected')
+    _no_results_locator = (By.CSS_SELECTOR, 'p.no-results')
+
+    @property
+    def _signature_table_row_locator(self):
+        if self.current_os_filter == "All":
+            return (By.CSS_SELECTOR, '#signature-list tbody tr')
+        else:
+            return (By.CSS_SELECTOR, '#peros-tbl tbody tr')
+
+    @property
+    def page_heading_product(self):
+        return self.find_element(*self._page_heading_product_locator).text
+
+    @property
+    def page_heading_version(self):
+        return self.find_element(*self._page_heading_version_locator).text
+
+    @property
+    def results_count(self):
+        return len(self.find_elements(*self._signature_table_row_locator))
+
+    @property
+    def results_found(self):
+        try:
+            return self.results_count > 0
+        except NoSuchElementException:
+            return False
+
+    @property
+    def no_results_text(self):
+        if self.is_element_present(*self._no_results_locator):
+            return self.find_element(*self._no_results_locator).text
+        else:
+            return False
+
+    def click_filter_by(self, option):
+        for element in self.find_elements(*self._filter_by_locator):
+            if element.text == option:
+                element.click()
+                return CrashStatsTopCrashers(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def click_filter_days_by(self, days):
+        '''
+            Click on the link with the amount of days you want to filter by
+        '''
+        for element in self.find_elements(*self._filter_days_by_locator):
+            if element.text == days:
+                element.click()
+                return CrashStatsTopCrashers(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def click_filter_os_by(self, os):
+        '''
+            Click on the link with the OS you want to filter by
+        '''
+        for element in self.find_elements(*self._filter_os_by_locator):
+            if element.text == os:
+                element.click()
+                return CrashStatsTopCrashers(self.selenium, self.base_url).wait_for_page_to_load()
+
+    @property
+    def current_filter_type(self):
+        return self.find_element(*self._current_filter_type_locator).text
+
+    @property
+    def current_days_filter(self):
+        return self.find_element(*self._current_days_filter_locator).text
+
+    @property
+    def current_os_filter(self):
+        return self.find_element(*self._current_os_filter_locator).text
+
+    @property
+    def signature_items(self):
+        return [self.SignatureItem(self, el) for el in self.find_elements(*self._signature_table_row_locator)]
+
+    def random_signature_items(self, count):
+        signature_items = self.signature_items
+        random_signature_items = []
+        for i in range(0, count):
+            random_signature_items.append(random.choice(signature_items))
+        return random_signature_items
+
+    def click_first_signature(self):
+        return self.signature_items[0].click()
+
+    @property
+    def first_signature_title(self):
+        return self.signature_items[0].title
+
+    class SignatureItem(Region):
+        _signature_link_locator = (By.CSS_SELECTOR, 'a.signature')
+        _browser_icon_locator = (By.CSS_SELECTOR, 'div img.browser')
+        _plugin_icon_locator = (By.CSS_SELECTOR, 'div img.plugin')
+
+        def click(self):
+            self.find_element(*self._signature_link_locator).click()
+            from pages.crash_report_page import CrashReport
+            return CrashReport(self.selenium, self.page.base_url).wait_for_page_to_load()
+
+        @property
+        def title(self):
+            return self.find_element(*self._signature_link_locator).get_attribute('title')
+
+        @property
+        def is_plugin_icon_visible(self):
+            return self.is_element_displayed(*self._plugin_icon_locator)
+
+        @property
+        def is_browser_icon_visible(self):
+            return self.is_element_displayed(*self._browser_icon_locator)

--- a/e2e-tests/pages/home_page.py
+++ b/e2e-tests/pages/home_page.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pypom import Region
+from selenium.webdriver.common.by import By
+
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashStatsHomePage(CrashStatsBasePage):
+
+    URL_TEMPLATE = '/'
+
+    _graph_loading_locator = (By.CSS_SELECTOR, '#homepage-graph .loading')
+    _release_channels_locator = (By.CSS_SELECTOR, '.release_channel')
+
+    def wait_for_page_to_load(self):
+        super(CrashStatsHomePage, self).wait_for_page_to_load()
+        self.wait.until(lambda s: not self.is_element_present(*self._graph_loading_locator))
+        return self
+
+    @property
+    def release_channels(self):
+        return [self.ReleaseChannels(self, el) for el in self.find_elements(*self._release_channels_locator)]
+
+    class ReleaseChannels(Region):
+
+        _release_channel_header_locator = (By.TAG_NAME, 'h4')
+        _top_crashers_link_locator = (By.LINK_TEXT, 'Top Crashers')
+
+        @property
+        def product_version_label(self):
+            return self.find_element(*self._release_channel_header_locator).text
+
+        def click_top_crasher(self):
+            self.find_element(*self._top_crashers_link_locator).click()
+            from pages.crash_stats_top_crashers_page import CrashStatsTopCrashers
+            return CrashStatsTopCrashers(self.selenium, self.page.base_url)

--- a/e2e-tests/pages/super_search_page.py
+++ b/e2e-tests/pages/super_search_page.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+from pypom import Region
+from pages.base_page import CrashStatsBasePage
+
+
+class CrashStatsSuperSearch(CrashStatsBasePage):
+
+    _page_title = 'Search - Mozilla Crash Reports'
+    _page_loaded_locator = (By.CSS_SELECTOR, '#s2id_simple-product input')
+    _advanced_search_loaded_locator = (By.CSS_SELECTOR, '#advanced-search .select2-container-active')
+    _search_button_locator = (By.ID, 'search-button')
+
+    # Simple Search
+    _simple_search_product_field_locator = (By.CSS_SELECTOR, '#s2id_simple-product input')
+    _simple_search_version_field_locator = (By.CSS_SELECTOR, '#s2id_simple-version input')
+    _simple_search_platform_field_locator = (By.CSS_SELECTOR, '#s2id_simple-platform input')
+    _simple_search_platform_text_locator = (By.CSS_SELECTOR, '#s2id_simple-product .select2-choices li div')
+
+    # Advanced Search
+    _new_line_button_locator = (By.CSS_SELECTOR, 'button.new-line')
+    _highlighted_text_locator = (By.CSS_SELECTOR, 'li[class*="highlighted"]')
+    _facet_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(2) span:first-child')
+    _facet_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .field')
+    _operator_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(4) span')
+    _operator_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .operator')
+    _match_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .select2-search-field input')
+    _match_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(6) div')
+
+    # More options section
+    _more_options_locator = (By.CSS_SELECTOR, '.options h4')
+    _more_options_facet_text_locator = (By.CSS_SELECTOR, '#s2id__facets ul li div')
+    _delete_facet_locator = (By.CSS_SELECTOR, '#s2id__facets a.select2-search-choice-close')
+    _input_facet_locator = (By.CSS_SELECTOR, '#s2id__facets ul input')
+    _facet_name_suggestion_locator = (By.CSS_SELECTOR, '.select2-result-label')
+
+    # Search results section
+    _error_text_locator = (By.CSS_SELECTOR, '.errorlist li li')
+    _results_facet_locator = (By.CSS_SELECTOR, '#search_results-nav li:nth-child(2) span')
+    _column_list_locator = (By.CSS_SELECTOR, '#s2id__columns_fake ul li.select2-search-choice')
+    _table_row_locator = (By.CSS_SELECTOR, '#reports-list tbody tr')
+    _loader_locator = (By.CLASS_NAME, 'loader')
+    _crash_reports_tab_locator = (By.CSS_SELECTOR, '#search_results-nav [href="#crash-reports"] span')
+
+    def wait_for_page_to_load(self):
+        super(CrashStatsSuperSearch, self).wait_for_page_to_load()
+        self.wait.until(lambda s: self.is_element_displayed(*self._page_loaded_locator))
+        return self
+
+    # Simple Search form fields
+
+    def select_product(self, product):
+        self.find_element(*self._simple_search_product_field_locator).send_keys(product)
+
+    def select_version(self, version):
+        self.find_element(*self._simple_search_version_field_locator).send_keys(version)
+
+    def select_platform(self, platform):
+        el = self.find_element(*self._simple_search_platform_field_locator)
+        el.send_keys(platform)
+        el.send_keys(Keys.RETURN)
+
+    @property
+    def selected_products(self):
+        return self.find_element(*self._simple_search_platform_text_locator).text
+
+    # Advanced Search form fields
+
+    def click_new_line(self):
+        ''' Opens up the advanced search field options '''
+        self.find_element(*self._new_line_button_locator).click()
+        self.wait.until(lambda s: self.is_element_present(*self._advanced_search_loaded_locator))
+
+    def select_facet(self, line_id, field):
+        input_locator = (self._facet_field_locator[0], self._facet_field_locator[1] % line_id)
+        self.wait.until(lambda s: self.is_element_present(*input_locator))
+        facet_field = self.find_element(*input_locator)
+        facet_field.send_keys(field)
+        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        facet_field.send_keys(Keys.RETURN)
+
+    def select_operator(self, line_id, operator):
+        input_locator = (self._operator_field_locator[0], self._operator_field_locator[1] % line_id)
+        self.wait.until(lambda s: self.is_element_present(*input_locator))
+        operator_field = self.find_element(*input_locator)
+        operator_field.send_keys(operator)
+        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        operator_field.send_keys(Keys.RETURN)
+
+    def select_match(self, line_id, match):
+        input_locator = (self._match_field_locator[0], self._match_field_locator[1] % line_id)
+        self.wait.until(lambda s: self.is_element_present(*input_locator))
+        self.find_element(*input_locator).send_keys(match)
+        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        self.find_element(*self._highlighted_text_locator).click()
+
+    def field(self, line_id):
+        return self.find_element(self._facet_text_locator[0], self._facet_text_locator[1] % line_id).text
+
+    def operator(self, line_id):
+        return self.find_element(self._operator_text_locator[0], self._operator_text_locator[1] % line_id).text
+
+    def match(self, line_id):
+        return self.find_element(self._match_text_locator[0], self._match_text_locator[1] % line_id).text
+
+    @property
+    def error(self):
+        return self.find_element(*self._error_text_locator).text
+
+    def click_search(self):
+        self.find_element(*self._search_button_locator).click()
+        self.wait.until(lambda s: not self.is_element_present(*self._loader_locator))
+
+    def click_more_options(self):
+        self.find_element(*self._more_options_locator).click()
+
+    def click_crash_reports_tab(self):
+        self.wait.until(lambda s: self.is_element_displayed(*self._crash_reports_tab_locator))
+        self.find_element(*self._crash_reports_tab_locator).click()
+
+    # More options section
+    @property
+    def more_options_facet(self):
+        return self.selenium.find_element(*self._more_options_facet_text_locator).text
+
+    def more_options_select_facet(self, facet):
+        self.find_element(*self._input_facet_locator).click()
+        self.find_element(*self._input_facet_locator).send_keys(facet)
+        self.find_element(*self._facet_name_suggestion_locator).click()
+
+    def more_options_delete_facet(self):
+        self.find_element(*self._delete_facet_locator).click()
+        self.wait.until(lambda s: not self.is_element_present(*self._delete_facet_locator))
+
+    # Search results section
+    @property
+    def search_results_table_header(self):
+        return self.SearchResultHeader(self)
+
+    @property
+    def columns(self):
+        return[self.Column(self, el) for el in self.find_elements(*self._column_list_locator)]
+
+    @property
+    def search_results(self):
+        return [self.SearchResult(self, el) for el in self.find_elements(*self._table_row_locator)]
+
+    @property
+    def are_search_results_found(self):
+        return len(self.search_results) > 0
+
+    def wait_for_column_deleted(self, number_of_expected_columns):
+        self.wait.until(lambda s: number_of_expected_columns == len(self.columns))
+
+    def wait_for_facet_in_results(self, facet):
+        self.wait.until(lambda s: facet.lower() in self.results_facet.lower())
+
+    @property
+    def results_facet(self):
+        return self.find_element(*self._results_facet_locator).text
+
+    def is_column_in_list(self, column_name):
+        return column_name in [column.column_name for column in self.columns]
+
+    class SearchResultHeader(Region):
+
+        _table_header_name_locator = (By.CSS_SELECTOR, '#reports-list thead th')
+
+        @property
+        def table_column_names(self):
+            return [el.text.lower() for el in self.find_elements(*self._table_header_name_locator)]
+
+        def is_column_not_present(self, column_name):
+            self.wait.until(
+                lambda s: column_name not in self.table_column_names, message='Column %s found in table header.' % column_name)
+            return True
+
+    class Column(Region):
+
+        _column_name_locator = (By.CSS_SELECTOR, 'div')
+        _column_delete_locator = (By.CSS_SELECTOR, 'a')
+
+        @property
+        def column_name(self):
+            self.wait.until(lambda s: self.is_element_displayed(*self._column_name_locator))
+            return self.find_element(*self._column_name_locator).text
+
+        def delete_column(self):
+            self.find_element(*self._column_delete_locator).click()
+
+    class SearchResult(Region):
+
+        _columns_locator = (By.CSS_SELECTOR, 'td')
+
+        @property
+        def _columns(self):
+            return self.find_elements(*self._columns_locator)

--- a/e2e-tests/pages/super_search_page.py
+++ b/e2e-tests/pages/super_search_page.py
@@ -15,7 +15,7 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
 
     _page_title = 'Search - Mozilla Crash Reports'
     _page_loaded_locator = (By.CSS_SELECTOR, '#s2id_simple-product input')
-    _advanced_search_loaded_locator = (By.CSS_SELECTOR, '#advanced-search .select2-container-active')
+    _advanced_search_loaded_locator = (By.CSS_SELECTOR, '#advanced-search .select2-container')
     _search_button_locator = (By.ID, 'search-button')
 
     # Simple Search
@@ -28,8 +28,8 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
     _new_line_button_locator = (By.CSS_SELECTOR, 'button.new-line')
     _highlighted_text_locator = (By.CSS_SELECTOR, 'li[class*="highlighted"]')
     _facet_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(2) span:first-child')
-    _facet_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .field')
-    _operator_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(4) span')
+    _facet_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .select2-search input')
+    _operator_text_locator = (By.CSS_SELECTOR, '#advanced-se    arch fieldset[id="%s"] > div:nth-child(4) span')
     _operator_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .operator')
     _match_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .select2-search-field input')
     _match_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(6) div')
@@ -76,29 +76,29 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
     def click_new_line(self):
         ''' Opens up the advanced search field options '''
         self.find_element(*self._new_line_button_locator).click()
-        self.wait.until(lambda s: self.is_element_present(*self._advanced_search_loaded_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*self._advanced_search_loaded_locator))
 
     def select_facet(self, line_id, field):
         input_locator = (self._facet_field_locator[0], self._facet_field_locator[1] % line_id)
-        self.wait.until(lambda s: self.is_element_present(*input_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*self._highlighted_text_locator))
         facet_field = self.find_element(*input_locator)
         facet_field.send_keys(field)
-        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*self._highlighted_text_locator))
         facet_field.send_keys(Keys.RETURN)
 
     def select_operator(self, line_id, operator):
         input_locator = (self._operator_field_locator[0], self._operator_field_locator[1] % line_id)
-        self.wait.until(lambda s: self.is_element_present(*input_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*input_locator))
         operator_field = self.find_element(*input_locator)
         operator_field.send_keys(operator)
-        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*self._highlighted_text_locator))
         operator_field.send_keys(Keys.RETURN)
 
     def select_match(self, line_id, match):
         input_locator = (self._match_field_locator[0], self._match_field_locator[1] % line_id)
-        self.wait.until(lambda s: self.is_element_present(*input_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*input_locator))
         self.find_element(*input_locator).send_keys(match)
-        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        self.wait.until(lambda s: self.is_element_displayed(*self._highlighted_text_locator))
         self.find_element(*self._highlighted_text_locator).click()
 
     def field(self, line_id):

--- a/e2e-tests/pages/super_search_page.py
+++ b/e2e-tests/pages/super_search_page.py
@@ -15,7 +15,7 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
 
     _page_title = 'Search - Mozilla Crash Reports'
     _page_loaded_locator = (By.CSS_SELECTOR, '#s2id_simple-product input')
-    _advanced_search_loaded_locator = (By.CSS_SELECTOR, '#advanced-search .select2-container')
+    _advanced_search_loaded_locator = (By.CSS_SELECTOR, '#advanced-search .select2-container-active')
     _search_button_locator = (By.ID, 'search-button')
 
     # Simple Search
@@ -28,8 +28,8 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
     _new_line_button_locator = (By.CSS_SELECTOR, 'button.new-line')
     _highlighted_text_locator = (By.CSS_SELECTOR, 'li[class*="highlighted"]')
     _facet_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(2) span:first-child')
-    _facet_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .select2-search input')
-    _operator_text_locator = (By.CSS_SELECTOR, '#advanced-se    arch fieldset[id="%s"] > div:nth-child(4) span')
+    _facet_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .field')
+    _operator_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(4) span')
     _operator_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .operator')
     _match_field_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] .select2-search-field input')
     _match_text_locator = (By.CSS_SELECTOR, '#advanced-search fieldset[id="%s"] > div:nth-child(6) div')

--- a/e2e-tests/pages/uuid_report.py
+++ b/e2e-tests/pages/uuid_report.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base_page import CrashStatsBasePage
+
+
+class UUIDReport(CrashStatsBasePage):
+
+    # https://crash-stats.mozilla.com/report/index/<UUID>
+    _body_uuid_locator = (By.CSS_SELECTOR, '#mainbody #report-header-details code:nth-of-type(1)')
+    _body_signature_locator = (By.CSS_SELECTOR, '#mainbody #report-header-details code:nth-of-type(2)')
+
+    _table_locator = (By.CSS_SELECTOR, 'table.data-table')
+    _table_uuid_locator = (By.CSS_SELECTOR, '#report-index tbody tr:nth-of-type(2) td')
+    _table_signature_locator = (By.CSS_SELECTOR, '#report-index tbody tr:nth-of-type(1) td')
+
+    @property
+    def uuid_in_body(self):
+        return self.find_element(*self._body_uuid_locator).text
+
+    @property
+    def uuid_in_table(self):
+        return self.find_element(*self._table_uuid_locator).text
+
+    @property
+    def signature_in_body(self):
+        return self.find_element(*self._body_signature_locator).text
+
+    @property
+    def signature_in_table(self):
+        return self.find_element(*self._table_signature_locator).text

--- a/e2e-tests/pages/version.py
+++ b/e2e-tests/pages/version.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+from distutils.version import Version
+
+
+class FirefoxVersion(Version):
+    """Version numbering for Firefox.
+
+    The following are valid version numbers (shown in the order that
+    would be obtained by sorting according to the supplied cmp function):
+
+    3.6 3.6.0 (these two are equivalent)
+    4.0
+    5.0a1
+    5.0(beta)
+    5.0b3
+    5.0pre
+    5.0
+    6.0.1
+    17.0
+    17.0esr (newer than 17.0)
+
+    """
+
+    version_re = re.compile(r'^(\d+) \. (\d+) (\. (\d+))?'
+                            r'((a|b|pre|\(beta\)|esr)(\d*))?$',
+                            re.VERBOSE)
+
+    def parse(self, vstring):
+        match = self.version_re.match(vstring)
+        if not match:
+            raise ValueError('invalid version number "%s"' % vstring)
+
+        (major, minor, patch, prerelease, prerelease_num) = \
+            match.group(1, 2, 4, 6, 7)
+
+        self.version = tuple(map(int, [major, minor, patch or 0]))
+
+        self.prerelease = None
+        self.postrelease = None
+
+        if prerelease == "esr":
+            self.postrelease = "esr"
+
+        elif prerelease:
+            try:
+                self.prerelease = (prerelease, int(prerelease_num))
+            except ValueError:
+                self.prerelease = (prerelease, None)
+
+    def __str__(self):
+        if self.version[2] == 0:
+            vstring = '.'.join(map(str, self.version[0:2]))
+        else:
+            vstring = '.'.join(map(str, self.version))
+
+        if self.postrelease:
+            vstring += self.postrelease
+
+        if self.prerelease:
+            prerelease, pr_num = self.prerelease
+            vstring += prerelease + (str(pr_num) if pr_num else '')
+
+        return vstring
+
+    def __repr__(self):
+        return 'FirefoxVersion ("%s")' % str(self)
+
+    def __cmp__(self, other):
+        if isinstance(other, basestring):
+            other = FirefoxVersion(other)
+
+        compare = cmp(self.version, other.version)
+
+        # Numeric versions don't match, so just return the cmp() result.
+        if compare:
+            return compare
+
+        # The versions are the same, so compare the "postreleases".
+
+        if self.postrelease and not other.postrelease:
+            return 1
+        elif not self.postrelease and other.postrelease:
+            return -1
+        # If there is ever another postrelease, logic will need to be
+        # added here to provide comparison for them.
+
+        # The postreleases are the same, so compare the "prereleases".
+
+        # case 1: neither has prerelease; they're equal
+        # case 2: self has prerelease, other doesn't; other is greater
+        # case 3: self doesn't have prerelease, other does: self is greater
+        # case 4: both have prerelease: must compare them!
+
+        if not self.prerelease and not other.prerelease:
+            return 0
+        elif self.prerelease and not other.prerelease:
+            return -1
+        elif not self.prerelease and other.prerelease:
+            return 1
+        else:
+            prereleases = ('a', '(beta)', 'b', 'pre')
+            prerelease_compare = cmp(prereleases.index(self.prerelease[0]),
+                                     prereleases.index(other.prerelease[0]))
+            if not prerelease_compare:
+                if self.prerelease[1] is None and other.prerelease[1] is not None:
+                    return 1
+                elif self.prerelease[1] is not None and other.prerelease[1] is None:
+                    return -1
+                else:
+                    return cmp(self.prerelease[1], other.prerelease[1])
+            else:
+                return prerelease_compare

--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,6 +1,11 @@
-bidpom
-PyPOM
-pytest~=3.0.0
-pytest-selenium
+bidpom==2.0.1
+PyPOM==1.0
+bidpom==2.0.1
+pytest==3.0.2
+pytest-base-url==1.1.0
+pytest-html==1.10.0
+pytest-selenium==1.3.1
+pytest-variables==1.4
 pytest-xdist==1.15.0
+selenium==2.53.6
 requests==2.11.1

--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,0 +1,6 @@
+bidpom
+PyPOM
+pytest~=3.0.0
+pytest-selenium
+pytest-xdist==1.15.0
+requests==2.11.1

--- a/e2e-tests/setup.cfg
+++ b/e2e-tests/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+ignore=E501
+
+[tool:pytest]
+base_url=https://crash-stats.allizom.org
+sensitive_url=mozilla\.org

--- a/e2e-tests/tests/conftest.py
+++ b/e2e-tests/tests/conftest.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def session_capabilities(session_capabilities):
+    session_capabilities.setdefault('tags', []).append('socorro')
+    return session_capabilities

--- a/e2e-tests/tests/test_crash_reports.py
+++ b/e2e-tests/tests/test_crash_reports.py
@@ -118,25 +118,6 @@ class TestCrashReports:
             'Signature in body did not match the signature in the '
 
     @pytest.mark.nondestructive
-    @pytest.mark.parametrize(('product'), [
-        'Firefox',
-        pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')", reason='bug 1299916')('Thunderbird'),
-        'SeaMonkey',
-        'FennecAndroid'])
-    def test_the_product_releases_return_results(self, base_url, selenium, product):
-        csp = CrashStatsHomePage(selenium, base_url).open()
-        csp.header.select_product(product)
-
-        for i in range(len(csp.release_channels)):
-            top_crasher_page = csp.release_channels[i].click_top_crasher()
-            if top_crasher_page.no_results_text is not False:
-                assert 'Range by Report Date instead?' in top_crasher_page.no_results_text
-            else:
-                assert top_crasher_page.results_found, 'No results found'
-            selenium.back()
-            csp.wait_for_page_to_load()
-
-    @pytest.mark.nondestructive
     def test_that_7_days_is_selected_default_for_nightlies(self, base_url, selenium):
         csp = CrashStatsHomePage(selenium, base_url).open()
         top_crashers = csp.release_channels

--- a/e2e-tests/tests/test_crash_reports.py
+++ b/e2e-tests/tests/test_crash_reports.py
@@ -1,0 +1,201 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.home_page import CrashStatsHomePage
+
+
+class TestCrashReports:
+
+    _expected_products = [
+        'Firefox',
+        'Thunderbird',
+        'SeaMonkey',
+        'FennecAndroid']
+
+    @pytest.mark.nondestructive
+    @pytest.mark.parametrize(('product'), [
+        'Firefox',
+        'Thunderbird',
+        'SeaMonkey',
+        'FennecAndroid'])
+    def test_that_reports_form_has_same_product(self, base_url, selenium, product):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        csp.header.select_product(product)
+        assert product in selenium.title
+
+        crash_per_day = csp.header.select_report('Crashes per Day')
+        assert crash_per_day.page_heading == selenium.title
+        assert crash_per_day.header.current_product == crash_per_day.product_select
+
+    @pytest.mark.nondestructive
+    @pytest.mark.parametrize(('product'), [
+        'Firefox',
+        'Thunderbird',
+        'SeaMonkey',
+        'FennecAndroid'])
+    def test_that_current_version_selected_in_top_crashers_header(self, base_url, selenium, product):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        csp.header.select_product(product)
+        cstc = csp.header.select_report('Top Crashers')
+        cstc.header.select_version('Current Versions')
+
+        assert product == cstc.page_heading_product
+        assert cstc.page_heading_version == cstc.header.current_version
+
+    @pytest.mark.nondestructive
+    def test_that_top_crasher_filter_all_return_results(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        product = csp.header.current_product
+        cstc = csp.header.select_report('Top Crashers')
+        if cstc.results_found:
+            assert product == cstc.page_heading_product
+
+        cstc.click_filter_by('All')
+        assert cstc.results_count > 0
+
+    @pytest.mark.nondestructive
+    def test_that_top_crasher_filter_browser_return_results(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        product = csp.header.current_product
+        cstc = csp.header.select_report('Top Crashers')
+        if cstc.results_found:
+            assert product == cstc.page_heading_product
+
+        cstc.click_filter_by('Browser')
+        assert cstc.results_count > 0
+
+    @pytest.mark.nondestructive
+    def test_that_top_crasher_filter_plugin_return_results(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        product = csp.header.current_product
+        cstc = csp.header.select_report('Top Crashers')
+        if cstc.results_found:
+            assert product == cstc.page_heading_product
+
+        cstc.click_filter_by('Plugin')
+        assert cstc.results_count > 0
+
+    @pytest.mark.nondestructive
+    @pytest.mark.parametrize(('product'), _expected_products)
+    def test_that_top_crashers_reports_links_work(self, base_url, selenium, product):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        csp.header.select_product(product)
+
+        for i in range(len(csp.release_channels)):
+            top_crasher_name = csp.release_channels[i].product_version_label
+            top_crasher_page = csp.release_channels[i].click_top_crasher()
+            top_crasher_page.wait_for_page_to_load()
+            assert top_crasher_name in top_crasher_page.page_heading
+            selenium.back()
+            csp.wait_for_page_to_load()
+
+    @pytest.mark.nondestructive
+    def test_top_crasher_reports_tab_has_uuid_report(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        top_crashers = csp.release_channels[-1].click_top_crasher()
+        crash_signature = top_crashers.click_first_signature()
+        crash_signature.click_reports_tab()
+        reports_table_count = len(crash_signature.reports)
+
+        # verify crash reports table is populated
+        assert crash_signature.results_count_total > 0
+        assert reports_table_count > 0, 'No reports found'
+
+        most_recent_report = crash_signature.reports[0]
+        uuid_report = most_recent_report.click_report_date()
+
+        # verify the uuid report page
+        assert '' != uuid_report.uuid_in_body, 'UUID not found in body'
+        assert '' != uuid_report.uuid_in_table, 'UUID not found in table'
+        assert '' != uuid_report.signature_in_body, 'Signature not found in body'
+        assert '' != uuid_report.signature_in_table, 'Signature not found in table'
+        assert (uuid_report.uuid_in_body == uuid_report.uuid_in_table), \
+            'UUID in body did not match the UUID in the table'
+        assert (uuid_report.signature_in_body in uuid_report.signature_in_table), \
+            'Signature in body did not match the signature in the '
+
+    @pytest.mark.nondestructive
+    @pytest.mark.parametrize(('product'), [
+        'Firefox',
+        pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')", reason='bug 1299916')('Thunderbird'),
+        'SeaMonkey',
+        'FennecAndroid'])
+    def test_the_product_releases_return_results(self, base_url, selenium, product):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        csp.header.select_product(product)
+
+        for i in range(len(csp.release_channels)):
+            top_crasher_page = csp.release_channels[i].click_top_crasher()
+            if top_crasher_page.no_results_text is not False:
+                assert 'Range by Report Date instead?' in top_crasher_page.no_results_text
+            else:
+                assert top_crasher_page.results_found, 'No results found'
+            selenium.back()
+            csp.wait_for_page_to_load()
+
+    @pytest.mark.nondestructive
+    def test_that_7_days_is_selected_default_for_nightlies(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        top_crashers = csp.release_channels
+        tc_page = top_crashers[1].click_top_crasher()
+
+        assert '7' == tc_page.current_days_filter
+
+    @pytest.mark.nondestructive
+    def test_that_only_browser_reports_have_browser_icon(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        reports_page = csp.release_channels[-1].click_top_crasher()
+        product_type, days, os = 'Browser', '7', 'Windows'
+        assert product_type == reports_page.current_filter_type
+
+        reports_page.click_filter_days_by(days)
+        reports_page.click_filter_os_by(os)
+        assert product_type == reports_page.current_filter_type
+        assert days == reports_page.current_days_filter
+        assert os == reports_page.current_os_filter
+
+        signature_list_items = reports_page.random_signature_items(19)
+        assert len(signature_list_items) > 0, 'Signature list items not found'
+
+        for signature_item in signature_list_items:
+            assert (signature_item.is_browser_icon_visible), \
+                "Signature %s did not have a browser icon" % signature_item.title
+            assert (not signature_item.is_plugin_icon_visible), \
+                "Signature %s unexpectedly had a plugin icon" % signature_item.title
+
+    @pytest.mark.nondestructive
+    def test_that_only_plugin_reports_have_plugin_icon(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        reports_page = csp.release_channels[-1].click_top_crasher()
+        product_type, days, os = 'Plugin', '28', 'Windows'
+        reports_page.click_filter_by(product_type)
+        reports_page.click_filter_days_by(days)
+        reports_page.click_filter_os_by(os)
+        assert product_type == reports_page.current_filter_type
+        assert days == reports_page.current_days_filter
+        assert os == reports_page.current_os_filter
+
+        signature_list_items = reports_page.signature_items
+
+        assert len(signature_list_items) > 0, 'Signature list items not found'
+
+        for signature_item in signature_list_items[:min(signature_list_items, 24)]:
+            assert (signature_item.is_plugin_icon_visible), \
+                "Signature %s did not have a plugin icon" % signature_item.title
+            assert (not signature_item.is_browser_icon_visible), \
+                "Signature %s unexpectedly had a browser icon" % signature_item.title
+
+    @pytest.mark.nondestructive
+    def test_that_lowest_version_topcrashers_do_not_return_errors(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        lowest_version_index = len(csp.header.version_select_text) - 1
+        csp.header.select_version_by_index(lowest_version_index)
+        cstc = csp.header.select_report('Top Crashers')
+        cstc.click_filter_days_by('14')
+        assert 'error' not in cstc.page_heading
+
+        cstc.click_filter_by('Plugin')
+        assert 'error' not in cstc.page_heading

--- a/e2e-tests/tests/test_layout.py
+++ b/e2e-tests/tests/test_layout.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.home_page import CrashStatsHomePage
+
+
+class TestLayout:
+
+    @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Fennec shouldn't be an option - bug 1292594")
+    def test_that_products_are_sorted_correctly(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        product_list = ['Firefox',
+                        'Thunderbird',
+                        'FennecAndroid',
+                        'SeaMonkey']
+        products = csp.header.product_list
+
+        assert product_list == products, 'Expected products not in the product dropdown'
+
+
+class TestSuperSearchLayout:
+
+    @pytest.mark.nondestructive
+    def test_super_search_page_is_loaded(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        assert cs_super._page_title == selenium.title
+
+    @pytest.mark.nondestructive
+    def test_search_change_column(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        cs_super.click_search()
+        assert cs_super.are_search_results_found
+
+        cs_super.click_more_options()
+
+        # Delete all columns except the last one
+        for column in cs_super.columns[:-1]:
+            cs_super.click_crash_reports_tab()
+            current_column = column.column_name
+            assert current_column in cs_super.search_results_table_header.table_column_names
+
+            number_of_columns = len(cs_super.columns)
+            column.delete_column()
+            cs_super.wait_for_column_deleted(number_of_columns - 1)
+            assert cs_super.is_column_in_list(current_column) is not True
+
+            cs_super.click_search()
+            if len(cs_super.columns) > 1:
+                cs_super.click_crash_reports_tab()
+                assert cs_super.are_search_results_found
+                assert cs_super.search_results_table_header.is_column_not_present(current_column)
+
+        # verify simple search terms have persisted
+        assert 'Firefox' == cs_super.selected_products
+        assert cs_super.columns[0].column_name in cs_super.search_results_table_header.table_column_names
+
+    @pytest.mark.nondestructive
+    def test_search_change_facet(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        cs_super.click_search()
+
+        assert cs_super.more_options_facet in cs_super.results_facet.lower()
+
+        cs_super.click_more_options()
+        cs_super.more_options_delete_facet()
+        cs_super.more_options_select_facet('address')
+        assert 'address' == cs_super.more_options_facet
+
+        cs_super.click_search()
+        # The facet in the results does not update immediately,
+        # so wait for it to be the value we expect
+        cs_super.wait_for_facet_in_results(cs_super.more_options_facet)

--- a/e2e-tests/tests/test_search.py
+++ b/e2e-tests/tests/test_search.py
@@ -1,0 +1,81 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.home_page import CrashStatsHomePage
+
+
+class TestSuperSearch:
+
+    @pytest.mark.nondestructive
+    def test_search_for_unrealistic_data(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        cs_super.select_platform('Windows')
+        # Do an advanced search
+        cs_super.click_new_line()
+        cs_super.select_facet('0', 'date')
+        cs_super.select_operator('0', '>')
+        cs_super.select_match('0', '2000:01:01 00-00')
+        cs_super.click_search()
+        assert 'Enter a valid date/time.' == cs_super.error
+
+    @pytest.mark.nondestructive
+    def test_search_with_one_line(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        cs_super.click_search()
+        assert cs_super.are_search_results_found
+        assert 'Firefox' == cs_super.selected_products
+
+    @pytest.mark.nondestructive
+    def test_search_with_multiple_lines(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        # Do an advanced search
+        cs_super.click_new_line()
+        cs_super.select_facet('0', 'release channel')
+        cs_super.select_operator('0', 'has terms')
+        cs_super.select_match('0', 'nightly')
+        cs_super.click_search()
+        assert cs_super.are_search_results_found
+        # verify simple search terms have persisted
+        assert 'Firefox' == cs_super.selected_products
+        # verify advanced search terms have persisted
+        assert 'release channel' == cs_super.field('0')
+        assert 'has terms' == cs_super.operator('0')
+        assert 'nightly' == cs_super.match('0')
+
+
+class TestSearchForSpecificResults:
+
+    @pytest.mark.nondestructive
+    def test_search_for_valid_signature(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        report_list = csp.release_channels[-1].click_top_crasher()
+        signature = report_list.first_signature_title
+        result = csp.header.search_for_crash(signature)
+
+        assert result.are_search_results_found
+
+    @pytest.mark.nondestructive
+    def test_selecting_one_version_doesnt_show_other_versions(self, base_url, selenium):
+        maximum_checks = 20  # limits the number of reports to check
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        product = csp.header.current_product
+        versions = csp.header.current_versions
+        version = str(versions[1])
+        csp.header.select_version(version)
+        report_list = csp.release_channels[-1].click_top_crasher()
+        crash_report_page = report_list.click_first_signature()
+        crash_report_page.click_reports_tab()
+        reports = crash_report_page.reports
+
+        assert len(reports) > 0, 'reports not found for signature'
+
+        random_indexes = csp.get_random_indexes(reports, maximum_checks)
+        for index in random_indexes:
+            report = reports[index]
+            assert product == report.product

--- a/e2e-tests/tests/test_search.py
+++ b/e2e-tests/tests/test_search.py
@@ -9,6 +9,7 @@ from pages.home_page import CrashStatsHomePage
 
 class TestSuperSearch:
 
+    @pytest.mark.skip("TODO: Update to work with the new date picker")
     @pytest.mark.nondestructive
     def test_search_for_unrealistic_data(self, base_url, selenium):
         csp = CrashStatsHomePage(selenium, base_url).open()

--- a/e2e-tests/tests/test_smoke_tests.py
+++ b/e2e-tests/tests/test_smoke_tests.py
@@ -31,6 +31,7 @@ class TestSmokeTests:
         csp.selenium.get(base_url + self._exploitability_url)
         assert 'Login Required' in csp.page_heading
 
+    @pytest.mark.skip("TODO: Persona is being deprecated - move test to Google Accounts")
     def test_non_privileged_accounts_cannot_view_exploitable_crash_reports(self, base_url, selenium):
         csp = CrashStatsHomePage(selenium, base_url).open()
         csp.footer.login()

--- a/e2e-tests/tests/test_smoke_tests.py
+++ b/e2e-tests/tests/test_smoke_tests.py
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+import urllib
+
+from pages.home_page import CrashStatsHomePage
+
+
+class TestSmokeTests:
+
+    _expected_products = ['Firefox',
+                          'Thunderbird',
+                          'SeaMonkey',
+                          'FennecAndroid']
+    _exploitability_url = '/exploitability/?product=Firefox'
+
+    @pytest.mark.nondestructive
+    def test_that_bugzilla_link_contain_current_site(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        path = '/invalidpath'
+        csp.selenium.get(base_url + path)
+
+        assert 'bug_file_loc=%s%s' % (base_url, path) in urllib.unquote(csp.link_to_bugzilla)
+
+    @pytest.mark.nondestructive
+    def test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        assert 'Exploitable Crashes' not in csp.header.report_list
+        csp.selenium.get(base_url + self._exploitability_url)
+        assert 'Login Required' in csp.page_heading
+
+    def test_non_privileged_accounts_cannot_view_exploitable_crash_reports(self, base_url, selenium):
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        csp.footer.login()
+        assert csp.footer.is_logged_in
+        assert 'Exploitable Crashes' not in csp.header.report_list
+        csp.selenium.get(base_url + self._exploitability_url)
+        assert 'Insufficient Privileges' in csp.page_heading
+        csp.footer.logout()
+        assert csp.footer.is_logged_out


### PR DESCRIPTION
Initial move of the end-to-end functional tests out of QA's repo and into the project repo.

-- Oct 10 --
Adding a few more requirements - thanks @peterbe for the meeting today -
> Let's merge this once the tests pass or skip

- [x] the tests that depend on personatestuser.org (needs a skip)
- [x] the tests that facet on "date" and now times out (needs a fix)
- [x] the SeaMonkey "lack of data" test (needs a fix)
- [x] insure tests pass on our adhoc staging instace - http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/socorro.adhoc/