### PR TITLE
Fixes bug 1316144 - Allow querying root fields in Super Search.

### DIFF
--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -73,16 +73,22 @@ class SuperSearch(SearchBase):
 
         return self.get_list_of_indices(start_date, end_date)
 
+    def get_full_field_name(self, field_data):
+        if not field_data['namespace']:
+            return field_data['in_database_name']
+
+        return '{}.{}'.format(
+            field_data['namespace'],
+            field_data['in_database_name'],
+        )
+
     def format_field_names(self, hit):
         """Return a hit with each field's database name replaced by its
         exposed name. """
         new_hit = {}
         for field_name in self.request_columns:
             field = self.all_fields[field_name]
-            database_field_name = '{}.{}'.format(
-                field['namespace'],
-                field['in_database_name'],
-            )
+            database_field_name = self.get_full_field_name(field)
             new_hit[field_name] = hit.get(database_field_name)
 
         return new_hit
@@ -121,10 +127,7 @@ class SuperSearch(SearchBase):
                 msg='Field "%s" is not allowed to be returned' % value
             )
 
-        field_name = '%s.%s' % (
-            field_['namespace'],
-            field_['in_database_name']
-        )
+        field_name = self.get_full_field_name(field_)
 
         if full and field_['has_full_version']:
             # If the param has a full version, that means what matters
@@ -237,11 +240,7 @@ class SuperSearch(SearchBase):
                     continue
 
                 field_data = self.all_fields[param.name]
-
-                name = '%s.%s' % (
-                    field_data['namespace'],
-                    field_data['in_database_name']
-                )
+                name = self.get_full_field_name(field_data)
 
                 if param.data_type in ('date', 'datetime'):
                     param.value = datetimeutil.date_to_string(param.value)

--- a/socorro/unittest/external/es/base.py
+++ b/socorro/unittest/external/es/base.py
@@ -741,6 +741,24 @@ SUPERSEARCH_FIELDS = {
             'analyzer': 'semicolon_keywords',
         }
     },
+    # A field that is in the root of the crash report document.
+    'removed_fields': {
+        'data_validation_type': 'enum',
+        'default_value': None,
+        'form_field_choices': None,
+        'has_full_version': False,
+        'in_database_name': 'removed_fields',
+        'is_exposed': True,
+        'is_mandatory': False,
+        'is_returned': True,
+        'name': 'removed_fields',
+        'namespace': '',
+        'permissions_needed': [],
+        'query_type': 'string',
+        'storage_mapping': {
+            'type': 'string',
+        }
+    },
     # Add a synonym field.
     'product_2': {
         'data_validation_type': 'enum',
@@ -913,18 +931,24 @@ class ElasticsearchTestCase(TestCase):
         )
         self.index_client.refresh(index=[es_index])
 
-    def index_crash(self, processed_crash, raw_crash=None, crash_id=None):
+    def index_crash(
+        self, processed_crash, raw_crash=None, crash_id=None, root_doc=None
+    ):
         if crash_id is None:
             crash_id = str(uuid.UUID(int=random.getrandbits(128)))
 
         if raw_crash is None:
             raw_crash = {}
 
-        doc = {
+        doc = {}
+        if root_doc:
+            doc = dict(root_doc)
+
+        doc.update({
             'crash_id': crash_id,
             'processed_crash': processed_crash,
             'raw_crash': raw_crash,
-        }
+        })
         res = self.connection.index(
             index=self.config.elasticsearch.elasticsearch_index,
             doc_type=self.config.elasticsearch.elasticsearch_doctype,


### PR DESCRIPTION
Fixes a bug with the way Super Search manages fields. A field that had no namespace (ie. that is in the root of the crash document) became `.field` instead of `field`, thus preventing any filtering or aggregating on it.