### PR TITLE
fixes bug 1314693 - execute script to get right Firefox versions corr…

### DIFF
--- a/scripts/crons/cron_libraries.sh
+++ b/scripts/crons/cron_libraries.sh
@@ -70,7 +70,7 @@ do
 done
 
 #MANUAL_VERSION_OVERRIDE="47.0b1 47.0b2 47.0b3 47.0b4 47.0b5 47.0b6 47.0b7 47.0b8 47.0b9 47.0b99 48.0a2 49.0a1"
-VERSIONS=`./active-firefox-versions.py`
+VERSIONS=`/data/socorro/application/scripts/crons/active-firefox-versions.py`
 techo "Phase 2: start"
 for I in Firefox
 do


### PR DESCRIPTION
…ectly

I don't know when `cron_libraries.sh` stopped working. I look at `/var/log/socorro/cron_libraries.log` and found:

```
/data/socorro/application/scripts/crons/cron_libraries.sh: line 73: ./active-firefox-versions.py: No such file or directory
```

Then I manually `sudo vi /data/socorro/application/scripts/crons/cron_libraries.sh` and edited the same change as this PR, ran the script again (`sudo su - socorro -c "/usr/bin/envconsul -once -prefix socorro/common -upcase -sanitize /data/socorro/application/scripts/crons/cron_libraries.sh >> /var/log/socorro/cron_libraries.log 2>&1"`) and now there's correlations in crash-analysis.mozilla.com for all the hottest Firefox versions. 

The urgency is low because...

* Soon Marco's new correlations in crash-stats (report index and signature report) will replace all of this.
* My manual vi edit won't go away any time soon. 