### PR TITLE
fixes bug 1311697 - deep copy SocorroDotDict better

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -20,6 +20,25 @@ from configman.converters import classes_in_namespaces_converter, \
 from configman.dotdict import DotDict as ConfigmanDotDict
 
 
+def socorrodotdict_to_dict(sdotdict):
+    """Takes a socorrolib.lib.util.DotDict and returns a dict
+
+    This does a complete object traversal converting all instances of the
+    things named DotDict to dict so it's deep-copyable.
+
+    """
+    def _dictify(thing):
+        if isinstance(thing, collections.Mapping):
+            return dict([(key, _dictify(val)) for key, val in thing.items()])
+        elif isinstance(thing, basestring):
+            return thing
+        elif isinstance(thing, collections.Sequence):
+            return [_dictify(item) for item in thing]
+        return thing
+
+    return _dictify(sdotdict)
+
+
 #==============================================================================
 class MemoryDumpsMapping(dict):
     """there has been a bifurcation in the crash storage data throughout the
@@ -610,8 +629,7 @@ class PolyCrashStorage(CrashStorageBase):
                     if isinstance(value, collections.Mapping):
                         dictify(value)
 
-            dictified = dict(crash)
-            dictify(dictified)
+            dictified = socorrodotdict_to_dict(crash)
             return SocorroDotDict(copy.deepcopy(dictified))
 
         for a_store in self.stores.itervalues():

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -622,15 +622,9 @@ class PolyCrashStorage(CrashStorageBase):
             Ideally, we shouldn't be using any of this *DotDict and just
             use plain dict objects.
             """
-            def dictify(thing):
-                for key, value in thing.items():
-                    if isinstance(value, SocorroDotDict):
-                        thing[key] = dict(value)
-                    if isinstance(value, collections.Mapping):
-                        dictify(value)
-
-            dictified = socorrodotdict_to_dict(crash)
-            return SocorroDotDict(copy.deepcopy(dictified))
+            return SocorroDotDict(
+                copy.deepcopy(socorrodotdict_to_dict(crash))
+            )
 
         for a_store in self.stores.itervalues():
             self.quit_check()

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -603,7 +603,16 @@ class PolyCrashStorage(CrashStorageBase):
             Ideally, we shouldn't be using any of this *DotDict and just
             use plain dict objects.
             """
-            return SocorroDotDict(copy.deepcopy(dict(crash)))
+            def dictify(thing):
+                for key, value in thing.items():
+                    if isinstance(value, SocorroDotDict):
+                        thing[key] = dict(value)
+                    if isinstance(value, collections.Mapping):
+                        dictify(value)
+
+            dictified = dict(crash)
+            dictify(dictified)
+            return SocorroDotDict(copy.deepcopy(dictified))
 
         for a_store in self.stores.itervalues():
             self.quit_check()

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import copy
+
 import mock
 from nose.tools import eq_, ok_, assert_raises
 
@@ -17,6 +19,7 @@ from socorro.external.crashstorage_base import (
     BenchmarkingCrashStorage,
     MemoryDumpsMapping,
     FileDumpsMapping,
+    socorrodotdict_to_dict
 )
 from socorrolib.lib.util import DotDict as SocorroDotDict
 from socorro.unittest.testbase import TestCase
@@ -61,6 +64,76 @@ class MutatingProcessedCrashCrashStorage(CrashStorageBase):
 
 def fake_quit_check():
     return False
+
+
+class Testsocorrodotdict_to_dict(TestCase):
+    def test_primitives(self):
+        # Test all the primitives
+        eq_(socorrodotdict_to_dict(None), None)
+        eq_(socorrodotdict_to_dict([]), [])
+        eq_(socorrodotdict_to_dict(''), '')
+        eq_(socorrodotdict_to_dict(1), 1)
+        eq_(socorrodotdict_to_dict({}), {})
+
+    def test_complex(self):
+        def comp(data, expected):
+            # First socorrodotdict_to_dict the data and compare it.
+            new_dict = socorrodotdict_to_dict(data)
+            eq_(new_dict, expected)
+
+            # Now deepcopy the new dict to make sure it's ok.
+            copy.deepcopy(new_dict)
+
+        # dict -> dict
+        comp({'a': 1}, {'a': 1})
+
+        # outer socorrodotdict -> dict
+        comp(SocorroDotDict({'a': 1}), {'a': 1})
+
+        # nested socorrodotdict -> dict
+        comp(
+            SocorroDotDict({
+                'a': 1,
+                'b': SocorroDotDict({
+                    'a': 2
+                })
+            }),
+            {'a': 1, 'b': {'a': 2}}
+        )
+        # inner socorrodotdict
+        comp(
+            {
+                'a': 1,
+                'b': SocorroDotDict({
+                    'a': 2
+                })
+            },
+            {'a': 1, 'b': {'a': 2}}
+        )
+        # in a list
+        comp(
+            {
+                'a': 1,
+                'b': [
+                    SocorroDotDict({
+                        'a': 2
+                    }),
+                    3,
+                    4
+                ]
+            },
+            {'a': 1, 'b': [{'a': 2}, 3, 4]}
+        )
+        # mixed dotdicts
+        comp(
+            DotDict({
+                'a': 1,
+                'b': SocorroDotDict({
+                    'a': 2
+                })
+            }),
+            {'a': 1, 'b': {'a': 2}}
+        )
 
 
 class TestBase(TestCase):


### PR DESCRIPTION
I feel like I totally stressed through this. Lots of things going on today. 
This PR adds a test that does break unless you apply the fix. 
Also, this change does make the whole processor work. I've tested it by making the the crash gets sent in correctly (to my personal AWS S3 bucket). 

Let's get this to prod soon. 