### PR TITLE
fixes bug 1309731 - link to Google Auth wiki page

### DIFF
--- a/webapp-django/crashstats/authentication/jinja2/auth/login_failure.html
+++ b/webapp-django/crashstats/authentication/jinja2/auth/login_failure.html
@@ -6,6 +6,13 @@
 
 <h4>Unfortunately unable to sign you in.</h4>
 
+<p>
+    If you have problems logging in, please see the
+    <a href="{{ GOOGLE_AUTH_HELP_URL }}"
+        class="google-signin-help">Google Sign-In Help</a>
+    documentation.
+</p>
+
 <h4><a href="/">Return to the home page</a></h4>
 
 </div>

--- a/webapp-django/crashstats/base/jinja2/footer_nav.html
+++ b/webapp-django/crashstats/base/jinja2/footer_nav.html
@@ -7,5 +7,12 @@
         <li><a href="{{ url('api:documentation') }}">API</a></li>
         <li><a href="https://github.com/mozilla/socorro">Source</a></li>
         <li><a href="https://www.mozilla.org/privacy/websites/">Privacy Policy</a></li>
+        <li>
+            <a
+                href="{{ GOOGLE_AUTH_HELP_URL }}"
+                class="google-signin-help">
+                Google Sign-In Help
+            </a>
+        </li>
     </ul>
 </div>

--- a/webapp-django/crashstats/crashstats/context_processors.py
+++ b/webapp-django/crashstats/crashstats/context_processors.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+
+def help_urls(request):
+    return {
+        'GOOGLE_AUTH_HELP_URL': settings.GOOGLE_AUTH_HELP_URL,
+    }

--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/login.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/login.html
@@ -25,6 +25,12 @@
         <p>
           The page you requested requires authentication. Use the login button at the lower right to log in.
         </p>
+        <p>
+            If you have problems logging in, please see the
+            <a href="{{ GOOGLE_AUTH_HELP_URL }}"
+                class="google-signin-help">Google Sign-In Help</a>
+            documentation.
+        </p>
     {% endif %}
     </div>
 </div>

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -137,6 +137,7 @@ _CONTEXT_PROCESSORS = (
     '%s.base.context_processors.google_analytics' % PROJECT_MODULE,
     '%s.base.context_processors.browserid' % PROJECT_MODULE,
     '%s.status.context_processors.status_message' % PROJECT_MODULE,
+    '%s.crashstats.context_processors.help_urls' % PROJECT_MODULE,
 )
 
 TEMPLATES = [
@@ -793,3 +794,6 @@ LAST_LOGIN_MAX = config(
     default=60 * 60 * 24,
     cast=int
 )
+
+
+GOOGLE_AUTH_HELP_URL = 'https://wiki.mozilla.org/Socorro/GoogleAuth'


### PR DESCRIPTION
No matter how I tried, it always looked so untidy and misaligned when the link was there in the right-hand lower corner. 
Considering that a large majority of people don't struggle with Google Sign-In, I think it's better to put it on the left with the other footer links. 