### PR TITLE
Add warning about how production RPM is broken

### DIFF
--- a/docs/production-install.rst
+++ b/docs/production-install.rst
@@ -10,6 +10,16 @@ Currently Socorro is supported on CentOS 7
 For any other platform, you must build from source. See
 :ref:`development-chapter` for more information.
 
+.. WARNING::
+
+   October 7th, 2016: The RPM contains a ``socorro-virtualenv/`` that's built
+   using a local install of Python 2.7.11, so it doesn't work on a standard
+   CentOS install.
+
+   This is covered in `bug 1308469
+   <https://bugzilla.mozilla.org/show_bug.cgi?id=1308469>`_.
+
+
 Installing services
 -------------------
 


### PR DESCRIPTION
We create the RPM on a build box using a local install of Python
2.7.11 so the socorro-virtualenv/ that gets created points to Python
libs that don't exist on a standard CentOS install.

This adds a warning about that and a link to the bug in question. This
is a stopgap until it gets fixed.

This is a docs change, so quick r?