### PR TITLE
bug 1305807 - remove inline scripts in topcrashers

### DIFF
--- a/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
+++ b/webapp-django/crashstats/topcrashers/jinja2/topcrashers/topcrashers.html
@@ -6,17 +6,6 @@
 {% endblock %}
 
 {% block site_js %}
-<script type="text/javascript">//<![CDATA[
-    var SocReport = {
-        sig_base: '{{ url('crashstats:correlations_signatures_json') }}',
-        base: '{{ url('crashstats:correlations_json') }}',
-        path: 'product={{ product }}&version={{ version }}',
-        loading: 'Loading <img src="{{ static('img/loading.png') }}" width="16" height="17" />',
-        product: '{{ product }}',
-        version: '{{ version }}',
-    };
-//]]>
-</script>
     {{ super() }}
     {% javascript 'jquery_tablesorter' %}
     {% javascript 'bugzilla' %}
@@ -29,7 +18,13 @@ Top Crashers for {{ product }} {{ ', '.join(query.versions) }}
 {% endblock %}
 
 {% block content %}
-    <div id="mainbody">
+    <div id="mainbody"
+        data-correlations-base="{{ url('crashstats:correlations_json') }}"
+        data-correlations-sig-base="{{ url('crashstats:correlations_signatures_json') }}"
+        data-product="{{ product }}"
+        data-version="{{ version }}"
+        data-loading-img="{{ static('img/loading.png') }}"
+        >
         <div class="page-heading">
             <h2>
                 Top Crashers for <span id="current-product">{{ product }}</span>


### PR DESCRIPTION
Apart from some minor jshint fixes, I did refactor how the `all_signatures` variable worked. I thought it was race condition problem in how jquery executes it's `always` promise. Turns out, that wasn't a problem but I wasn't testing it correctly. However, I decided this is better. 

It used to do this:
```javascript
var all_signatures = {}

function loadajax(callback) {
    $.ajax(...)
    .done(function(result) {
       all_signatures = result
    })
    .always(function() {
       callback(all_signatures)
    })
}
function otherfunction() {
    ...do something with global all_signatures...
}

loadajax(otherfunction)
```

Instead it's like this now:

```javascript
//var all_signatures = {}

function loadajax(callback) {
    $.ajax(...)
    .done(function(result) {
       all_signatures = result
       callback(all_signatures)
    })
}
function otherfunction(all_signatures) {
    ...do something with LOCAL all_signatures...
}

loadajax(otherfunction)
```
