### PR TITLE
bug 1314258 - run './manage.py collectstatic' with env vars

### DIFF
--- a/webapp-django/bin/bootstrap.sh
+++ b/webapp-django/bin/bootstrap.sh
@@ -10,13 +10,6 @@ source ${VIRTUAL_ENV:-"../socorro-virtualenv"}/bin/activate
 export PATH=$PATH:./node_modules/.bin/
 export SECRET_KEY="doesn't matter, tests"
 
-# See https://bugzilla.mozilla.org/show_bug.cgi?id=1314258
-# When the collectstatic command is run, it needs to have all the
-# config set from consulate. But because we don't know how to do
-# that here, we instead set it temporarily here in this build script.
-# NOTE! This is NOT a sensitive key/secret.
-export GOOGLE_ANALYTICS_ID="UA-35433268-50"
-
 echo "Install the node packages"
 npm install
 

--- a/webapp-django/bin/bootstrap.sh
+++ b/webapp-django/bin/bootstrap.sh
@@ -10,6 +10,13 @@ source ${VIRTUAL_ENV:-"../socorro-virtualenv"}/bin/activate
 export PATH=$PATH:./node_modules/.bin/
 export SECRET_KEY="doesn't matter, tests"
 
+# See https://bugzilla.mozilla.org/show_bug.cgi?id=1314258
+# When the collectstatic command is run, it needs to have all the
+# config set from consulate. But because we don't know how to do
+# that here, we instead set it temporarily here in this build script.
+# NOTE! This is NOT a sensitive key/secret.
+export GOOGLE_ANALYTICS_ID="UA-35433268-50"
+
 echo "Install the node packages"
 npm install
 

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -600,7 +600,10 @@ if raven_dsn:
         'release': SOCORRO_REVISION,
     }
 
-# Optional Google Analytics ID (UA-XXXXX-X)
+# The Mozilla Google Analytics ID is used here as a default.
+# The reason is that our deployment (when it runs `./manage.py collectstatic`)
+# runs before the environment variables have been all set.
+# See https://bugzilla.mozilla.org/show_bug.cgi?id=1314258
 GOOGLE_ANALYTICS_ID = config('GOOGLE_ANALYTICS_ID', 'UA-35433268-50')
 
 # Set to True enable analysis of all model fetches

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -601,7 +601,7 @@ if raven_dsn:
     }
 
 # Optional Google Analytics ID (UA-XXXXX-X)
-GOOGLE_ANALYTICS_ID = config('GOOGLE_ANALYTICS_ID', None)
+GOOGLE_ANALYTICS_ID = config('GOOGLE_ANALYTICS_ID', 'UA-35433268-50')
 
 # Set to True enable analysis of all model fetches
 ANALYZE_MODEL_FETCHES = config('ANALYZE_MODEL_FETCHES', False, cast=bool)


### PR DESCRIPTION
@willkg I honestly don't know how this script gets executed. Ideally, I'd like for it to be executed with the usual `env consul -prefix ....` stuff but I don't know where that happens and @jdotpz is on PTO today. 

I'm hopeful that this fix will unbreak our broken Google Analytics in stage and prod. 