### PR TITLE
bug 1305807 - move google analytics to not be inline

### DIFF
--- a/webapp-django/crashstats/base/context_processors.py
+++ b/webapp-django/crashstats/base/context_processors.py
@@ -1,12 +1,7 @@
 from django.conf import settings
 
 
-def google_analytics(request):
+def debug(request):
     return {
-        'GOOGLE_ANALYTICS_ID': getattr(settings, 'GOOGLE_ANALYTICS_ID', None),
-        'GOOGLE_ANALYTICS_DOMAIN': getattr(
-            settings,
-            'GOOGLE_ANALYTICS_DOMAIN',
-            'auto'
-        )
+        'DEBUG': settings.DEBUG,
     }

--- a/webapp-django/crashstats/base/ga.py
+++ b/webapp-django/crashstats/base/ga.py
@@ -62,9 +62,7 @@ def track_pageview(
         logging.debug('GOOGLE_ANALYTICS_ID not set up. No pageview tracking.')
         return
 
-    domain = settings.GOOGLE_ANALYTICS_DOMAIN
-    if not domain or domain == 'auto':
-        domain = RequestSite(request).domain
+    domain = RequestSite(request).domain
 
     params = {}
     params['v'] = 1  # version

--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -8,17 +8,16 @@
         {% block site_css %}
             {% stylesheet 'crashstats_base' %}
         {% endblock %}
-    {% if GOOGLE_ANALYTICS_ID %}
-        <script type="text/javascript">
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-          ga('create', '{{ GOOGLE_ANALYTICS_ID }}', '{{ GOOGLE_ANALYTICS_DOMAIN }}');
-          ga('send', 'pageview');
-        </script>
-    {% endif %}
+        {% if not DEBUG %}
+        {#
+            Use the preload technique which gives a performance boost for
+            modern browsers.
+            See https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet
+        #}
+        {% javascript 'google_analytics' %}
+        <script async src="https://www.google-analytics.com/analytics.js"></script>
+        {% endif %}
 
     <meta name="google-signin-client_id" content="{{ OAUTH2_CLIENT_ID }}">
     {% if OAUTH2_SIGNOUT %}

--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -10,13 +10,13 @@
         {% endblock %}
 
         {% if not DEBUG %}
-        {#
-            Use the preload technique which gives a performance boost for
-            modern browsers.
-            See https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet
-        #}
-        {% javascript 'google_analytics' %}
-        <script async src="https://www.google-analytics.com/analytics.js"></script>
+            {#
+                Use the preload technique which gives a performance boost for
+                modern browsers.
+                See https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet
+            #}
+            {% javascript 'google_analytics' %}
+            <script async src="https://www.google-analytics.com/analytics.js"></script>
         {% endif %}
 
     <meta name="google-signin-client_id" content="{{ OAUTH2_CLIENT_ID }}">

--- a/webapp-django/crashstats/crashstats/pipelinecompilers.py
+++ b/webapp-django/crashstats/crashstats/pipelinecompilers.py
@@ -14,10 +14,13 @@ class GoogleAnalyticsCompiler(CompilerBase):
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not outdated and not force:
             return  # No need to recompiled file
-        with open(infile) as source:
-            new_content = source.read().replace(
-                'UA-XXXXX-X',
-                settings.GOOGLE_ANALYTICS_ID
-            )
-            with open(outfile, 'w') as destination:
-                destination.write(new_content)
+
+        # It might not be set. For example, in Travis runs.
+        if settings.GOOGLE_ANALYTICS_ID:
+            with open(infile) as source:
+                new_content = source.read().replace(
+                    'UA-XXXXX-X',
+                    settings.GOOGLE_ANALYTICS_ID
+                )
+                with open(outfile, 'w') as destination:
+                    destination.write(new_content)

--- a/webapp-django/crashstats/crashstats/pipelinecompilers.py
+++ b/webapp-django/crashstats/crashstats/pipelinecompilers.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+
+from pipeline.compilers import CompilerBase
+
+
+class GoogleAnalyticsCompiler(CompilerBase):
+    """All this compiler does is to replace the fake Google Analytics
+    Tracking ID in the static asset called google_analytics.js."""
+    output_extension = 'js'
+
+    def match_file(self, filename):
+        return 'google_analytics.js' in filename
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return  # No need to recompiled file
+        with open(infile) as source:
+            new_content = source.read().replace(
+                'UA-XXXXX-X',
+                settings.GOOGLE_ANALYTICS_ID
+            )
+            with open(outfile, 'w') as destination:
+                destination.write(new_content)

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/google_analytics.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/google_analytics.js
@@ -1,3 +1,3 @@
 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', 'UA-35433268-50', 'auto');
+ga('create', 'UA-XXXXX-X', 'auto');
 ga('send', 'pageview');

--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/google_analytics.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/google_analytics.js
@@ -1,0 +1,3 @@
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', 'UA-35433268-50', 'auto');
+ga('send', 'pageview');

--- a/webapp-django/crashstats/crashstats/tests/test_pipelinecompilers.py
+++ b/webapp-django/crashstats/crashstats/tests/test_pipelinecompilers.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+import tempfile
+
+from nose.tools import ok_
+
+from crashstats.base.tests.testbase import DjangoTestCase
+from crashstats.crashstats.pipelinecompilers import GoogleAnalyticsCompiler
+from crashstats import crashstats
+
+SOURCE_FILE = os.path.join(
+    crashstats.__path__[0],  # dir of the module
+    'static/crashstats/js/socorro/google_analytics.js'
+)
+assert os.path.isfile(SOURCE_FILE), SOURCE_FILE
+
+
+class TestGoogleAnalyticsCompiler(DjangoTestCase):
+
+    def setUp(self):
+        super(TestGoogleAnalyticsCompiler, self).setUp()
+        self.tmp_static = tempfile.mkdtemp('static')
+
+    def tearDown(self):
+        super(TestGoogleAnalyticsCompiler, self).tearDown()
+        shutil.rmtree(self.tmp_static)
+
+    def test_match(self):
+        compiler = GoogleAnalyticsCompiler(False, None)
+        ok_(compiler.match_file('/foo/google_analytics.js'))
+        ok_(not compiler.match_file('/foo/bar.js'))
+
+    def test_compile(self):
+        compiler = GoogleAnalyticsCompiler(False, None)
+        with self.settings(GOOGLE_ANALYTICS_ID='UA-12345-6'):
+            outfile = os.path.join(self.tmp_static, 'google-analytics.min.js')
+            assert not os.path.isfile(outfile)
+            compiler.compile_file(SOURCE_FILE, outfile)
+            assert not os.path.isfile(outfile)
+
+            # Try again
+            compiler.compile_file(SOURCE_FILE, outfile, outdated=True)
+            assert os.path.isfile(outfile)
+            # now the outfile should have been created
+            with open(outfile) as f:
+                content = f.read()
+                ok_('UA-12345-6' in content)

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -507,18 +507,6 @@ class BaseTestViews(DjangoTestCase):
         ]
 
 
-class TestAnalytics(BaseTestViews):
-
-    @override_settings(GOOGLE_ANALYTICS_ID='xyz123')
-    @override_settings(GOOGLE_ANALYTICS_DOMAIN='test.biz')
-    def test_google_analytics(self):
-        url = reverse('home:home', args=('WaterWolf',))
-        response = self.client.get(url)
-        eq_(response.status_code, 200)
-        ok_('xyz123' in response.content)
-        ok_('test.biz' in response.content)
-
-
 class TestViews(BaseTestViews):
 
     def test_contribute_json(self):

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -549,6 +549,7 @@ PIPELINE = {
     'DISABLE_WRAPPER': True,
     'COMPILERS': (
         'pipeline.compilers.less.LessCompiler',
+        'crashstats.crashstats.pipelinecompilers.GoogleAnalyticsCompiler',
     ),
     # The pipeline.jinja2.PipelineExtension extension doesn't support
     # automatically rendering any potentional compilation errors into

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -600,10 +600,7 @@ if raven_dsn:
         'release': SOCORRO_REVISION,
     }
 
-# Google Analytics ID (UA-XXXXX-X) used for sending
-# pings to Google Analytics about usage of the public API.
-# Note that the Mozilla Google Analytics ID is hardcoded
-# in the static file: google_analytics.js
+# Optional Google Analytics ID (UA-XXXXX-X)
 GOOGLE_ANALYTICS_ID = config('GOOGLE_ANALYTICS_ID', None)
 
 # Set to True enable analysis of all model fetches

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -127,7 +127,7 @@ _CONTEXT_PROCESSORS = (
     'django.contrib.messages.context_processors.messages',
     'django.core.context_processors.request',
     '%s.authentication.context_processors.oauth2' % PROJECT_MODULE,
-    '%s.base.context_processors.google_analytics' % PROJECT_MODULE,
+    '%s.base.context_processors.debug' % PROJECT_MODULE,
     '%s.status.context_processors.status_message' % PROJECT_MODULE,
     '%s.crashstats.context_processors.help_urls' % PROJECT_MODULE,
 )
@@ -599,10 +599,11 @@ if raven_dsn:
         'release': SOCORRO_REVISION,
     }
 
-# Optional Google Analytics ID (UA-XXXXX-X)
+# Google Analytics ID (UA-XXXXX-X) used for sending
+# pings to Google Analytics about usage of the public API.
+# Note that the Mozilla Google Analytics ID is hardcoded
+# in the static file: google_analytics.js
 GOOGLE_ANALYTICS_ID = config('GOOGLE_ANALYTICS_ID', None)
-# Root domain. Required iff you're providing an analytics ID.
-GOOGLE_ANALYTICS_DOMAIN = config('GOOGLE_ANALYTICS_DOMAIN', 'auto')
 
 # Set to True enable analysis of all model fetches
 ANALYZE_MODEL_FETCHES = config('ANALYZE_MODEL_FETCHES', False, cast=bool)

--- a/webapp-django/crashstats/settings/bundles.py
+++ b/webapp-django/crashstats/settings/bundles.py
@@ -464,6 +464,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/error.min.js',
     },
+    'google_analytics': {
+        'source_filenames': (
+            'crashstats/js/socorro/google_analytics.js',
+        ),
+        'output_filename': 'js/google-analytics.min.js',
+    },
 }
 
 # This is sanity checks, primarily for developers. It checks that

--- a/webapp-django/crashstats/settings/test.py
+++ b/webapp-django/crashstats/settings/test.py
@@ -82,9 +82,6 @@ MIDDLEWARE_MIDDLEWARE_RETRY_SLEEPTIME = 3
 GOOGLE_ANALYTICS_API_URL = 'https://example.com/collect'
 # By default, unset the GOOGLE_ANALYTICS_ID
 GOOGLE_ANALYTICS_ID = None
-# Forcibly setting this to be what the default is in settings/base.py
-# so that local settings don't break tests.
-GOOGLE_ANALYTICS_DOMAIN = 'auto'
 
 
 # During testing we want to pretend that we've set up the OAuth2


### PR DESCRIPTION
I don't know how much you know about Google Analytics. 
I had to do a bunch of research myself. Perhaps it's good if you have to do some research of your own to check that I'm doing the right thing. 

The most important change here is that the GA ID is now super hardcoded. 
Yes, it spells trouble for other companies that tries to use our webapp, but does that even exist any more? And also, GA will filter out any traffic that comes from domains not recognized in GA Admin. 

I did the same for Air Mozilla (which uses the non-360 GA still), because it's just not realistic that someone will run that site under a different domain. https://github.com/mozilla/airmozilla/blob/master/airmozilla/base/static/js/google-analytics.js#L2