### PR TITLE
fixes bug 1306048 - ability to connect to S3 by region for symbol upload

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -655,11 +655,11 @@ if (
 
 
 SYMBOLS_FILE_PREFIX = config('SYMBOLS_FILE_PREFIX', 'v1')
-# e.g. "us-west-2" see boto.s3.connection.Location
-# Only needed if the bucket has never been created
+
+# But we set the default to what Mozilla Socorro uses
 SYMBOLS_BUCKET_DEFAULT_LOCATION = config(
     'SYMBOLS_BUCKET_DEFAULT_LOCATION',
-    None
+    'us-west-2'
 )
 
 # This `IMPLEMENTATIONS_DATABASE_URL` is optional. By default, the

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -656,7 +656,7 @@ if (
 
 SYMBOLS_FILE_PREFIX = config('SYMBOLS_FILE_PREFIX', 'v1')
 
-# But we set the default to what Mozilla Socorro uses
+# Set to the default Mozilla Socorro uses
 SYMBOLS_BUCKET_DEFAULT_LOCATION = config(
     'SYMBOLS_BUCKET_DEFAULT_LOCATION',
     'us-west-2'

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -69,17 +69,11 @@ def unpack_and_upload(iterator, symbols_upload, bucket_name, bucket_location):
                 "Setting %s must be set" % key
             )
 
-    conn = boto.connect_s3(
-        settings.AWS_ACCESS_KEY,
-        settings.AWS_SECRET_ACCESS_KEY,
-        # Deliberately commented out until we know a better way to do
-        # this. When connecting to S3 on a Python 2.7 on OSX, you can't
-        # get buckets that dots in the name. But applying this calling_format
-        # thing breaks on our Python 2.7 on production.
-        # So it's commented out, in a rush, until we discover a unified
-        # way of dealing with this on local dev environments as well
-        # as in production.
-        # calling_format=boto.s3.connection.OrdinaryCallingFormat(),
+    conn = boto.s3.connect_to_region(
+        bucket_location,
+        aws_access_key_id=settings.AWS_ACCESS_KEY,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
     )
     assert bucket_name
 


### PR DESCRIPTION
I know this is probably pretty hard to test but here's what I did...

1) I have this in my `.env`
```
# Personal
AWS_ACCESS_KEY=...secret...
AWS_SECRET_ACCESS_KEY=...secret...

SYMBOLS_BUCKET_DEFAULT_LOCATION=us-west-2
#SYMBOLS_BUCKET_DEFAULT_NAME=peterbe-crash-stats-symbols
SYMBOLS_BUCKET_DEFAULT_NAME=peterbe.crash.stats.symbols
```

2) Tried to upload a .zip file and got this error:
```
CertificateError: hostname 'peterbe.crash.stats.symbols.s3.amazonaws.com' doesn't match either of '*.s3.amazonaws.com', 's3.amazonaws.com'
```

3) Applied the patch and uploaded again now now it worked!
<img width="954" alt="screen shot 2016-09-28 at 3 08 36 pm" src="https://cloud.githubusercontent.com/assets/26739/18928304/7634d30e-858d-11e6-86e0-809f00bdd677.png">

Once this PR lands there shouldn't be anything we need to do in config. 