### PR TITLE
Fixes bug 1281540 - Ensure dates are UTC in links to signature report.

### DIFF
--- a/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
+++ b/webapp-django/crashstats/supersearch/static/supersearch/js/socorro/date_filters.js
@@ -69,6 +69,10 @@ $(function () {
                 // will most likely be wrong now.
                 $('.date-shortcuts a').removeClass('selected');
 
+                if (!Array.isArray(dates)) {
+                    dates = [dates];
+                }
+
                 // Set date filters values.
                 dates.forEach(function (value) {
                     var date;
@@ -79,7 +83,7 @@ $(function () {
                         else {
                             date = value.slice(1);
                         }
-                        setDate('from', moment(date).toDate());
+                        setDate('from', moment.utc(date).utcOffset(date).toDate());
                     }
                     else if (value.indexOf('<') === 0) {
                         if (value.indexOf('<=') === 0) {
@@ -88,7 +92,7 @@ $(function () {
                         else {
                             date = value.slice(1);
                         }
-                        setDate('to', moment(date).toDate());
+                        setDate('to', moment.utc(date).utcOffset(date).toDate());
                     }
                 });
             },

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from django import http
 from django.conf import settings
 from django.shortcuts import redirect, render
+from django.utils import timezone
 from django.utils.http import urlquote
 
 from session_csrf import anonymous_csrf
@@ -208,9 +209,9 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
     context['version'] = versions[0]
 
     if tcbs_mode == 'realtime':
-        end_date = datetime.datetime.utcnow().replace(microsecond=0)
+        end_date = timezone.now().replace(microsecond=0)
     elif tcbs_mode == 'byday':
-        end_date = datetime.datetime.utcnow().replace(
+        end_date = timezone.now().replace(
             hour=0, minute=0, second=0, microsecond=0
         )
 


### PR DESCRIPTION
@peterbe Alright, I've got this! ``moment`` is actually a pretty good library to deal with these timezone problems, it just took me some time to find the right functions to use. 

So now, if a date has no timezone, UTC is used. If a date has a timezone, that timezone is used to convert the date to UTC. That is dealt with in the ``datetime_filters`` component directly, when dealing with dates from the URL. 

I also kept the topcrashers's timezone-aware date change, because it's better, but it is not needed to fix the problem. 