### PR TITLE
Bug 1308824 - add vcruntime140.dll to skiplist

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -187,6 +187,7 @@ strstr
 __swrite
 TlsGetValue
 TouchBadMemory
+vcruntime140\.dll@0x.*
 _VEC_memcpy
 _VEC_memzero
 .*WaitFor.*


### PR DESCRIPTION
Like https://bugzilla.mozilla.org/show_bug.cgi?id=1308795, there is no vcruntime140.dll symbol into socorro now.  So we should add it to prefix skiplist.

When we used old vc, we add MSVCRT120.DLL to skiplist by https://bugzilla.mozilla.org/show_bug.cgi?id=1161067.