### PR TITLE
bug 1231783 - Send all processor errors to sentry

### DIFF
--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -57,15 +57,15 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
         'companion_class',
         doc='a classname that runs a process in parallel with the processor',
         default='',
-        #default='socorro.processor.symbol_cache_manager.SymbolLRUCacheManager',
+        # default='socorro.processor.symbol_cache_manager.SymbolLRUCacheManager',
         from_string_converter=class_converter
     )
 
     ###########################################################################
-    ### TODO: implement an __init__ and a waiting func.  The waiting func
-    ### will take registrations of periodic things to do over some time
-    ### interval.  the first periodic thing is the rereading of the
-    ### signature generation stuff from the database.
+    # TODO: implement an __init__ and a waiting func.  The waiting func
+    # will take registrations of periodic things to do over some time
+    # interval.  the first periodic thing is the rereading of the
+    # signature generation stuff from the database.
     ###########################################################################
 
     required_config.namespace('sentry')

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -7,6 +7,7 @@
 
 import os
 import sys
+import collections
 
 import raven
 from configman import Namespace
@@ -19,7 +20,6 @@ from socorrolib.app.fetch_transform_save_app import (
 from socorro.external.crashstorage_base import CrashIDNotFound
 from socorrolib.lib.util import DotDict
 from socorro.external.fs.crashstorage import FSDatedPermanentStorage
-from socorro.external.crashstorage_base import PolyStorageError
 
 
 #==============================================================================
@@ -151,7 +151,7 @@ class ProcessorApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
 
             if self.config.sentry and self.config.sentry.dsn:
                 try:
-                    if isinstance(exception, PolyStorageError):
+                    if isinstance(exception, collections.Sequence):
                         # Then it's already an iterable!
                         exceptions = exception
                     else:

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -31,39 +31,45 @@ class TestProcessorApp(TestCase):
         mocked_source_crashstorage = mock.Mock()
         mocked_source_crashstorage.id = 'mocked_source_crashstorage'
         config.source.crashstorage_class = mock.Mock(
-          return_value=mocked_source_crashstorage
+            return_value=mocked_source_crashstorage
         )
 
         config.destination = DotDict()
         mocked_destination_crashstorage = mock.Mock()
         mocked_destination_crashstorage.id = 'mocked_destination_crashstorage'
         config.destination.crashstorage_class = mock.Mock(
-          return_value=mocked_destination_crashstorage
+            return_value=mocked_destination_crashstorage
         )
 
         config.processor = DotDict()
         mocked_processor = mock.Mock()
         mocked_processor.id = 'mocked_processor'
         config.processor.processor_class = mock.Mock(
-          return_value=mocked_processor
+            return_value=mocked_processor
         )
 
         config.number_of_submissions = 'forever'
         config.new_crash_source = DotDict()
+
         class FakedNewCrashSource(object):
+
             def __init__(self, *args, **kwargs):
                 pass
+
             def new_crashes(self):
-                return sequencer(((1,), {}),
-                                 2,  # ensure both forms acceptable
-                                 None,
-                                 ((3,), {}))()
+                return sequencer(
+                    ((1,), {}),
+                    2,  # ensure both forms acceptable
+                    None,
+                    ((3,), {})
+                )()
+
         config.new_crash_source.new_crash_source_class = FakedNewCrashSource
 
         config.companion_process = DotDict()
         mocked_companion_process = mock.Mock()
         config.companion_process.companion_class = mock.Mock(
-          return_value=mocked_companion_process
+            return_value=mocked_companion_process
         )
 
         config.logger = mock.MagicMock()
@@ -97,25 +103,30 @@ class TestProcessorApp(TestCase):
         pa.source.get_raw_dumps_as_files = mocked_get_raw_dumps_as_files
 
         fake_processed_crash = DotDict()
-        mocked_get_unredacted_processed = mock.Mock(return_value=fake_processed_crash)
+        mocked_get_unredacted_processed = mock.Mock(
+            return_value=fake_processed_crash
+        )
         pa.source.get_unredacted_processed = mocked_get_unredacted_processed
 
         mocked_process_crash = mock.Mock(return_value=7)
         pa.processor.process_crash = mocked_process_crash
         pa.destination.save_processed = mock.Mock()
         finished_func = mock.Mock()
-        with mock.patch('socorro.processor.processor_app.os.unlink') as mocked_unlink:
+        patch_path = 'socorro.processor.processor_app.os.unlink'
+        with mock.patch(patch_path) as mocked_unlink:
             # the call being tested
             pa.transform(17, finished_func)
         # test results
         mocked_unlink.assert_called_with('fake_dump_TEMPORARY.dump')
         pa.source.get_raw_crash.assert_called_with(17)
         pa.processor.process_crash.assert_called_with(
-          fake_raw_crash,
-          fake_dump,
-          fake_processed_crash
+            fake_raw_crash,
+            fake_dump,
+            fake_processed_crash
         )
-        pa.destination.save_raw_and_processed.assert_called_with(fake_raw_crash, None, 7, 17)
+        pa.destination.save_raw_and_processed.assert_called_with(
+            fake_raw_crash, None, 7, 17
+        )
         eq_(finished_func.call_count, 1)
 
     def test_transform_crash_id_missing(self):
@@ -129,8 +140,8 @@ class TestProcessorApp(TestCase):
         pa.transform(17, finished_func)
         pa.source.get_raw_crash.assert_called_with(17)
         pa.processor.reject_raw_crash.assert_called_with(
-          17,
-          'this crash cannot be found in raw crash storage'
+            17,
+            'this crash cannot be found in raw crash storage'
         )
         eq_(finished_func.call_count, 1)
 
@@ -145,8 +156,8 @@ class TestProcessorApp(TestCase):
         pa.transform(17, finished_func)
         pa.source.get_raw_crash.assert_called_with(17)
         pa.processor.reject_raw_crash.assert_called_with(
-          17,
-          'error in loading: bummer'
+            17,
+            'error in loading: bummer'
         )
         eq_(finished_func.call_count, 1)
 

--- a/socorro/unittest/processor/test_processor_app.py
+++ b/socorro/unittest/processor/test_processor_app.py
@@ -3,12 +3,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import mock
-from nose.tools import eq_
+from nose.tools import eq_, assert_raises
 
 from configman.dotdict import DotDict
 
 from socorro.processor.processor_app import ProcessorApp
-from socorro.external.crashstorage_base import CrashIDNotFound
+from socorro.external.crashstorage_base import (
+    CrashIDNotFound,
+    PolyStorageError,
+)
 from socorro.unittest.testbase import TestCase
 
 
@@ -21,7 +24,7 @@ def sequencer(*args):
 
 class TestProcessorApp(TestCase):
 
-    def get_standard_config(self):
+    def get_standard_config(self, sentry_dsn=None):
         config = DotDict()
 
         config.source = DotDict()
@@ -65,12 +68,10 @@ class TestProcessorApp(TestCase):
 
         config.logger = mock.MagicMock()
 
-        return config
+        config.sentry = mock.MagicMock()
+        config.sentry.dsn = sentry_dsn
 
-    def test_setup(self):
-        config = self.get_standard_config()
-        pa = ProcessorApp(config)
-        pa._setup_source_and_destination()
+        return config
 
     def test_source_iterator(self):
         config = self.get_standard_config()
@@ -148,3 +149,172 @@ class TestProcessorApp(TestCase):
           'error in loading: bummer'
         )
         eq_(finished_func.call_count, 1)
+
+    def test_transform_polystorage_error_without_raven_configured(self):
+        config = self.get_standard_config()
+        pa = ProcessorApp(config)
+        pa._setup_source_and_destination()
+        pa.source.get_raw_crash.return_value = DotDict({'raw': 'crash'})
+        pa.source.get_raw_dumps_as_files.return_value = {}
+
+        def mocked_save_raw_and_processed(*_):
+            exception = PolyStorageError()
+            exception.exceptions.append(NameError('waldo'))
+            raise exception
+
+        pa.destination.save_raw_and_processed.side_effect = (
+            mocked_save_raw_and_processed
+        )
+        # The important thing is that this is the exception that
+        # is raised and not something from the raven error handling.
+        assert_raises(
+            PolyStorageError,
+            pa.transform,
+            'mycrashid'
+        )
+
+        config.logger.warning.assert_called_with(
+            'Raven DSN is not configured and an exception happened'
+        )
+
+    @mock.patch('socorro.processor.processor_app.raven')
+    def test_transform_polystorage_error_with_raven_configured_successful(
+        self,
+        mock_raven,
+    ):
+
+        captured_exceptions = []  # a global
+
+        def mock_capture_exception(exc_info=None):
+            captured_exceptions.append(exc_info)
+            return 'someidentifier'
+
+        raven_mock_client = mock.MagicMock()
+        raven_mock_client.captureException.side_effect = mock_capture_exception
+
+        mock_raven.Client.return_value = raven_mock_client
+
+        config = self.get_standard_config(
+            sentry_dsn='https://abc123@example.com/project'
+        )
+        pa = ProcessorApp(config)
+        pa._setup_source_and_destination()
+        pa.source.get_raw_crash.return_value = DotDict({'raw': 'crash'})
+        pa.source.get_raw_dumps_as_files.return_value = {}
+
+        def mocked_save_raw_and_processed(*_):
+            exception = PolyStorageError()
+            exception.exceptions.append(NameError('waldo'))
+            exception.exceptions.append(AssertionError(False))
+            raise exception
+
+        pa.destination.save_raw_and_processed.side_effect = (
+            mocked_save_raw_and_processed
+        )
+        # The important thing is that this is the exception that
+        # is raised and not something from the raven error handling.
+        assert_raises(
+            PolyStorageError,
+            pa.transform,
+            'mycrashid'
+        )
+
+        config.logger.info.assert_called_with(
+            'Error captured in Sentry! Reference: someidentifier'
+        )
+        eq_(len(captured_exceptions), 2)
+        captured_exception, captured_exception_2 = captured_exceptions
+        eq_(captured_exception.__class__, NameError)
+        eq_(captured_exception.message, 'waldo')
+        eq_(captured_exception_2.__class__, AssertionError)
+        eq_(captured_exception_2.message, False)
+
+    @mock.patch('socorro.processor.processor_app.raven')
+    def test_transform_misc_error_with_raven_configured_successful(
+        self,
+        mock_raven,
+    ):
+
+        captured_exceptions = []  # a global
+
+        def mock_capture_exception(exc_info=None):
+            captured_exceptions.append(exc_info)
+            return 'someidentifier'
+
+        raven_mock_client = mock.MagicMock()
+        raven_mock_client.captureException.side_effect = mock_capture_exception
+
+        mock_raven.Client.return_value = raven_mock_client
+
+        config = self.get_standard_config(
+            sentry_dsn='https://abc123@example.com/project'
+        )
+        pa = ProcessorApp(config)
+        pa._setup_source_and_destination()
+        pa.source.get_raw_crash.return_value = DotDict({'raw': 'crash'})
+        pa.source.get_raw_dumps_as_files.return_value = {}
+
+        def mocked_save_raw_and_processed(*_):
+            raise ValueError('Someone is wrong on the Internet')
+
+        pa.destination.save_raw_and_processed.side_effect = (
+            mocked_save_raw_and_processed
+        )
+        # The important thing is that this is the exception that
+        # is raised and not something from the raven error handling.
+        assert_raises(
+            ValueError,
+            pa.transform,
+            'mycrashid'
+        )
+
+        config.logger.info.assert_called_with(
+            'Error captured in Sentry! Reference: someidentifier'
+        )
+        eq_(len(captured_exceptions), 1)
+        captured_exception, = captured_exceptions
+        eq_(captured_exception.__class__, ValueError)
+        eq_(captured_exception.message, 'Someone is wrong on the Internet')
+
+    @mock.patch('socorro.processor.processor_app.raven')
+    def test_transform_polystorage_error_with_raven_configured_failing(
+        self,
+        mock_raven,
+    ):
+
+        def mock_capture_exception(exc_info=None):
+            raise ValueError('Someone is wrong on the Internet')
+
+        raven_mock_client = mock.MagicMock()
+        raven_mock_client.captureException.side_effect = mock_capture_exception
+
+        mock_raven.Client.return_value = raven_mock_client
+
+        config = self.get_standard_config(
+            sentry_dsn='https://abc123@example.com/project'
+        )
+        pa = ProcessorApp(config)
+        pa._setup_source_and_destination()
+        pa.source.get_raw_crash.return_value = DotDict({'raw': 'crash'})
+        pa.source.get_raw_dumps_as_files.return_value = {}
+
+        def mocked_save_raw_and_processed(*_):
+            exception = PolyStorageError()
+            exception.exceptions.append(NameError('waldo'))
+            exception.exceptions.append(AssertionError(False))
+            raise exception
+
+        pa.destination.save_raw_and_processed.side_effect = (
+            mocked_save_raw_and_processed
+        )
+        # The important thing is that this is the exception that
+        # is raised and not something from the raven error handling.
+        assert_raises(
+            PolyStorageError,
+            pa.transform,
+            'mycrashid'
+        )
+
+        config.logger.error.assert_called_with(
+            'Unable to report error with Raven', exc_info=True
+        )


### PR DESCRIPTION
I've tested this quite extensively. E.g.
https://sentry.prod.mozaws.net/operations/socorro-stage/issues/362120/
https://sentry.prod.mozaws.net/operations/socorro-stage/issues/362112/

The crucial part is the new lines inside `processor_app.py`. 
The most important thing is how the exception is juggled. 

### First key learning...

If anything goes wrong in any of the crashstoage classes, the processor collects all exceptions into an instance of a `PolyStorageError`. That's why it's important to loop over over this. It might be more than 1 exception. If you don't do this iteration **iff** it's a an error inside one of the crashstorage classes you get errors in Sentry like this: https://sentry.prod.mozaws.net/operations/socorro-stage/issues/362043/ (scroll down and look at the "Exception".

And because it might NOT be a `PolyStorageError` you'll see that 
```python
if isinstance(exception, PolyStorageError):
    # Then it's already an iterable!
    exceptions = exception
else:
    exceptions = [exception]
```

### Second key learning...

Python is tricky when it comes to doing `try:except` INSIDE an exception frame. 
Consider: https://gist.github.com/peterbe/c39548a3eec97634e7d2de28fa768f11
What's wrong with that gist is the Traceback points to "line 8" which is not where the error happened. It happened on line 2.

The only way to get this to report correctly is to capture the `sys.exc_info()` as local variable(s) and then at the bottom of the parent exception you raise it like this `raise exc_type, exc_value, exc_tb`. 

See for the working solution:  https://gist.github.com/peterbe/007c7acef30ff8bb0ba90e9a92350bae

####  Lastly...
This PR is two commits. First one with the juicy change. Second one with pep8 cleanups. You might want to click on the first commit in PR to avoid the pep8 cleanup noise. 
Also, this PR is not automatically closing the bug. That's because I want to configure sentry and test that it works first. 