### PR TITLE
Bug 1305807 remove inline scripts in crashes per user

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/crashes_per_day.html
@@ -11,7 +11,7 @@ Crashes per Day for {{ product }}
 {% endblock %}
 
 {% block content %}
-<div id="mainbody">
+<div id="mainbody" data-graph-data="{{ graph_data | to_json }}">
 
 <div class="page-heading">
     <h2>Crashes per Day for {{ product }}</h2>
@@ -261,8 +261,4 @@ Crashes per Day for {{ product }}
     {% javascript 'jquery_ui' %}
     {% javascript 'metricsgraphics' %}
     {% javascript 'crashes_per_day' %}
-    <script>
-    var DATA = {{ graph_data | json_dumps }};
-    window.socGraphByReportType = false;
-    </script>
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/daily.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/daily.html
@@ -10,7 +10,7 @@
 {% block page_title %}Crashes per Active Daily Install for {{ product }}{% endblock %}
 
 {% block content %}
-<div id="mainbody">
+<div id="mainbody" data-graph-data="{{ graph_data | to_json }}">
 
     <div class="panel">
         <header class="title">
@@ -240,8 +240,4 @@
 {% javascript 'metricsgraphics' %}
 {% javascript 'jquery_ui' %}
 {% javascript 'daily' %}
-<script>
-    var data = {{ graph_data | json_dumps }};
-    window.socGraphByReportType = false;
-</script>
 {% endblock %}

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_day.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/crashes_per_day.js
@@ -1,51 +1,50 @@
-/*global window, $, DATA, MG*/
-/* This file a partial re-write from daily.js (which is deprecated) */
+/*global window, $, MG*/
 
 $(function() {
     'use strict';
 
     var COLORS = ['#6a3d9a', '#e31a1c', '#008800', '#1f78b4'];
 
-    if (window.socGraphByReportType === false) {
-        if (DATA.count) {
-            // Format the graph data.
-            var graphData = [];
-            var legend = [];
-            // This works because there are always
-            // equally many labels as there are ratios
-            // and their order is set.
-            $.each(DATA.labels, function(i, label) {
-                legend.push(label);
-                graphData.push(
-                    $.map(DATA.ratios[i], function(value) {
-                        return {
-                            date: new Date(value[0]),
-                            ratio: value[1]
-                        };
-                    })
-                );
-            });
+    var data = $('#mainbody').data('graph-data');
 
-            // Draw the graph.
-            MG.data_graphic({
-                data: graphData,
-                full_width: true,
-                target: '#crashes-per-adi-graph',
-                x_accessor: 'date',
-                y_accessor: 'ratio',
-                axes_not_compact: true,
-                utc_time: true,
-                interpolate: 'basic',
-                area: false,
-                legend: legend,
-                legend_target: '#crashes-per-adi-legend',
-                show_secondary_x_label: false
-            });
+    if (data.count) {
+        // Format the graph data.
+        var graphData = [];
+        var legend = [];
+        // This works because there are always
+        // equally many labels as there are ratios
+        // and their order is set.
+        $.each(data.labels, function(i, label) {
+            legend.push(label);
+            graphData.push(
+                $.map(data.ratios[i], function(value) {
+                    return {
+                        date: new Date(value[0]),
+                        ratio: value[1]
+                    };
+                })
+            );
+        });
 
-        } else {
-            $('#crashes-per-adi-graph')
-                .text('No results were found.');
-        }
+        // Draw the graph.
+        MG.data_graphic({
+            data: graphData,
+            full_width: true,
+            target: '#crashes-per-adi-graph',
+            x_accessor: 'date',
+            y_accessor: 'ratio',
+            axes_not_compact: true,
+            utc_time: true,
+            interpolate: 'basic',
+            area: false,
+            legend: legend,
+            legend_target: '#crashes-per-adi-legend',
+            show_secondary_x_label: false
+        });
+
+    } else {
+        $('#crashes-per-adi-graph')
+            .text('No results were found.');
     }
 
     $('th.version').each(function() {

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/daily.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/daily.js
@@ -4,44 +4,44 @@ $(function() {
     var aduChartContainer = $("#crashes-per-adi-graph"),
         colours = ['#6a3d9a', '#e31a1c', '#008800', '#1f78b4'];
 
-    if (window.socGraphByReportType === false) {
-        if(data.count > 0) {
+    var data = $('#mainbody').data('graph-data');
 
-            // Format the graph data.
-            var graphData = [];
-            var legend = [];
-            for (var i = 1; i < data.product_versions.length + 1; i++) {
-                graphData.push(
-                    $.map(data['ratio' + i], function(value) {
-                        return {
-                            'date': new Date(value[0]),
-                            'ratio': value[1]
-                        };
-                    })
-                );
+    if(data.count > 0) {
 
-                legend.push(data.labels[i - 1]);
-            }
+        // Format the graph data.
+        var graphData = [];
+        var legend = [];
+        for (var i = 1; i < data.product_versions.length + 1; i++) {
+            graphData.push(
+                $.map(data['ratio' + i], function(value) {
+                    return {
+                        'date': new Date(value[0]),
+                        'ratio': value[1]
+                    };
+                })
+            );
 
-            // Draw the graph.
-            MG.data_graphic({
-                data: graphData,
-                full_width: true,
-                target: '#crashes-per-adi-graph',
-                x_accessor: 'date',
-                y_accessor: 'ratio',
-                axes_not_compact: true,
-                utc_time: true,
-                interpolate: 'basic',
-                area: false,
-                legend: legend,
-                legend_target: '#crashes-per-adi-legend',
-                show_secondary_x_label: false
-            });
-
-        } else {
-            aduChartContainer.text('No results were found.');
+            legend.push(data.labels[i - 1]);
         }
+
+        // Draw the graph.
+        MG.data_graphic({
+            data: graphData,
+            full_width: true,
+            target: '#crashes-per-adi-graph',
+            x_accessor: 'date',
+            y_accessor: 'ratio',
+            axes_not_compact: true,
+            utc_time: true,
+            interpolate: 'basic',
+            area: false,
+            legend: legend,
+            legend_target: '#crashes-per-adi-legend',
+            show_secondary_x_label: false
+        });
+
+    } else {
+        aduChartContainer.text('No results were found.');
     }
 
     $("#daily_search_version_form_products").change(function() {

--- a/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_report.html
@@ -11,7 +11,23 @@
 {% endblock %}
 
 {% block content %}
-<div id="mainbody">
+<div
+    id="mainbody"
+    data-urls-summary="{{ url('signature:signature_summary') }}"
+    data-urls-aggregations="{{ url('signature:signature_report') }}aggregation/"
+    data-urls-reports="{{ url('signature:signature_reports') }}"
+    data-urls-graphs="{{ url('signature:signature_report') }}graphs/"
+    data-urls-bugzilla="{{ url('signature:signature_bugzilla') }}"
+    data-urls-comments="{{ url('signature:signature_comments') }}"
+    data-urls-correlations="{{ url('signature:signature_correlations') }}"
+    data-urls-graph="{{ url('signature:signature_report') }}graphdata/"
+
+    data-channels="{{ channels | to_json }}"
+    data-fields="{{ fields | to_json }}"
+    data-columns="{{ columns | to_json }}"
+    data-sort="{{ sort | join(',') }}"
+    data-default-channel="{{ channel }}"
+>
     <div class="page-heading">
         <h2>Signature report for <em>{{ signature }}</em></h2>
         <p>
@@ -72,25 +88,6 @@
 
 {% block site_js %}
     {{ super() }}
-
-<script>
-var SOURCE_URLS = {
-    'summary': "{{ url('signature:signature_summary') }}",
-    'aggregations': "{{ url('signature:signature_report') }}aggregation/",
-    'reports': "{{ url('signature:signature_reports') }}",
-    'graphs': "{{ url('signature:signature_report') }}graphs/",
-    'bugzilla': "{{ url('signature:signature_bugzilla') }}",
-    'comments': "{{ url('signature:signature_comments') }}",
-    'correlations': "{{ url('signature:signature_correlations') }}",
-    'graph': "{{ url('signature:signature_report') }}graphdata/",
-};
-var BASE_URL = location.protocol + '//' + location.host;
-var FIELDS = {{ fields | json_dumps }};
-var CHANNELS = {{ channels | json_dumps }};
-var COLUMNS = {{ columns | json_dumps }};
-var SORT = "{{ sort | join(',') }}";
-var DEFAULT_CHANNEL = '{{ channel }}';
-</script>
 
 {% javascript 'd3' %}
 {% javascript 'jquery_ui' %}

--- a/webapp-django/crashstats/signature/static/signature/js/signature_report.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_report.js
@@ -9,6 +9,11 @@ var SignatureReport = {
     },
 };
 
+SignatureReport.getURL = function (name) {
+    'use strict';
+    return $('#mainbody').data('urls-' + name);
+};
+
 SignatureReport.init = function () {
     'use strict';
 

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
@@ -28,7 +28,7 @@ SignatureReport.Tab = function (tabName, config) {
 
     // Tab is not loaded until this.showTab is called.
     this.loaded = false;
-    this.dataUrl = window.SOURCE_URLS[this.tabName];
+    this.dataUrl = SignatureReport.getURL(this.tabName);
 
     // Make the HTML elements.
     this.$panelElement = $('<section>',

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_aggregations.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_aggregations.js
@@ -31,8 +31,10 @@ SignatureReport.AggregationsTab.prototype.loadControls = function() {
     this.$selectElement = $('<select>', {'class': 'fields-list'});
     this.$selectElement.append($('<option>'));
 
+    var fields = $('#mainbody').data('fields');
+
     // Append an option element for each field.
-    $.each(window.FIELDS, function(i, field) {
+    $.each(fields, function(i, field) {
         that.$selectElement.append($('<option>', {
             'value': field.id,
             'text': field.text

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_graph.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_graph.js
@@ -30,8 +30,11 @@ SignatureReport.GraphTab.prototype.loadControls = function() {
     var selectElement = $('<select>', {'class': 'channels-list'});
     selectElement.append($('<option>'));
 
+    // Pick up necessary data from the DOM
+    var channels = $('#mainbody').data('channels');
+
     // Make and append and option for each channel.
-    $.each(window.CHANNELS, function (i, channel) {
+    $.each(channels, function (i, channel) {
         selectElement.append($('<option>', {
             'value': channel,
             'text': channel

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_graphs.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_graphs.js
@@ -30,8 +30,11 @@ SignatureReport.GraphsTab.prototype.loadControls = function () {
     this.$selectElement = $('<select>', {'class': 'fields-list'});
     this.$selectElement.append($('<option>'));
 
+    // Pick up necessary data from the DOM
+    var fields = $('#mainbody').data('fields');
+
     // Append an option element for each field.
-    $.each(window.FIELDS, function(i, field) {
+    $.each(fields, function(i, field) {
         that.$selectElement.append($('<option>', {
             'value': field.id,
             'text': field.text

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab_reports.js
@@ -25,24 +25,29 @@ SignatureReport.ReportsTab.prototype.loadControls = function() {
     // For accessing this inside functions.
     var that = this;
 
+    // Pick up necessary data from the DOM
+    var columns = $('#mainbody').data('columns');
+    var fields = $('#mainbody').data('fields');
+    var sort = $('#mainbody').data('sort');
+
     // Make the control elements: an input and an update button.
     // (The hidden input is for select2.)
     var columnsInputHidden = $('<input>',  {
         'type': 'hidden',
         'name': '_columns',
-        'value': window.COLUMNS
+        'value': columns,
     });
 
     this.$columnsInput = $('<input>', {
         'type': 'text',
         'name': '_columns_fake',
-        'value': window.COLUMNS
+        'value': columns,
     });
 
     this.$sortInputHidden = $('<input>', {
         'type': 'hidden',
         'name': '_sort',
-        'value': window.SORT
+        'value': sort,
     });
 
     var updateButton = $('<button>', {
@@ -61,7 +66,7 @@ SignatureReport.ReportsTab.prototype.loadControls = function() {
 
     // Make the columns input sortable.
     this.$columnsInput.select2({
-        'data': window.FIELDS,
+        'data': fields,
         'multiple': true,
         'width': 'element',
         'sortResults': socorro.search.sortResults,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1305807 is about trying to get rid of ALL `<script>` tags. I got started and did the Crashes per user and the Signature report. 

I think there's more yet to be done but I didn't want the PR to get too big. So let's start with this. 

The commits don't close the bug automatically but I'll close this branch with this to start. 