### PR TITLE
fixes bug 1300367 - remove view current_server_status too

### DIFF
--- a/alembic/versions/5bafdc19756c_drop_server_status_table.py
+++ b/alembic/versions/5bafdc19756c_drop_server_status_table.py
@@ -23,7 +23,7 @@ from sqlalchemy.dialects import postgresql
 
 
 def upgrade():
-    op.drop_table('server_status')
+    op.execute('DROP TABLE server_status CASCADE')
 
 
 def downgrade():


### PR DESCRIPTION
There is no mention of this view being defined. It might be a lurking relic from the extreme dark olden times. 
I dare not attempt to run this on the stage DB because then it won't test that this migration actually works when it gets applied on stage. 
There might be other views that lurk. 

Here's a list of all views we have:
```
breakpad=> select table_name from INFORMATION_SCHEMA.views WHERE table_schema = ANY (current_schemas(false));
         table_name
----------------------------
 crashes_by_user_build_view
 crashes_by_user_rollup
 crashes_by_user_view
 current_server_status
 product_info
 default_versions
 default_versions_builds
 home_page_graph_build_view
 home_page_graph_view
 index_bloat
 performance_check_1
 product_crash_ratio
 product_os_crash_ratio
 product_selector
(14 rows)
```

So I did some digging and found it really hard to find any information about how to list all views that a table belongs to. For example, when you do `pg_dump -s -t server_status` there's no mention of the view. And there's nothing when listing EVERYTHING using this query: http://stackoverflow.com/a/3907999/398670

At first I thought I'd add `op.execute('drop view if exists current_server_status')` but a much safer way (in case there are more crazy views depending on this table and mentioned error was just the *first* one) is to use CASCADE. 

CASCADE is a Postgresql specific feature and apparently not something that Alembic supports [according to its author here](https://groups.google.com/forum/#!topic/sqlalchemy/HPvdDE7_umc)

So that's why I'm opting for doing a `op.execute(` instead. 