### PR TITLE
Fixes bug 1306208 by adding a link to the MDN search docs.

### DIFF
--- a/webapp-django/crashstats/supersearch/jinja2/supersearch/search.html
+++ b/webapp-django/crashstats/supersearch/jinja2/supersearch/search.html
@@ -20,6 +20,12 @@
                 <li><a href="{{ url('supersearch.search_custom') }}">Custom query</a></li>
                 {% endif %}
             </ul>
+            <div id="sumo-link">
+                <a href="https://developer.mozilla.org/en-US/docs/A_guide_to_searching_crash_reports"
+                   title="MDN documentation on searching crash reports"
+                   rel="noopener"
+                >A guide to searching crash reports</a>
+            </div>
         </nav>
     </div>
 


### PR DESCRIPTION
Here's a screenshot showing the new "A guide to searching crash reports" button.

![super-search](https://cloud.githubusercontent.com/assets/1940286/18941699/916af166-8656-11e6-90f1-230760430ef7.png)
