### PR TITLE
fixes bug 1313676 - Optimize how crashes are cloned in processor

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -618,26 +618,18 @@ class PolyCrashStorage(CrashStorageBase):
         # dict which we can more easily copy.deepcopy() operate on.
         processed_crash_as_dict = socorrodotdict_to_dict(processed_crash)
 
-        def make_deep_copy(crash):
-            """Return a SocorroDotDict deep copy of the crash (processed
-            crash in our case).
-
-            It's important to remember that copy.deepcopy() doesn't work
-            on a SocorroDotDict object so the crash in this context needs
-            to be pure python dict.
-
-            Ideally, we shouldn't be using any of this *DotDict and just
-            use plain dict objects.
-            """
-            return SocorroDotDict(copy.deepcopy(crash))
-
         for a_store in self.stores.itervalues():
             self.quit_check()
             try:
                 a_store.save_raw_and_processed(
                     raw_crash,
                     dump,
-                    make_deep_copy(processed_crash_as_dict),
+                    # We do this because `a_store.save_raw_and_processed`
+                    # expects the processed crash to be a DotDict but
+                    # you can't deepcopy those, so we deepcopy the
+                    # pure dict version and then dress it back up as a
+                    # DotDict.
+                    SocorroDotDict(copy.deepcopy(processed_crash_as_dict)),
                     crash_id
                 )
             except Exception:

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -612,19 +612,24 @@ class PolyCrashStorage(CrashStorageBase):
                                crash_id):
         storage_exception = PolyStorageError()
 
+        # Later we're going to need to clone this per every crash storage
+        # in the loop. But, to save time, before we do that, convert the
+        # processed crash which is a SocorroDotDict into a pure python
+        # dict which we can more easily copy.deepcopy() operate on.
+        processed_crash_as_dict = socorrodotdict_to_dict(processed_crash)
+
         def make_deep_copy(crash):
-            """Return a deep copy of the SocorroDotDict.
-            It doesn't work to use `copy.deepcopy(crash)` because the
-            the SocorroDotDict doesn't support that at all.
-            So, instead we convert it to a plain dict, copy that, and
-            convert it back to SocorroDotDict in the end.
+            """Return a SocorroDotDict deep copy of the crash (processed
+            crash in our case).
+
+            It's important to remember that copy.deepcopy() doesn't work
+            on a SocorroDotDict object so the crash in this context needs
+            to be pure python dict.
 
             Ideally, we shouldn't be using any of this *DotDict and just
             use plain dict objects.
             """
-            return SocorroDotDict(
-                copy.deepcopy(socorrodotdict_to_dict(crash))
-            )
+            return SocorroDotDict(copy.deepcopy(crash))
 
         for a_store in self.stores.itervalues():
             self.quit_check()
@@ -632,7 +637,7 @@ class PolyCrashStorage(CrashStorageBase):
                 a_store.save_raw_and_processed(
                     raw_crash,
                     dump,
-                    make_deep_copy(processed_crash),
+                    make_deep_copy(processed_crash_as_dict),
                     crash_id
                 )
             except Exception:


### PR DESCRIPTION
**tl;dr here's the executive summary of my measurements...**
```
____OLD_WAY____
# uuids 31
# measurements 93
time per uuid 0.252148882035
____NEW_WAY____
# uuids 31
# measurements 124
time per uuid 0.170331147409

average time just to make the pure dict copy 0.0462440675305
```

I took 31 random uuids, instrumented some `t0=time.time(); do_something(); t1=time.time()` in the master branch. Ran a bunch of processing and dumped all the measurements to a file. 
Then I wrote this new code, and put time measurements again. This time I had to do one measurement for making the pure dict first and 3 measurements for each cloning. 

See, 31 uuids --> 3x31=93 measurements. And with the new way, 31+3x31=124. 

It's promising. This small sample indicates that it'll be ~30% faster this new way just for this "region" of the code. In other words, processing won't become 30% faster (if someone else reads this and gets too excited)