### PR TITLE
bug 1312006 - Upload crash_reports.json to S3

### DIFF
--- a/socorro/cron/jobs/upload_crash_report_json_schema.py
+++ b/socorro/cron/jobs/upload_crash_report_json_schema.py
@@ -1,0 +1,58 @@
+from configman import Namespace
+from configman.converters import class_converter
+from crontabber.base import BaseCronApp
+
+from socorro.schemas import CRASH_REPORT_JSON_SCHEMA_AS_STRING
+
+
+class UploadCrashReportJSONSchemaCronApp(BaseCronApp):
+    app_name = 'upload-crash-report-json-schema'
+    app_description = """
+    We always send a copy of the crash (mainly processed crash) to a
+    S3 bucket meant for Telemetry to ingest.
+    When they ingest, they need a copy of our crash_report.json JSON
+    Schema file.
+
+    They use that not to understand the JSON we store but the underlying
+    structure (types, nesting etc.) necessary for storing it in .parquet
+    files in S3.
+
+    To get a copy of the crash_report.json they can take it from the
+    git repository but that's fragile since it depends on github.com
+    always being available.
+
+    By uploading it to S3 not only do we bet on S3 being more read-reliable
+    that github.com's server but by being in S3 AND unavailable that means
+    the whole ingestion process has to halt/pause anyway.
+    """
+
+    required_config = Namespace()
+    required_config.add_option(
+        'resource_class',
+        default=(
+            'socorro.external.boto.connection_context.S3ConnectionContext'
+        ),
+        doc=(
+            'fully qualified dotted Python classname to handle Boto '
+            'connections'
+        ),
+        from_string_converter=class_converter,
+        reference_value_from='resource.boto'
+    )
+    required_config.add_option(
+        'json_filename',
+        default='crash_report.json',
+        doc="Name of the file/key we're going to upload to"
+    )
+
+    def run(self):
+        connection_context = self.config.resource_class(self.config)
+        connection = connection_context._connect()
+        bucket = connection_context._get_bucket(
+            connection,
+            self.config.bucket_name
+        )
+        key = bucket.get_key(self.config.json_filename)
+        if not key:
+            key = bucket.new_key(self.config.json_filename)
+        key.set_contents_from_string(CRASH_REPORT_JSON_SCHEMA_AS_STRING)

--- a/socorro/schemas/__init__.py
+++ b/socorro/schemas/__init__.py
@@ -7,8 +7,15 @@ import json
 from pkg_resources import resource_stream
 
 
-def _get_file_content(filename):
+def _get_file_content(filename, parsed=True):
     with resource_stream(__name__, filename) as f:
-        return json.load(f)
+        if parsed:
+            return json.load(f)
+        else:
+            return f.read()
 
 CRASH_REPORT_JSON_SCHEMA = _get_file_content('crash_report.json')
+CRASH_REPORT_JSON_SCHEMA_AS_STRING = _get_file_content(
+    'crash_report.json',
+    parsed=False
+)

--- a/socorro/schemas/crash_report.json
+++ b/socorro/schemas/crash_report.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
-    "description": "schema of a processed crash from Socorro",
+    "description": "This is the JSON Schema of a public crash from Socorro. Its home is github.com/mozilla/socorro",
     "definitions": {
         "frames": {
             "type": "object",

--- a/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
+++ b/socorro/unittest/cron/jobs/test_upload_crash_report_json_schema.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import mock
+
+from nose.tools import ok_
+
+from crontabber.app import CronTabber
+from socorro.unittest.cron.jobs.base import IntegrationTestBase
+
+from socorro.unittest.cron.setup_configman import (
+    get_config_manager_for_crontabber,
+)
+from socorro.schemas import CRASH_REPORT_JSON_SCHEMA_AS_STRING
+
+
+class TestUploadCrashReportJSONSchemaCronApp(IntegrationTestBase):
+
+    def _setup_config_manager(self):
+        return get_config_manager_for_crontabber(
+            jobs='socorro.cron.jobs.upload_crash_report_json_schema.'
+                 'UploadCrashReportJSONSchemaCronApp|30d',
+        )
+
+    @mock.patch('boto.connect_s3')
+    def test_run(self, connect_s3):
+
+        key = mock.MagicMock()
+        connect_s3().get_bucket().get_key.return_value = None
+        connect_s3().get_bucket().new_key.return_value = key
+
+        with self._setup_config_manager().context() as config:
+            tab = CronTabber(config)
+            tab.run_all()
+
+            information = self._load_structure()
+            app_name = 'upload-crash-report-json-schema'
+            ok_(information[app_name])
+            ok_(not information[app_name]['last_error'])
+            ok_(information[app_name]['last_success'])
+
+        key.set_contents_from_string.assert_called_with(
+            CRASH_REPORT_JSON_SCHEMA_AS_STRING
+        )


### PR DESCRIPTION
Here's how I configured it when running locally:

```
[[class-UploadCrashReportJSONSchemaCronApp]]
    bucket_name=peterbe-crash-stats-telemetry
    access_key=AKIA...
    secret_access_key=SECRETYSECRET
```

I'm pretty sure we run crontabber with `socorro/common` as a prefix should it should automatically pick up the access_key and secret_access_key but I'm not so sure about the `bucket_name`. The only place this is elsewhere written down is for that `[[storage3]]` or whatever it's called in processor's crashstorage list. 

I'll update the bug with the necessary consulate instructions that I think we need. 
