### PR TITLE
bug 1309266 - API Tokens form going nuts

### DIFF
--- a/webapp-django/crashstats/tokens/jinja2/tokens/home.html
+++ b/webapp-django/crashstats/tokens/jinja2/tokens/home.html
@@ -108,8 +108,7 @@
             <h2>Generate a New Token</h2>
         </div>
         <div class="body">
-            {% if form %}
-            <form action="" method="post">{% csrf_token %}
+            <form method="post">{% csrf_token %}
                 <table class="data-table">
                     {{ form }}
                     <tr>
@@ -120,9 +119,6 @@
                     </tr>
                 </table>
             </form>
-            {% else %}
-            <p>You currently do not have any permissions to generate tokens for.</p>
-            {% endif %}
         </div>
     </div>
 


### PR DESCRIPTION
This might not solve it. But perhaps. 

It's not valid HTML to have an empty `action` attribute like that. Don't know if that's what's causing the browser to do weird things like submitting the form. Kinda reminds me of how it was dangerous to generate HTML like this `<img src="" ...>` because some browsers thought it would be a valid URL and crazy things could happen. 

Also, the form is always going to be there. It's never non-existent. If you're signed in, with or without any permissions, you can use the form to generate tokens. 