### PR TITLE
Revert "Bug 1296621 let polycrashstorage process cloned objects each time"

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -6,7 +6,6 @@
 saving, fetching and iterating over raw crashes, dumps and processed crashes.
 """
 
-import copy
 import sys
 import os
 import collections
@@ -592,26 +591,13 @@ class PolyCrashStorage(CrashStorageBase):
     def save_raw_and_processed(self, raw_crash, dump, processed_crash,
                                crash_id):
         storage_exception = PolyStorageError()
-
-        def make_deep_copy(crash):
-            """Return a deep copy of the SocorroDotDict.
-            It doesn't work to use `copy.deepcopy(crash)` because the
-            the SocorroDotDict doesn't support that at all.
-            So, instead we convert it to a plain dict, copy that, and
-            convert it back to SocorroDotDict in the end.
-
-            Ideally, we shouldn't be using any of this *DotDict and just
-            use plain dict objects.
-            """
-            return SocorroDotDict(copy.deepcopy(dict(crash)))
-
         for a_store in self.stores.itervalues():
             self.quit_check()
             try:
                 a_store.save_raw_and_processed(
                     raw_crash,
                     dump,
-                    make_deep_copy(processed_crash),
+                    processed_crash,
                     crash_id
                 )
             except Exception:

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -16,7 +16,7 @@ from socorro.external.crashstorage_base import (
     Redactor,
     BenchmarkingCrashStorage,
     MemoryDumpsMapping,
-    FileDumpsMapping,
+    FileDumpsMapping
 )
 from socorro.unittest.testbase import TestCase
 from configman import Namespace, ConfigurationManager
@@ -27,8 +27,11 @@ from mock import Mock
 class A(CrashStorageBase):
     foo = 'a'
     required_config = Namespace()
-    required_config.add_option('x', default=1)
-    required_config.add_option('y', default=2)
+    required_config.add_option('x',
+                               default=1)
+    required_config.add_option('y',
+                               default=2
+                              )
 
     def __init__(self, config, quit_check=None):
         super(A, self).__init__(config, quit_check)
@@ -44,18 +47,9 @@ class A(CrashStorageBase):
 class B(A):
     foo = 'b'
     required_config = Namespace()
-    required_config.add_option('z', default=2)
-
-
-class MutatingProcessedCrashCrashStorage(CrashStorageBase):
-    def save_raw_and_processed(
-        self,
-        raw_crash,
-        dump,
-        processed_crash,
-        crash_id
-    ):
-        del processed_crash['foo']
+    required_config.add_option('z',
+                               default=2
+                              )
 
 
 def fake_quit_check():
@@ -73,39 +67,31 @@ class TestBase(TestCase):
         required_config.update(CrashStorageBase.required_config)
 
         config_manager = ConfigurationManager(
-            [required_config],
-            app_name='testapp',
-            app_version='1.0',
-            app_description='app description',
-            values_source_list=[{
-                'logger': mock_logging,
-            }],
-            argv_source=[]
+          [required_config],
+          app_name='testapp',
+          app_version='1.0',
+          app_description='app description',
+          values_source_list=[{
+            'logger': mock_logging,
+          }],
+          argv_source=[]
         )
 
         with config_manager.context() as config:
             crashstorage = CrashStorageBase(
-                config,
-                quit_check_callback=fake_quit_check
+              config,
+              quit_check_callback=fake_quit_check
             )
             crashstorage.save_raw_crash({}, 'payload', 'ooid')
             crashstorage.save_processed({})
-            assert_raises(
-                NotImplementedError,
-                crashstorage.get_raw_crash, 'ooid'
-            )
-            assert_raises(
-                NotImplementedError,
-                crashstorage.get_raw_dump, 'ooid'
-            )
-            assert_raises(
-                NotImplementedError,
-                crashstorage.get_unredacted_processed, 'ooid'
-            )
-            assert_raises(
-                NotImplementedError,
-                crashstorage.remove, 'ooid'
-            )
+            assert_raises(NotImplementedError,
+                              crashstorage.get_raw_crash, 'ooid')
+            assert_raises(NotImplementedError,
+                              crashstorage.get_raw_dump, 'ooid')
+            assert_raises(NotImplementedError,
+                              crashstorage.get_unredacted_processed, 'ooid')
+            assert_raises(NotImplementedError,
+                              crashstorage.remove, 'ooid')
             eq_(crashstorage.new_crashes(), [])
             crashstorage.close()
 
@@ -135,10 +121,8 @@ class TestBase(TestCase):
 
             with mock.patch("__builtin__.open") as open_mock:
                 open_mock.return_value = mock.MagicMock()
-                (
-                    open_mock.return_value.__enter__
-                    .return_value.read.side_effect
-                ) = open_function
+                open_mock.return_value.__enter__.return_value.read  \
+                   .side_effect = open_function
                 crashstorage.save_raw_crash_with_file_dumps(
                     "fake raw crash",
                     FileDumpsMapping({
@@ -179,21 +163,19 @@ class TestBase(TestCase):
     def test_poly_crash_storage(self):
         n = Namespace()
         n.add_option(
-            'storage',
-            default=PolyCrashStorage,
+          'storage',
+          default=PolyCrashStorage,
         )
         n.add_option(
-            'logger',
-            default=mock.Mock(),
+          'logger',
+          default=mock.Mock(),
         )
-        value = {
-            'storage_classes': (
-                'socorro.unittest.external.test_crashstorage_base.A,'
-                'socorro.unittest.external.test_crashstorage_base.A,'
-                'socorro.unittest.external.test_crashstorage_base.B'
-            ),
-            'storage1.y': 37,
-        }
+        value = {'storage_classes':
+                    'socorro.unittest.external.test_crashstorage_base.A,'
+                    'socorro.unittest.external.test_crashstorage_base.A,'
+                    'socorro.unittest.external.test_crashstorage_base.B',
+                 'storage1.y': 37,
+                }
         cm = ConfigurationManager(n, values_source_list=[value])
         with cm.context() as config:
             eq_(config.storage0.crashstorage_class.foo, 'a')
@@ -203,20 +185,15 @@ class TestBase(TestCase):
 
             poly_store = config.storage(config)
             l = len(poly_store.storage_namespaces)
-            eq_(
-                l, 3,
-                'expected poly_store to have lenth of 3, '
-                'but %d was found instead' % l
-            )
+            eq_(l, 3, 'expected poly_store to have lenth of 3, '
+                                  'but %d was found instead' % l)
             eq_(poly_store.storage_namespaces[0], 'storage0')
             eq_(poly_store.storage_namespaces[1], 'storage1')
             eq_(poly_store.storage_namespaces[2], 'storage2')
             l = len(poly_store.stores)
-            eq_(
-                l, 3,
-                'expected poly_store.store to have lenth of 3, '
-                'but %d was found instead' % l
-            )
+            eq_(l, 3,
+                             'expected poly_store.store to have lenth of 3, '
+                                  'but %d was found instead' % l)
             eq_(poly_store.stores.storage0.foo, 'a')
             eq_(poly_store.stores.storage1.foo, 'a')
             eq_(poly_store.stores.storage2.foo, 'b')
@@ -238,10 +215,10 @@ class TestBase(TestCase):
                 v.save_processed.assert_called_once_with(processed_crash)
 
             poly_store.save_raw_and_processed(
-                raw_crash,
-                dump,
-                processed_crash,
-                'n'
+              raw_crash,
+              dump,
+              processed_crash,
+              'n'
             )
             for v in poly_store.stores.itervalues():
                 v.save_raw_crash.assert_called_with(raw_crash, dump, 'n')
@@ -293,62 +270,21 @@ class TestBase(TestCase):
             for v in poly_store.stores.itervalues():
                 v.close.assert_called_with()
 
-    def test_poly_crash_storage_processed_crash_immutability(self):
-        n = Namespace()
-        n.add_option(
-            'storage',
-            default=PolyCrashStorage,
-        )
-        n.add_option(
-            'logger',
-            default=mock.Mock(),
-        )
-        value = {
-            'storage_classes': (
-                'socorro.unittest.external.test_crashstorage_base'
-                '.MutatingProcessedCrashCrashStorage'
-            ),
-        }
-        cm = ConfigurationManager(n, values_source_list=[value])
-        with cm.context() as config:
-            raw_crash = {'ooid': '12345'}
-            dump = '12345'
-            processed_crash = {'foo': 'bar'}
-
-            poly_store = config.storage(config)
-
-            poly_store.save_raw_and_processed(
-                raw_crash,
-                dump,
-                processed_crash,
-                'n'
-            )
-            # It's important to be aware that the only thing
-            # MutatingProcessedCrashCrashStorage class does, in its
-            # save_raw_and_processed() is that it deletes a key called
-            # 'foo'.
-            # This test makes sure that the dict processed_crash here
-            # is NOT affected.
-            eq_(processed_crash['foo'], 'bar')
-
     def test_fallback_crash_storage(self):
         n = Namespace()
         n.add_option(
-            'storage',
-            default=FallbackCrashStorage,
+          'storage',
+          default=FallbackCrashStorage,
         )
         n.add_option(
-            'logger',
-            default=mock.Mock(),
+          'logger',
+          default=mock.Mock(),
         )
-        value = {
-            'primary.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.A'
-            ),
-            'fallback.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.B'
-            ),
-        }
+        value = {'primary.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.A',
+                 'fallback.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.B',
+                }
         cm = ConfigurationManager(
             n,
             values_source_list=[value],
@@ -369,44 +305,44 @@ class TestBase(TestCase):
             fb_store.fallback_store.save_raw_crash = Mock()
             fb_store.save_raw_crash(raw_crash, dump, crash_id)
             fb_store.primary_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
-            eq_(fb_store.fallback_store.save_raw_crash.call_count, 0)
+            eq_(fb_store.fallback_store.save_raw_crash.call_count,
+                             0)
 
             fb_store.primary_store.save_raw_crash = Mock()
             fb_store.primary_store.save_raw_crash.side_effect = Exception('!')
             fb_store.save_raw_crash(raw_crash, dump, crash_id)
             fb_store.primary_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
             fb_store.fallback_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
 
             fb_store.fallback_store.save_raw_crash = Mock()
             fb_store.fallback_store.save_raw_crash.side_effect = Exception('!')
-            assert_raises(
-                PolyStorageError,
-                fb_store.save_raw_crash,
-                raw_crash,
-                dump,
-                crash_id
-            )
+            assert_raises(PolyStorageError,
+                              fb_store.save_raw_crash,
+                              raw_crash,
+                              dump,
+                              crash_id
+                             )
             fb_store.primary_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
             fb_store.fallback_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
 
             # save_processed tests
@@ -414,32 +350,32 @@ class TestBase(TestCase):
             fb_store.fallback_store.save_processed = Mock()
             fb_store.save_processed(processed_crash)
             fb_store.primary_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
-            eq_(fb_store.fallback_store.save_processed.call_count, 0)
+            eq_(fb_store.fallback_store.save_processed.call_count,
+                             0)
 
             fb_store.primary_store.save_processed = Mock()
             fb_store.primary_store.save_processed.side_effect = Exception('!')
             fb_store.save_processed(processed_crash)
             fb_store.primary_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
             fb_store.fallback_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
 
             fb_store.fallback_store.save_processed = Mock()
             fb_store.fallback_store.save_processed.side_effect = Exception('!')
-            assert_raises(
-                PolyStorageError,
-                fb_store.save_processed,
-                processed_crash
-            )
+            assert_raises(PolyStorageError,
+                              fb_store.save_processed,
+                              processed_crash
+                             )
             fb_store.primary_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
             fb_store.fallback_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
 
             # close tests
@@ -464,29 +400,27 @@ class TestBase(TestCase):
 
             fb_store.fallback_store.close = Mock()
             fb_store.fallback_store.close.side_effect = Exception('!')
-            assert_raises(PolyStorageError, fb_store.close)
+            assert_raises(PolyStorageError,
+                              fb_store.close)
             fb_store.primary_store.close.assert_called_with()
             fb_store.fallback_store.close.assert_called_with()
 
     def test_migration_crash_storage(self):
         n = Namespace()
         n.add_option(
-            'storage',
-            default=MigrationCrashStorage,
+          'storage',
+          default=MigrationCrashStorage,
         )
         n.add_option(
-            'logger',
-            default=mock.Mock(),
+          'logger',
+          default=mock.Mock(),
         )
-        value = {
-            'primary.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.A'
-            ),
-            'fallback.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.B'
-            ),
-            'date_threshold': '150315'
-        }
+        value = {'primary.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.A',
+                 'fallback.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.B',
+                 'date_threshold': '150315'
+                }
         cm = ConfigurationManager(
             n,
             values_source_list=[value],
@@ -506,9 +440,9 @@ class TestBase(TestCase):
             migration_store.fallback_store.save_raw_crash = Mock()
             migration_store.save_raw_crash(raw_crash, dump, after_crash_id)
             migration_store.primary_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                after_crash_id
+              raw_crash,
+              dump,
+              after_crash_id
             )
             eq_(migration_store.fallback_store.save_raw_crash.call_count, 0)
 
@@ -518,9 +452,9 @@ class TestBase(TestCase):
             migration_store.save_raw_crash(raw_crash, dump, before_crash_id)
             eq_(migration_store.primary_store.save_raw_crash.call_count, 0)
             migration_store.fallback_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                before_crash_id
+              raw_crash,
+              dump,
+              before_crash_id
             )
 
             # save_processed tests
@@ -530,7 +464,7 @@ class TestBase(TestCase):
             migration_store.fallback_store.save_processed = Mock()
             migration_store.save_processed(processed_crash)
             migration_store.primary_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
             eq_(migration_store.fallback_store.save_processed.call_count, 0)
 
@@ -541,7 +475,7 @@ class TestBase(TestCase):
             migration_store.save_processed(processed_crash)
             eq_(migration_store.primary_store.save_processed.call_count, 0)
             migration_store.fallback_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
 
             # close tests
@@ -553,9 +487,7 @@ class TestBase(TestCase):
 
             migration_store.primary_store.close = Mock()
             migration_store.fallback_store.close = Mock()
-            migration_store.fallback_store.close.side_effect = (
-                NotImplementedError()
-            )
+            migration_store.fallback_store.close.side_effect = NotImplementedError()
             migration_store.close()
             migration_store.primary_store.close.assert_called_with()
             migration_store.fallback_store.close.assert_called_with()
@@ -568,29 +500,27 @@ class TestBase(TestCase):
 
             migration_store.fallback_store.close = Mock()
             migration_store.fallback_store.close.side_effect = Exception('!')
-            assert_raises(PolyStorageError, migration_store.close)
+            assert_raises(PolyStorageError,
+                              migration_store.close)
             migration_store.primary_store.close.assert_called_with()
             migration_store.fallback_store.close.assert_called_with()
 
     def test_deferred_crash_storage(self):
         n = Namespace()
         n.add_option(
-            'storage',
-            default=PrimaryDeferredStorage,
+          'storage',
+          default=PrimaryDeferredStorage,
         )
         n.add_option(
-            'logger',
-            default=mock.Mock(),
+          'logger',
+          default=mock.Mock(),
         )
-        value = {
-            'primary.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.A'
-            ),
-            'deferred.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.B'
-            ),
-            'deferral_criteria': lambda x: x.get('foo') == 'foo'
-        }
+        value = {'primary.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.A',
+                 'deferred.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.B',
+                  'deferral_criteria': lambda x: x.get('foo') == 'foo'
+                }
         cm = ConfigurationManager(n, values_source_list=[value])
         with cm.context() as config:
             eq_(config.primary.storage_class.foo, 'a')
@@ -608,17 +538,18 @@ class TestBase(TestCase):
             pd_store.deferred_store.save_raw_crash = Mock()
             pd_store.save_raw_crash(raw_crash, dump, crash_id)
             pd_store.primary_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
-            eq_(pd_store.deferred_store.save_raw_crash.call_count, 0)
+            eq_(pd_store.deferred_store.save_raw_crash.call_count,
+                             0)
 
             pd_store.save_raw_crash(deferred_crash, dump, crash_id)
             pd_store.deferred_store.save_raw_crash.assert_called_with(
-                deferred_crash,
-                dump,
-                crash_id
+              deferred_crash,
+              dump,
+              crash_id
             )
 
             # save_processed tests
@@ -626,13 +557,14 @@ class TestBase(TestCase):
             pd_store.deferred_store.save_processed = Mock()
             pd_store.save_processed(processed_crash)
             pd_store.primary_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
-            eq_(pd_store.deferred_store.save_processed.call_count, 0)
+            eq_(pd_store.deferred_store.save_processed.call_count,
+                             0)
 
             pd_store.save_processed(deferred_crash)
             pd_store.deferred_store.save_processed.assert_called_with(
-                deferred_crash
+              deferred_crash
             )
 
             # close tests
@@ -657,32 +589,29 @@ class TestBase(TestCase):
 
             pd_store.deferred_store.close = Mock()
             pd_store.deferred_store.close.side_effect = Exception('!')
-            assert_raises(PolyStorageError, pd_store.close)
+            assert_raises(PolyStorageError,
+                              pd_store.close)
             pd_store.primary_store.close.assert_called_with()
             pd_store.deferred_store.close.assert_called_with()
 
     def test_processed_crash_storage(self):
         n = Namespace()
         n.add_option(
-            'storage',
-            default=PrimaryDeferredProcessedStorage,
+          'storage',
+          default=PrimaryDeferredProcessedStorage,
         )
         n.add_option(
-            'logger',
-            default=mock.Mock(),
+          'logger',
+          default=mock.Mock(),
         )
-        value = {
-            'primary.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.A'
-            ),
-            'deferred.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.B'
-            ),
-            'processed.storage_class': (
-                'socorro.unittest.external.test_crashstorage_base.B'
-            ),
-            'deferral_criteria': lambda x: x.get('foo') == 'foo'
-        }
+        value = {'primary.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.A',
+                 'deferred.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.B',
+                 'processed.storage_class':
+                    'socorro.unittest.external.test_crashstorage_base.B',
+                  'deferral_criteria': lambda x: x.get('foo') == 'foo'
+                }
         cm = ConfigurationManager(
             n,
             values_source_list=[value],
@@ -706,17 +635,18 @@ class TestBase(TestCase):
             pd_store.processed_store.save_raw_crash = Mock()
             pd_store.save_raw_crash(raw_crash, dump, crash_id)
             pd_store.primary_store.save_raw_crash.assert_called_with(
-                raw_crash,
-                dump,
-                crash_id
+              raw_crash,
+              dump,
+              crash_id
             )
-            eq_(pd_store.deferred_store.save_raw_crash.call_count, 0)
+            eq_(pd_store.deferred_store.save_raw_crash.call_count,
+                             0)
 
             pd_store.save_raw_crash(deferred_crash, dump, crash_id)
             pd_store.deferred_store.save_raw_crash.assert_called_with(
-                deferred_crash,
-                dump,
-                crash_id
+              deferred_crash,
+              dump,
+              crash_id
             )
 
             # save_processed tests
@@ -725,13 +655,14 @@ class TestBase(TestCase):
             pd_store.processed_store.save_processed = Mock()
             pd_store.save_processed(processed_crash)
             pd_store.processed_store.save_processed.assert_called_with(
-                processed_crash
+              processed_crash
             )
-            eq_(pd_store.primary_store.save_processed.call_count, 0)
+            eq_(pd_store.primary_store.save_processed.call_count,
+                             0)
 
             pd_store.save_processed(deferred_crash)
             pd_store.processed_store.save_processed.assert_called_with(
-                deferred_crash
+              deferred_crash
             )
 
             # close tests
@@ -756,7 +687,8 @@ class TestBase(TestCase):
 
             pd_store.deferred_store.close = Mock()
             pd_store.deferred_store.close.side_effect = Exception('!')
-            assert_raises(PolyStorageError, pd_store.close)
+            assert_raises(PolyStorageError,
+                              pd_store.close)
             pd_store.primary_store.close.assert_called_with()
             pd_store.deferred_store.close.assert_called_with()
 
@@ -824,22 +756,22 @@ class TestBench(TestCase):
         fake_crash_store = Mock()
 
         config_manager = ConfigurationManager(
-            [required_config],
-            app_name='testapp',
-            app_version='1.0',
-            app_description='app description',
-            values_source_list=[{
-                'logger': mock_logging,
-                'wrapped_crashstore': fake_crash_store,
-                'benchmark_tag': 'test'
-            }],
-            argv_source=[]
+          [required_config],
+          app_name='testapp',
+          app_version='1.0',
+          app_description='app description',
+          values_source_list=[{
+            'logger': mock_logging,
+            'wrapped_crashstore': fake_crash_store,
+            'benchmark_tag': 'test'
+          }],
+          argv_source=[]
         )
 
         with config_manager.context() as config:
             crashstorage = BenchmarkingCrashStorage(
-                config,
-                quit_check_callback=fake_quit_check
+              config,
+              quit_check_callback=fake_quit_check
             )
             crashstorage.start_timer = lambda: 0
             crashstorage.end_timer = lambda: 1


### PR DESCRIPTION
Reverts mozilla/socorro#3459

This made Python CPU spike like crazy. The one I'm logged in to at the moment looks like this:
<img width="2026" alt="screen shot 2016-10-11 at 7 54 16 pm" src="https://cloud.githubusercontent.com/assets/26739/19292761/85d70066-8fec-11e6-80fb-009fb52046bf.png">

184% :)