### PR TITLE
bug 1260420 - set featured versions by product-defails.m.o

### DIFF
--- a/socorro/cron/jobs/featured_versions_automatic.py
+++ b/socorro/cron/jobs/featured_versions_automatic.py
@@ -1,0 +1,138 @@
+import re
+
+import requests
+
+from configman import Namespace
+from crontabber.base import BaseCronApp
+from crontabber.mixins import (
+    with_postgres_transactions,
+    with_single_postgres_transaction,
+)
+
+
+def alias_list_to_dict(input_string):
+    aliases = {}
+    for item in input_string.split(','):
+        if not item.strip():
+            continue
+        key, value = item.split(':')
+        aliases[key.strip()] = value.strip()
+    return aliases
+
+
+class DownloadError(Exception):
+    """when downloading a network resource fails"""
+
+
+@with_postgres_transactions()
+@with_single_postgres_transaction()
+class FeaturedVersionsAutomaticCronApp(BaseCronApp):
+    app_name = 'featured-versions-automatic'
+    app_description = """Use https://product-details.mozilla.org/1.0/
+    to automatically figure out what product versions should be
+    set as featured.
+    """
+
+    required_config = Namespace()
+    required_config.add_option(
+        'api_endpoint_url',
+        default=(
+            'https://product-details.mozilla.org/1.0/'
+        ),
+        doc='URL from which we can download all the featured versions'
+    )
+    required_config.add_option(
+        'products',
+        default='firefox,mobile,thunderbird',
+        from_string_converter=lambda line: tuple(
+            [x.strip() for x in line.split(',') if x.strip()]
+        ),
+        doc='a comma-delimited list of products to recognize'
+    )
+    required_config.add_option(
+        'aliases',
+        default='mobile:FennecAndroid',
+        from_string_converter=alias_list_to_dict,
+        doc=(
+            'a comma-delimited list of name:RealName. If a product '
+            'does not need an alias match it by capitalizing the name '
+            '(e.g. "thunderbird" -> "Thunderbird")'
+        )
+    )
+
+    def run(self, connection):
+        assert isinstance(self.config.api_endpoint_url, basestring)
+        assert self.config.api_endpoint_url.endswith('/')
+
+        # The @with_single_postgres_transaction decorator makes
+        # sure this cursor is committed or rolled back and cleaned up.
+        cursor = connection.cursor()
+
+        for product in self.config.products:
+            url = '{}{}_versions.json'.format(
+                self.config.api_endpoint_url,
+                product
+            )
+            response = requests.get(url)
+            if response.status_code != 200:
+                raise DownloadError(
+                    '{} ({})'.format(
+                        url,
+                        response.status_code,
+                    )
+                )
+            versions = response.json()
+            self._set_featured_versions(
+                cursor,
+                product,
+                versions,
+            )
+
+    def _set_featured_versions(self, cursor, product, versions):
+        # 'product_name' is what's it's called in our product_versions
+        # table.
+        product_name = self.config.aliases.get(
+            product,
+            product.capitalize()
+        )
+        featured = set()
+        if product_name == 'Firefox':
+            featured.add(versions['FIREFOX_NIGHTLY'])
+            featured.add(versions['FIREFOX_AURORA'])
+            featured.add(versions['LATEST_FIREFOX_VERSION'])
+            beta = versions['LATEST_FIREFOX_DEVEL_VERSION']
+            # If the beta version is something like '59.0b12'
+            # then convert that to '59.0b' which is basically right-stripping
+            # any numbers after the 'b'.
+            beta = re.sub('b(\d+)$', 'b', beta)
+            featured.add(beta)
+        elif product_name == 'FennecAndroid':
+            featured.add(versions['nightly_version'])
+            featured.add(versions['alpha_version'])
+            featured.add(versions['beta_version'])
+            featured.add(versions['version'])
+        elif product_name == 'Thunderbird':
+            featured.add(versions['LATEST_THUNDERBIRD_DEVEL_VERSION'])
+            featured.add(versions['LATEST_THUNDERBIRD_ALPHA_VERSION'])
+            featured.add(versions['LATEST_THUNDERBIRD_VERSION'])
+        else:
+            raise NotImplementedError(product_name)
+
+        # Remove all previous featured versions
+        cursor.execute("""
+            UPDATE product_versions
+            SET featured_version = false
+            WHERE featured_version = true AND product_name = %s
+        """, (product_name,))
+        cursor.execute("""
+            UPDATE product_versions
+            SET featured_version = true
+            WHERE product_name = %s AND version_string IN %s
+        """, (product_name, tuple(featured)))
+
+        self.config.logger.info(
+            'Set featured versions for {} to: {}'.format(
+                product_name,
+                ', '.join(sorted(featured)),
+            )
+        )

--- a/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
@@ -180,7 +180,7 @@ class IntegrationTestFeaturedVersionsAutomatic(IntegrationTestBase):
         """)
         self.conn.commit()
 
-    def _setup_config_manager(self, api_endpoint_url='https://example.com/'):
+    def _setup_config_manager(self):
         return get_config_manager_for_crontabber(
             jobs=(
                 'socorro.cron.jobs.featured_versions_automatic'
@@ -188,7 +188,9 @@ class IntegrationTestFeaturedVersionsAutomatic(IntegrationTestBase):
             ),
             overrides={
                 'crontabber.class-FeaturedVersionsAutomaticCronApp'
-                '.api_endpoint_url': api_endpoint_url,
+                '.api_endpoint_url': (
+                    'https://example.com/{product}_versions.json'
+                ),
             }
         )
 

--- a/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
@@ -1,0 +1,299 @@
+import datetime
+import json
+
+import mock
+from nose.tools import eq_, ok_
+
+from crontabber.app import CronTabber
+from socorro.unittest.cron.setup_configman import (
+    get_config_manager_for_crontabber,
+)
+
+
+from socorrolib.lib.datetimeutil import utc_now
+from socorro.unittest.cron.jobs.base import IntegrationTestBase
+from socorro.external.postgresql.dbapi2_util import (
+    execute_no_results,
+    execute_query_fetchall,
+)
+
+
+class Response(object):
+    def __init__(self, content, status_code=200):
+        if not isinstance(content, basestring):
+            content = json.dumps(content)
+        self.content = content.strip()
+        self.status_code = status_code
+
+    def json(self):
+        return json.loads(self.content)
+
+
+class IntegrationTestFeaturedVersionsAutomatic(IntegrationTestBase):
+
+    def setUp(self):
+        super(IntegrationTestFeaturedVersionsAutomatic, self).setUp()
+        self.__truncate()
+
+        now = utc_now()
+        build_date = now - datetime.timedelta(days=30)
+        sunset_date = now + datetime.timedelta(days=30)
+
+        execute_no_results(
+            self.conn,
+            """
+            INSERT INTO products
+            (product_name, sort, release_name)
+            VALUES
+            ('Firefox', 1, 'firefox'),
+            ('Fennec', 1, 'mobile')
+            """
+        )
+        execute_no_results(
+            self.conn,
+            """
+            INSERT INTO product_versions
+            (product_version_id, product_name, major_version, release_version,
+            version_string, version_sort, build_date, sunset_date,
+            featured_version, build_type)
+            VALUES
+            (
+                1,
+                'Firefox',
+                '15.0',
+                '15.0',
+                '15.0a1',
+                '000000150a1',
+                %(build_date)s,
+                %(sunset_date)s,
+                true,
+                'release'
+            ),
+            (
+                2,
+                'Firefox',
+                '24.5',
+                '24.5.0',
+                '24.5.0',
+                '024005000x000',
+                %(build_date)s,
+                %(sunset_date)s,
+                true,
+                'nightly'
+            ),
+            (
+                3,
+                'Firefox',
+                '49.0.1',
+                '49.0.1',
+                '49.0.1',
+                '000000150a1',
+                %(build_date)s,
+                %(sunset_date)s,
+                false,
+                'release'
+            ),
+            (
+                4,
+                'Firefox',
+                '50.0b',
+                '50.0b',
+                '50.0b',
+                '024005000x000',
+                %(build_date)s,
+                %(sunset_date)s,
+                false,
+                'beta'
+            ),
+            (
+                5,
+                'Firefox',
+                '51.0a2',
+                '51.0a2',
+                '51.0a2',
+                '000000150a1',
+                %(build_date)s,
+                %(sunset_date)s,
+                false,
+                'aurora'
+            ),
+            (
+                6,
+                'Firefox',
+                '52.0a1',
+                '52.0a1',
+                '52.0a1',
+                '024005000x000',
+                %(build_date)s,
+                %(sunset_date)s,
+                false,
+                'nightly'
+            )
+            """,
+            {
+                'build_date': build_date,
+                'sunset_date': sunset_date
+            }
+        )
+        execute_no_results(
+            self.conn,
+            """
+            INSERT INTO release_channels
+            (release_channel, sort)
+            VALUES
+            ('nightly', 1),
+            ('aurora', 2),
+            ('beta', 3),
+            ('release', 4)
+            """
+        )
+        execute_no_results(
+            self.conn,
+            """
+            INSERT INTO product_release_channels
+            (product_name, release_channel, throttle)
+            VALUES
+            ('Firefox', 'nightly', 1),
+            ('Firefox', 'aurora', 1),
+            ('Firefox', 'beta', 1),
+            ('Firefox', 'release', 1),
+            ('Fennec', 'release', 1),
+            ('Fennec', 'beta', 1)
+            """
+        )
+
+    def tearDown(self):
+        self.__truncate()
+        super(IntegrationTestFeaturedVersionsAutomatic, self).tearDown()
+
+    def __truncate(self):
+        """Named like this because the parent class has a _truncate()
+        which won't be executed by super(IntegrationTestFeaturedVersionsSync)
+        in its setUp()."""
+        self.conn.cursor().execute("""
+        TRUNCATE
+            products,
+            product_versions,
+            release_channels,
+            product_release_channels
+        CASCADE
+        """)
+        self.conn.commit()
+
+    def _setup_config_manager(self, api_endpoint_url='https://example.com/'):
+        return get_config_manager_for_crontabber(
+            jobs=(
+                'socorro.cron.jobs.featured_versions_automatic'
+                '.FeaturedVersionsAutomaticCronApp|1d'
+            ),
+            overrides={
+                'crontabber.class-FeaturedVersionsAutomaticCronApp'
+                '.api_endpoint_url': api_endpoint_url,
+            }
+        )
+
+    @mock.patch('requests.get')
+    def test_basic_run_job(self, rget):
+        config_manager = self._setup_config_manager()
+
+        def mocked_get(url):
+            if 'firefox_versions.json' in url:
+                return Response({
+                    'FIREFOX_NIGHTLY': '52.0a1',
+                    'FIREFOX_AURORA': '51.0a2',
+                    'FIREFOX_ESR': '45.4.0esr',
+                    'FIREFOX_ESR_NEXT': '',
+                    'LATEST_FIREFOX_DEVEL_VERSION': '50.0b7',
+                    'LATEST_FIREFOX_OLDER_VERSION': '3.6.28',
+                    'LATEST_FIREFOX_RELEASED_DEVEL_VERSION': '50.0b7',
+                    'LATEST_FIREFOX_VERSION': '49.0.1'
+                })
+            elif 'mobile_versions.json' in url:
+                return Response({
+                    'nightly_version': '52.0a1',
+                    'alpha_version': '51.0a2',
+                    'beta_version': '50.0b6',
+                    'version': '49.0',
+                    'ios_beta_version': '6.0',
+                    'ios_version': '5.0'
+                })
+            elif 'thunderbird_versions.json' in url:
+                return Response({
+                    'LATEST_THUNDERBIRD_VERSION': '45.4.0',
+                    'LATEST_THUNDERBIRD_DEVEL_VERSION': '50.0b1',
+                    'LATEST_THUNDERBIRD_ALPHA_VERSION': '51.0a2'
+                })
+            else:
+                raise NotImplementedError(url)
+
+        rget.side_effect = mocked_get
+
+        # Check what's set up in the fixture
+        rows = execute_query_fetchall(
+            self.conn,
+            'select product_name, version_string, featured_version '
+            'from product_versions order by version_string'
+        )
+        assert sorted(rows) == [
+            ('Firefox', '15.0a1', True),
+            ('Firefox', '24.5.0', True),
+            ('Firefox', '49.0.1', False),
+            ('Firefox', '50.0b', False),
+            ('Firefox', '51.0a2', False),
+            ('Firefox', '52.0a1', False),
+        ]
+
+        # This is necessary so we get a new cursor when we do other
+        # selects after the crontabber app has run.
+        self.conn.commit()
+
+        with config_manager.context() as config:
+            tab = CronTabber(config)
+            tab.run_all()
+
+            information = self._load_structure()
+            assert information['featured-versions-automatic']
+            assert not information['featured-versions-automatic']['last_error']
+            assert information['featured-versions-automatic']['last_success']
+
+            config.logger.info.assert_called_with(
+                'Set featured versions for Thunderbird to: '
+                '45.4.0, 50.0b1, 51.0a2'
+            )
+
+        rows = execute_query_fetchall(
+            self.conn,
+            'select product_name, version_string, featured_version '
+            'from product_versions'
+        )
+        eq_(
+            sorted(rows),
+            [
+                ('Firefox', '15.0a1', False),
+                ('Firefox', '24.5.0', False),
+                ('Firefox', '49.0.1', True),
+                ('Firefox', '50.0b', True),
+                ('Firefox', '51.0a2', True),
+                ('Firefox', '52.0a1', True),
+            ]
+        )
+
+    @mock.patch('requests.get')
+    def test_download_error(self, rget):
+        config_manager = self._setup_config_manager()
+
+        def mocked_get(url):
+            return Response('not here', status_code=404)
+
+        rget.side_effect = mocked_get
+
+        with config_manager.context() as config:
+            tab = CronTabber(config)
+            tab.run_all()
+
+            information = self._load_structure()
+            assert information['featured-versions-automatic']
+            assert information['featured-versions-automatic']['last_error']
+            error = information['featured-versions-automatic']['last_error']
+            ok_('DownloadError' in error['type'])
+            ok_('404' in error['value'])


### PR DESCRIPTION
I appreciate this is a bit hard to test manually. But I've done it. Perhaps you can simply trust me with the manual testing.

Here's what I did:
```
$ pg_dump -p 5433 -h localhost -U breakpad_rw -a -t product_versions -t products  breakpad  > /tmp/stagedbstuff.sql
$ psql socorro_integration_test < /tmp/stagedbstuff.sql
```
Now, I have in my local PG a bunch of realistic `product_versions` data. 

Then I run crontabber like this:
```
$ python socorro/cron/crontabber_app.py --admin.conf=../local-crontabber.ini 
```
In my `../local-crontabber.ini` the postgres credentials are set up to point to my local `socorro_integration_test` database. And the last couple of lines of that ini file are these:
```
    jobs='''
    #socorro.cron.jobs.bugzilla.BugzillaCronApp|1d
    socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp|1h
    '''
```

When I run it I get this output:

```
2016-10-18 13:07:06,827 DEBUG - MainThread -  - MainThread - about to run <class 'socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp'>
2016-10-18 13:07:07,514 INFO - MainThread -  - MainThread - Set featured versions for Firefox to: 49.0.1, 50.0b, 51.0a2, 52.0a1
2016-10-18 13:07:08,026 INFO - MainThread -  - MainThread - Set featured versions for FennecAndroid to: 49.0, 50.0b6, 51.0a2, 52.0a1
2016-10-18 13:07:08,544 INFO - MainThread -  - MainThread - Set featured versions for Thunderbird to: 45.4.0, 50.0b1, 51.0a2
2016-10-18 13:07:08,545 DEBUG - MainThread -  - MainThread - successfully ran <class 'socorro.cron.jobs.featured_versions_automatic.FeaturedVersionsAutomaticCronApp'> on 2016-10-18 17:07:06.843628+00:00
2016-10-18 13:07:08,564 INFO - MainThread -  - MainThread - done.
```

The most important thing to note is the featured versions specifically for Firefox are: `49.0.1, 50.0b, 51.0a2, 52.0a1`
That `50.0b` comes from taking `"LATEST_FIREFOX_DEVEL_VERSION"`  from https://product-details.mozilla.org/1.0/firefox_versions.json and carefully drop the number after the `b`. 