### PR TITLE
Bug 1293776: Fix prefix

### DIFF
--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -91,7 +91,6 @@ class BreakpadCollectorBase(GenericCollectorBase):
         else:
             raw_crash.legacy_processing = int(raw_crash.legacy_processing)
 
-
         try:
             # We want to capture the crash report size, but need to
             # differentiate between compressed vs. uncompressed data as well as
@@ -107,7 +106,7 @@ class BreakpadCollectorBase(GenericCollectorBase):
                 'compressed' if is_compressed else 'uncompressed',
             ])
             metrics_data = {
-                size_key: crash_report_size
+                'collector.' + size_key: crash_report_size
             }
             self.metrics.capture_stats(metrics_data)
         except Exception:

--- a/socorro/unittest/collector/test_wsgi_breakpad_collector.py
+++ b/socorro/unittest/collector/test_wsgi_breakpad_collector.py
@@ -135,7 +135,7 @@ class TestWSGIBreakpadCollector(TestCase):
 
         # Verify metrics were captured and .capture_stats() was called.
         config.metrics.capture_stats.assert_called_with(
-            {'crash_report_size_accepted_uncompressed': 1000}
+            {'collector.crash_report_size_accepted_uncompressed': 1000}
         )
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
@@ -192,7 +192,7 @@ class TestWSGIBreakpadCollector(TestCase):
 
         # Verify metrics were captured and .capture_stats() was called.
         config.metrics.capture_stats.assert_called_with(
-            {'crash_report_size_rejected_uncompressed': 1000}
+            {'collector.crash_report_size_rejected_uncompressed': 1000}
         )
 
     @mock.patch('socorro.collector.wsgi_breakpad_collector.time')
@@ -519,7 +519,7 @@ aux_dump contents
             r[11:-1]
         )
         config.metrics.capture_stats.assert_called_with(
-            {'crash_report_size_accepted_compressed': 1000}
+            {'collector.crash_report_size_accepted_compressed': 1000}
         )
 
     def test_no_x00_character(self):


### PR DESCRIPTION
The dogstatsd client uses the defaults (localhost and 8125 and no key
prefix), so that's why it's ignoring the key prefix we assigned.

I could fix that code, but that would affect all the metrics. Instead,
I'm manually adding the prefix.