### PR TITLE
Fixes bug 1316185: fold socorrolib back in

### DIFF
--- a/alembic/README
+++ b/alembic/README
@@ -35,7 +35,7 @@ We use a few types not currently supported by SQLAlchemy, so you may
 need to modify the migration slightly.
 
 
-== Helper functions in socorrolib.lib.migrations
+== Helper functions in socorro.lib.migrations
 
 We have a couple helper functions for doing cleanup tasks, and adding custom
 types. These functions and classes are imported by the default template for

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -11,8 +11,8 @@ revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1023855cf1ad_fixes_bug_1117911_load_truncate_.py
+++ b/alembic/versions/1023855cf1ad_fixes_bug_1117911_load_truncate_.py
@@ -11,8 +11,8 @@ revision = '1023855cf1ad'
 down_revision = '2cdb9abe6291'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/122bac0f6ade_bug_917823_remove_7d.py
+++ b/alembic/versions/122bac0f6ade_bug_917823_remove_7d.py
@@ -11,8 +11,8 @@ revision = '122bac0f6ade'
 down_revision = '3c5882fb7e3e'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/131b277f5ef7_bug_958595_removed_emails_table.py
+++ b/alembic/versions/131b277f5ef7_bug_958595_removed_emails_table.py
@@ -11,8 +11,8 @@ revision = '131b277f5ef7'
 down_revision = '6ef54091228'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/144f7ace11e7_bug_822304_priority_.py
+++ b/alembic/versions/144f7ace11e7_bug_822304_priority_.py
@@ -11,8 +11,8 @@ revision = '144f7ace11e7'
 down_revision = '3a5471a358bf'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1495b7307dd3_bug_1005326_filter_out_null.py
+++ b/alembic/versions/1495b7307dd3_bug_1005326_filter_out_null.py
@@ -11,8 +11,8 @@ revision = '1495b7307dd3'
 down_revision = '1961d1f70175'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/17e83fdeb135_bug_1076270_support_windows_10.py
+++ b/alembic/versions/17e83fdeb135_bug_1076270_support_windows_10.py
@@ -11,8 +11,8 @@ revision = '17e83fdeb135'
 down_revision = '52dbc7357409'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/18805d64cf6_bug_1035689_enforce_minimum_build_id_.py
+++ b/alembic/versions/18805d64cf6_bug_1035689_enforce_minimum_build_id_.py
@@ -11,8 +11,8 @@ revision = '18805d64cf6'
 down_revision = '391e42da94dd'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/18b22de09433_update_crontabber_ta.py
+++ b/alembic/versions/18b22de09433_update_crontabber_ta.py
@@ -11,8 +11,8 @@ revision = '18b22de09433'
 down_revision = '4c7a28212f15'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/191d0453cc07_making_reports_honor.py
+++ b/alembic/versions/191d0453cc07_making_reports_honor.py
@@ -11,8 +11,8 @@ revision = '191d0453cc07'
 down_revision = '523b9e57eba2'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1961d1f70175_.py
+++ b/alembic/versions/1961d1f70175_.py
@@ -11,8 +11,8 @@ revision = '1961d1f70175'
 down_revision = '295087fb3159'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1aa9adb91413_fixes_bug_907305_add.py
+++ b/alembic/versions/1aa9adb91413_fixes_bug_907305_add.py
@@ -11,8 +11,8 @@ revision = '1aa9adb91413'
 down_revision = '4d8345089e2a'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1ab8d5514ce2_fixes_bug_1023867_fixes_integer_.py
+++ b/alembic/versions/1ab8d5514ce2_fixes_bug_1023867_fixes_integer_.py
@@ -11,8 +11,8 @@ revision = '1ab8d5514ce2'
 down_revision = '433adca8a14c'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1b595e72bb25_.py
+++ b/alembic/versions/1b595e72bb25_.py
@@ -11,8 +11,8 @@ revision = '1b595e72bb25'
 down_revision = ('31168908ac42', '42c267d6ed35', '5a1b1cb955e9')
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1baef149e5d1_bug_1018349_add_coalesce_to_max_sort_.py
+++ b/alembic/versions/1baef149e5d1_bug_1018349_add_coalesce_to_max_sort_.py
@@ -11,8 +11,8 @@ revision = '1baef149e5d1'
 down_revision = '26521f842be2'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1ef041dfc3d5_nobug_load_update_reports_clean_from_.py
+++ b/alembic/versions/1ef041dfc3d5_nobug_load_update_reports_clean_from_.py
@@ -11,8 +11,8 @@ revision = '1ef041dfc3d5'
 down_revision = '1ab8d5514ce2'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/1f235c84eaed_bug_1025987_normalize_correlations_table.py
+++ b/alembic/versions/1f235c84eaed_bug_1025987_normalize_correlations_table.py
@@ -11,8 +11,8 @@ revision = '1f235c84eaed'
 down_revision = '3f007539efc'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/21887d27b1c4_fixes_bug_998473_update_add_new_product_.py
+++ b/alembic/versions/21887d27b1c4_fixes_bug_998473_update_add_new_product_.py
@@ -11,8 +11,8 @@ revision = '21887d27b1c4'
 down_revision = '447682fe2ab6'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/21e4e35689f6_bug_993786_update_crash_adu_by_build_.py
+++ b/alembic/versions/21e4e35689f6_bug_993786_update_crash_adu_by_build_.py
@@ -11,8 +11,8 @@ revision = '21e4e35689f6'
 down_revision = '224f0fda6ecb'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/224f0fda6ecb_bug_984562-track-b2g-1_3.py
+++ b/alembic/versions/224f0fda6ecb_bug_984562-track-b2g-1_3.py
@@ -11,8 +11,8 @@ revision = '224f0fda6ecb'
 down_revision = '4c279bec76d8'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/22ec34ad88fc_fixes_bug_963600_add.py
+++ b/alembic/versions/22ec34ad88fc_fixes_bug_963600_add.py
@@ -11,8 +11,8 @@ revision = '22ec34ad88fc'
 down_revision = '4bb277899d74'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/235c80dc2e12_fixes_bug_1047079_remove_processors_.py
+++ b/alembic/versions/235c80dc2e12_fixes_bug_1047079_remove_processors_.py
@@ -11,8 +11,8 @@ revision = '235c80dc2e12'
 down_revision = '556e11f2d00f'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/2580b5b6b7aa_fixes_bug_980077_alter_table_laglog_to_.py
+++ b/alembic/versions/2580b5b6b7aa_fixes_bug_980077_alter_table_laglog_to_.py
@@ -11,8 +11,8 @@ revision = '2580b5b6b7aa'
 down_revision = 'c1ac31c8fea'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/26521f842be2_bug_1030218_group_correlations_by_reason.py
+++ b/alembic/versions/26521f842be2_bug_1030218_group_correlations_by_reason.py
@@ -11,8 +11,8 @@ revision = '26521f842be2'
 down_revision = '3e872b0759f0'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/295087fb3159_fixes_bug_915246_adds_product_name_and_.py
+++ b/alembic/versions/295087fb3159_fixes_bug_915246_adds_product_name_and_.py
@@ -12,8 +12,8 @@ revision = '295087fb3159'
 down_revision = '21887d27b1c4'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/2990eb43b269_update_product_versions.py
+++ b/alembic/versions/2990eb43b269_update_product_versions.py
@@ -11,7 +11,7 @@ revision = '2990eb43b269'
 down_revision = '3860644579f4'
 
 from alembic import op
-from socorrolib.lib.migrations import load_stored_proc
+from socorro.lib.migrations import load_stored_proc
 
 
 def upgrade():

--- a/alembic/versions/2c48009040da_bug_958558_migration_for_update_product_.py
+++ b/alembic/versions/2c48009040da_bug_958558_migration_for_update_product_.py
@@ -11,8 +11,8 @@ revision = '2c48009040da'
 down_revision = '4cacd567770f'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/2cdb9abe6291_fixes_bug_1122145_add_release_repos_for_.py
+++ b/alembic/versions/2cdb9abe6291_fixes_bug_1122145_add_release_repos_for_.py
@@ -11,8 +11,8 @@ revision = '2cdb9abe6291'
 down_revision = '445fefe2e08f'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/31168908ac42_fixes_bug_1053956_deprecate_raw_adu_in_.py
+++ b/alembic/versions/31168908ac42_fixes_bug_1053956_deprecate_raw_adu_in_.py
@@ -11,8 +11,8 @@ revision = '31168908ac42'
 down_revision = 'e4ea2ae3413'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/317e15fbf13a_backfill_graphics_de.py
+++ b/alembic/versions/317e15fbf13a_backfill_graphics_de.py
@@ -11,8 +11,8 @@ revision = '317e15fbf13a'
 down_revision = '191d0453cc07'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3294c1805e91_bug_1037244_switch_to_raw_adi.py
+++ b/alembic/versions/3294c1805e91_bug_1037244_switch_to_raw_adi.py
@@ -11,8 +11,8 @@ revision = '3294c1805e91'
 down_revision = '18805d64cf6'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/32b54dec3fc0_fixes_bug_970406_add_raw_adi_logs_table.py
+++ b/alembic/versions/32b54dec3fc0_fixes_bug_970406_add_raw_adi_logs_table.py
@@ -11,8 +11,8 @@ revision = '32b54dec3fc0'
 down_revision = '1ef041dfc3d5'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/335c2bfd99a6_bug_1255444_fix_fennecandroid_for_new_.py
+++ b/alembic/versions/335c2bfd99a6_bug_1255444_fix_fennecandroid_for_new_.py
@@ -11,8 +11,8 @@ revision = '335c2bfd99a6'
 down_revision = '9371b45451b'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/355d0795af7f_add_lag_log_table.py
+++ b/alembic/versions/355d0795af7f_add_lag_log_table.py
@@ -11,8 +11,8 @@ revision = '355d0795af7f'
 down_revision = '4f87c13b66c5'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/373ef4569b93_correlations_table.py
+++ b/alembic/versions/373ef4569b93_correlations_table.py
@@ -9,7 +9,7 @@ Create Date: 2016-04-25 14:11:28.373859
 from alembic import op
 import sqlalchemy as sa
 
-from socorrolib.lib import jsontype
+from socorro.lib import jsontype
 
 # revision identifiers, used by Alembic.
 revision = '373ef4569b93'

--- a/alembic/versions/391e42da94dd_bug_1035957_use_literal_now_for_.py
+++ b/alembic/versions/391e42da94dd_bug_1035957_use_literal_now_for_.py
@@ -12,8 +12,8 @@ revision = '391e42da94dd'
 down_revision = '495bf3fcdb63'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3a36327c2845_bug_1054078_match_mac_os_x_on_darwin.py
+++ b/alembic/versions/3a36327c2845_bug_1054078_match_mac_os_x_on_darwin.py
@@ -11,8 +11,8 @@ revision = '3a36327c2845'
 down_revision = '3e64019254d1'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3a5471a358bf_adding_a_migration_f.py
+++ b/alembic/versions/3a5471a358bf_adding_a_migration_f.py
@@ -11,8 +11,8 @@ revision = '3a5471a358bf'
 down_revision = '4aacaea3eb48'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3c5882fb7e3e_bug_956436_new_build.py
+++ b/alembic/versions/3c5882fb7e3e_bug_956436_new_build.py
@@ -11,8 +11,8 @@ revision = '3c5882fb7e3e'
 down_revision = '4a6b5fec10e9'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3e64019254d1_bug_1053632_collapse_raw_adi_release_.py
+++ b/alembic/versions/3e64019254d1_bug_1053632_collapse_raw_adi_release_.py
@@ -13,8 +13,8 @@ down_revision = '3294c1805e91'
 import datetime
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3e872b0759f0_bug_1025987_bigint_is_overkill.py
+++ b/alembic/versions/3e872b0759f0_bug_1025987_bigint_is_overkill.py
@@ -11,8 +11,8 @@ revision = '3e872b0759f0'
 down_revision = '1f235c84eaed'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3e9fd64194df_fixes_bug_1149716_update_partitioned_by_.py
+++ b/alembic/versions/3e9fd64194df_fixes_bug_1149716_update_partitioned_by_.py
@@ -11,8 +11,8 @@ revision = '3e9fd64194df'
 down_revision = '63d05b930c3'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3f007539efc_fixes_bug_1024666_add_raw_adi_table.py
+++ b/alembic/versions/3f007539efc_fixes_bug_1024666_add_raw_adi_table.py
@@ -11,8 +11,8 @@ revision = '3f007539efc'
 down_revision = '32b54dec3fc0'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/3f03539b66de_bug_1151229_fix_typo_in_update_.py
+++ b/alembic/versions/3f03539b66de_bug_1151229_fix_typo_in_update_.py
@@ -11,8 +11,8 @@ revision = '3f03539b66de'
 down_revision = '3e9fd64194df'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/42c267d6ed35_reload_update_reports_duplicates.py
+++ b/alembic/versions/42c267d6ed35_reload_update_reports_duplicates.py
@@ -11,8 +11,8 @@ revision = '42c267d6ed35'
 down_revision = 'e4ea2ae3413'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/433adca8a14c_bug_1007379_adu_by_sig_should_show_.py
+++ b/alembic/versions/433adca8a14c_bug_1007379_adu_by_sig_should_show_.py
@@ -13,8 +13,8 @@ down_revision = '1495b7307dd3'
 import datetime
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/445fefe2e08f_fixes_bug_794549_add_partitioning_to_.py
+++ b/alembic/versions/445fefe2e08f_fixes_bug_794549_add_partitioning_to_.py
@@ -11,8 +11,8 @@ revision = '445fefe2e08f'
 down_revision = '5387d590bc45'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/447682fe2ab6_fixes_bug_997760_adds_hourly_update_for_.py
+++ b/alembic/versions/447682fe2ab6_fixes_bug_997760_adds_hourly_update_for_.py
@@ -11,8 +11,8 @@ revision = '447682fe2ab6'
 down_revision = '21e4e35689f6'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/46c7fb8a8671_bug_946266_reprocess.py
+++ b/alembic/versions/46c7fb8a8671_bug_946266_reprocess.py
@@ -11,8 +11,8 @@ revision = '46c7fb8a8671'
 down_revision = '144f7ace11e7'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/477e1c6e6df3_fixes_bug_933963_spl.py
+++ b/alembic/versions/477e1c6e6df3_fixes_bug_933963_spl.py
@@ -11,8 +11,8 @@ revision = '477e1c6e6df3'
 down_revision = '18b22de09433'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/48e9a4366530_bug_958198_exploitab.py
+++ b/alembic/versions/48e9a4366530_bug_958198_exploitab.py
@@ -11,8 +11,8 @@ revision = '48e9a4366530'
 down_revision = '122bac0f6ade'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/491cdcf9f97c_bug_972563_gccrashes_nightly.py
+++ b/alembic/versions/491cdcf9f97c_bug_972563_gccrashes_nightly.py
@@ -11,8 +11,8 @@ revision = '491cdcf9f97c'
 down_revision = '1aa9adb91413'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/495bf3fcdb63_fix_invalid_notice_in_update_signatures_hourly.py
+++ b/alembic/versions/495bf3fcdb63_fix_invalid_notice_in_update_signatures_hourly.py
@@ -11,8 +11,8 @@ revision = '495bf3fcdb63'
 down_revision = '1baef149e5d1'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/495e6c766315_reload_sunset_date_function.py
+++ b/alembic/versions/495e6c766315_reload_sunset_date_function.py
@@ -7,7 +7,7 @@ Create Date: 2016-10-31 12:46:22.476356
 """
 
 from alembic import op
-from socorrolib.lib.migrations import load_stored_proc
+from socorro.lib.migrations import load_stored_proc
 
 # revision identifiers, used by Alembic.
 revision = '495e6c766315'

--- a/alembic/versions/4a068f8838c6_bug_959731_update_product_versions_.py
+++ b/alembic/versions/4a068f8838c6_bug_959731_update_product_versions_.py
@@ -11,8 +11,8 @@ revision = '4a068f8838c6'
 down_revision = '514789372d99'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4a6b5fec10e9_bug_951825_update_exploitability.py
+++ b/alembic/versions/4a6b5fec10e9_bug_951825_update_exploitability.py
@@ -12,8 +12,8 @@ revision = '4a6b5fec10e9'
 down_revision = '58d0dc2f6aa4'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4aacaea3eb48_adding_duration.py
+++ b/alembic/versions/4aacaea3eb48_adding_duration.py
@@ -11,8 +11,8 @@ revision = '4aacaea3eb48'
 down_revision = '477e1c6e6df3'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4b2567293aee_bug_974726_move_correlations_to_postgres.py
+++ b/alembic/versions/4b2567293aee_bug_974726_move_correlations_to_postgres.py
@@ -11,8 +11,8 @@ revision = '4b2567293aee'
 down_revision = '74d6fd90b59'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4bb277899d74_add_version_build_co.py
+++ b/alembic/versions/4bb277899d74_add_version_build_co.py
@@ -11,8 +11,8 @@ revision = '4bb277899d74'
 down_revision = '355d0795af7f'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4c279bec76d8_fixes_bug_976069_add_raw_and_processed_.py
+++ b/alembic/versions/4c279bec76d8_fixes_bug_976069_add_raw_and_processed_.py
@@ -11,8 +11,8 @@ revision = '4c279bec76d8'
 down_revision = '4b2567293aee'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4c7a28212f15_crontabber.py
+++ b/alembic/versions/4c7a28212f15_crontabber.py
@@ -11,7 +11,7 @@ revision = '4c7a28212f15'
 down_revision = '317e15fbf13a'
 
 from alembic import op
-from socorrolib.lib import jsontype
+from socorro.lib import jsontype
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/alembic/versions/4cacd567770f_bug_958558_add_new_release_changes.py
+++ b/alembic/versions/4cacd567770f_bug_958558_add_new_release_changes.py
@@ -11,8 +11,8 @@ revision = '4cacd567770f'
 down_revision = '48e9a4366530'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4d8345089e2a_fixes_bug_968493_add.py
+++ b/alembic/versions/4d8345089e2a_fixes_bug_968493_add.py
@@ -11,8 +11,8 @@ revision = '4d8345089e2a'
 down_revision = '131b277f5ef7'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/4f87c13b66c5_fix_for_bug_960621_compensates_for_.py
+++ b/alembic/versions/4f87c13b66c5_fix_for_bug_960621_compensates_for_.py
@@ -11,8 +11,8 @@ revision = '4f87c13b66c5'
 down_revision = '58ed3acc86cb'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/514789372d99_fixes_bug_959354_remaining_stored_proc_.py
+++ b/alembic/versions/514789372d99_fixes_bug_959354_remaining_stored_proc_.py
@@ -13,8 +13,8 @@ down_revision = '2c48009040da'
 import datetime
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/523b9e57eba2_migration_for_creati.py
+++ b/alembic/versions/523b9e57eba2_migration_for_creati.py
@@ -17,7 +17,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy import types
 from sqlalchemy.sql import table, column
 
-from socorrolib.lib.migrations import fix_permissions
+from socorro.lib.migrations import fix_permissions
 
 
 class CITEXT(types.UserDefinedType):

--- a/alembic/versions/52dbc7357409_bug_1056025_and_bug_1037855_rename_.py
+++ b/alembic/versions/52dbc7357409_bug_1056025_and_bug_1037855_rename_.py
@@ -13,8 +13,8 @@ down_revision = '3a36327c2845'
 import datetime
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/5387d590bc45_fixes_bug_1117907_remove_sigsum_fks_.py
+++ b/alembic/versions/5387d590bc45_fixes_bug_1117907_remove_sigsum_fks_.py
@@ -11,8 +11,8 @@ revision = '5387d590bc45'
 down_revision = '235c80dc2e12'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/556e11f2d00f_bug_948644_record_missing_symbols_from_.py
+++ b/alembic/versions/556e11f2d00f_bug_948644_record_missing_symbols_from_.py
@@ -11,8 +11,8 @@ revision = '556e11f2d00f'
 down_revision = '17e83fdeb135'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/56f5cdf9bcdb_bug_1000160_use_version_string_instead_.py
+++ b/alembic/versions/56f5cdf9bcdb_bug_1000160_use_version_string_instead_.py
@@ -11,8 +11,8 @@ revision = '56f5cdf9bcdb'
 down_revision = '3f03539b66de'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/58d0dc2f6aa4_adding_adu_by_build_.py
+++ b/alembic/versions/58d0dc2f6aa4_adding_adu_by_build_.py
@@ -11,8 +11,8 @@ revision = '58d0dc2f6aa4'
 down_revision = '46c7fb8a8671'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/58ed3acc86cb_fixes_bug_958640_adu_updates.py
+++ b/alembic/versions/58ed3acc86cb_fixes_bug_958640_adu_updates.py
@@ -11,8 +11,8 @@ revision = '58ed3acc86cb'
 down_revision = '4a068f8838c6'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/5a1b1cb955e9_fix_bug_1124750_drop_edit_product_info.py
+++ b/alembic/versions/5a1b1cb955e9_fix_bug_1124750_drop_edit_product_info.py
@@ -11,8 +11,8 @@ revision = '5a1b1cb955e9'
 down_revision = 'e4ea2ae3413'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/5bafdc19756c_drop_server_status_table.py
+++ b/alembic/versions/5bafdc19756c_drop_server_status_table.py
@@ -11,8 +11,8 @@ revision = '5bafdc19756c'
 down_revision = '89ef86a3d57a'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/63d05b930c3_fixes_bug_1136854_fix_permissions_.py
+++ b/alembic/versions/63d05b930c3_fixes_bug_1136854_fix_permissions_.py
@@ -11,8 +11,8 @@ revision = '63d05b930c3'
 down_revision = '732abe64c5a'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/6ef54091228_bug_967593_gc_crash_count.py
+++ b/alembic/versions/6ef54091228_bug_967593_gc_crash_count.py
@@ -11,8 +11,8 @@ revision = '6ef54091228'
 down_revision = '22ec34ad88fc'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/732abe64c5a_fixes_bug_1136711_deprecate_bixie.py
+++ b/alembic/versions/732abe64c5a_fixes_bug_1136711_deprecate_bixie.py
@@ -11,8 +11,8 @@ revision = '732abe64c5a'
 down_revision = '1b595e72bb25'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/74d6fd90b59_bug_928051_add_b2g_to_reports_clean.py
+++ b/alembic/versions/74d6fd90b59_bug_928051_add_b2g_to_reports_clean.py
@@ -11,8 +11,8 @@ revision = '74d6fd90b59'
 down_revision = '2580b5b6b7aa'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/9371b45451b_remove_explosiveness_and_suspicious.py
+++ b/alembic/versions/9371b45451b_remove_explosiveness_and_suspicious.py
@@ -7,7 +7,7 @@ Create Date: 2016-01-20 13:25:27.414375
 """
 
 from alembic import op
-from socorrolib.lib.migrations import load_stored_proc
+from socorro.lib.migrations import load_stored_proc
 
 # revision identifiers, used by Alembic.
 revision = '9371b45451b'

--- a/alembic/versions/b99155654de_sunset_all_future_metrofirefox.py
+++ b/alembic/versions/b99155654de_sunset_all_future_metrofirefox.py
@@ -11,7 +11,7 @@ revision = 'b99155654de'
 down_revision = '56f5cdf9bcdb'
 
 from alembic import op
-from socorrolib.lib.migrations import load_stored_proc
+from socorro.lib.migrations import load_stored_proc
 
 
 def upgrade():

--- a/alembic/versions/c1ac31c8fea_fix_bug_972612_is_gc_count_should_be_.py
+++ b/alembic/versions/c1ac31c8fea_fix_bug_972612_is_gc_count_should_be_.py
@@ -13,8 +13,8 @@ down_revision = '491cdcf9f97c'
 import datetime
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/alembic/versions/e4d30f140ed_add_new_rule_to_copy.py
+++ b/alembic/versions/e4d30f140ed_add_new_rule_to_copy.py
@@ -51,7 +51,7 @@ def upgrade():
         # Indexes
     op.bulk_insert(transform_rule, [{
         "category": 'processor.json_rewrite'
-        , "predicate": 'socorrolib.lib.transform_rules.is_not_null_predicate'
+        , "predicate": 'socorro.lib.transform_rules.is_not_null_predicate'
         , "predicate_args": ''
         , "predicate_kwargs": 'key="PluginContentURL"'
         , "action": 'socorro.processor.processor.json_reformat_action'
@@ -60,7 +60,7 @@ def upgrade():
         , "rule_order": '5'
     }, {
         "category": 'processor.json_rewrite'
-        , "predicate": 'socorrolib.lib.transform_rules.is_not_null_predicate'
+        , "predicate": 'socorro.lib.transform_rules.is_not_null_predicate'
         , "predicate_args": ''
         , "predicate_kwargs": 'key="PluginUserComment"'
         , "action": 'socorro.processor.processor.json_reformat_action'

--- a/alembic/versions/e4ea2ae3413_fixes_bug_1122145_update_special_.py
+++ b/alembic/versions/e4ea2ae3413_fixes_bug_1122145_update_special_.py
@@ -11,8 +11,8 @@ revision = 'e4ea2ae3413'
 down_revision = '1023855cf1ad'
 
 from alembic import op
-from socorrolib.lib import citexttype, jsontype, buildtype
-from socorrolib.lib.migrations import fix_permissions, load_stored_proc
+from socorro.lib import citexttype, jsontype, buildtype
+from socorro.lib.migrations import fix_permissions, load_stored_proc
 
 import sqlalchemy as sa
 from sqlalchemy import types

--- a/config/cron_submitter.ini-dist
+++ b/config/cron_submitter.ini-dist
@@ -75,7 +75,7 @@
     # name: producer_consumer_class
     # doc: the class implements a threaded producer consumer queue
     # converter: configman.converters.class_converter
-    producer_consumer_class='socorrolib.lib.threaded_task_manager.ThreadedTaskManager'
+    producer_consumer_class='socorro.lib.threaded_task_manager.ThreadedTaskManager'
 
 [source]
 

--- a/config/processor.ini-dist
+++ b/config/processor.ini-dist
@@ -480,7 +480,7 @@
         #prefix=
 
         # name of a class that will gather statistics
-        #stats_class=socorrolib.lib.statistics.StatisticsForStatsd
+        #stats_class=socorro.lib.statistics.StatisticsForStatsd
 
         # the hostname of statsd
         # see "resource.statsd.statsd_host" for the default or override it here
@@ -502,7 +502,7 @@
     #number_of_threads=4
 
     # the class implements a threaded producer consumer queue
-    #producer_consumer_class=socorrolib.lib.threaded_task_manager.ThreadedTaskManager
+    #producer_consumer_class=socorro.lib.threaded_task_manager.ThreadedTaskManager
 
 [registrar]
 

--- a/docs/development/addaservice.rst
+++ b/docs/development/addaservice.rst
@@ -20,7 +20,7 @@ there is a PostgreSQL submodule, an elasticsearch submodule and a boto (AWS S3)
 submodule.
 
 You will also find some common code among external resources in
-``socorrolib.lib``.
+``socorro.lib``.
 
 The "Middleware" in Socorro is divided into two separate modules.
 ``socorro/middleware/middleware_app.py`` is the file that contains the actual
@@ -96,7 +96,7 @@ method that will contain all your business logic. For example::
 
     # file socorro/external/postgresql/crash.py
 
-    from socorrolib.lib import MissingOrBadArgumentError, external_common
+    from socorro.lib import MissingOrBadArgumentError, external_common
     from socorro.external.postgresql.base import PostgreSQLBase
 
 
@@ -193,7 +193,7 @@ Here is an example of an integration test file for a PostgreSQL service
 
     from nose.tools import eq_, assert_raises
 
-    from socorrolib.lib import MissingOrBadArgumentError
+    from socorro.lib import MissingOrBadArgumentError
     from socorro.external.postgresql.crash import Crash
     from unittestbase import PostgreSQLTestCase
 

--- a/docs/development/dumpingdumptables.rst
+++ b/docs/development/dumpingdumptables.rst
@@ -19,7 +19,7 @@ https://bugzilla.mozilla.org/show_bug.cgi?id=484032
 Library support
 ---------------
 
-'done' as of 2009-05-07 in socorrolib.lib.dmpStorage (Coding, testing is done; integration testing is done, 'go live' is today)
+'done' as of 2009-05-07 in socorro.lib.dmpStorage (Coding, testing is done; integration testing is done, 'go live' is today)
 Socorro UI
 
 /report/index/{uuid}

--- a/docs/development/generic_app.rst
+++ b/docs/development/generic_app.rst
@@ -12,7 +12,7 @@ To illustrate the example, let's look at an example of an app that
 uses ``generic_app`` to leverage ``configman`` to run. Let's look at `weeklyReportsPartitions.py
 <https://github.com/mozilla/socorro/blob/master/socorro/cron/weeklyReportsPartitions.py>`_
 
-As you can see, it's a subclass of the `socorrolib.app.generic_app.App
+As you can see, it's a subclass of the `socorro.app.generic_app.App
 <https://github.com/mozilla/socorro/blob/master/socorro/app/generic_app.py>`_
 class which is a the-least-you-need wrapper for a minimal app. As you
 can see, it takes care of logging and executing your ``main`` function.

--- a/docs/development/glossary/jsondumpstorage.rst
+++ b/docs/development/glossary/jsondumpstorage.rst
@@ -83,7 +83,7 @@ the elderly json/dump pairs.
 class JsonDumpStorage
 ---------------------
 
-``socorrolib.lib.JsonDumpStorage`` holds data and implements methods for
+``socorro.lib.JsonDumpStorage`` holds data and implements methods for
 creating and accessing crash files.
 
 **public methods**

--- a/requirements.txt
+++ b/requirements.txt
@@ -280,9 +280,6 @@ pyinotify==0.9.6 ; sys_platform == 'linux' or sys_platform == 'linux2' \
     --hash=sha256:9c998a5d7606ca835065cdabc013ae6c66eb9ea76a00a1e3bc6e0cfe2b4f71f4
 django-jinja==2.1.2 \
     --hash=sha256:fc2b6a65201b27711e800eb2e1262ff42a32f027bd2267e34121f1bd2bd6b933
-socorrolib==0.2.3 \
-    --hash=sha256:f8502ef21f6db7e9a72737aa442b50f958cdf48fd437ebcf4fe51dd379cbcd8e \
-    --hash=sha256:aa83e259155df030227e857a10fb65c8f43d8717f4e28556cd15b8ed60964214
 humanfriendly==1.44.7 \
     --hash=sha256:fcee758612edc6fead9b8fd1d5a473eab2c3a84cf8766f3ce70862ccd35e8a64
 jsonschema==2.5.1 \

--- a/scripts/collector.py
+++ b/scripts/collector.py
@@ -4,9 +4,9 @@
 
 import web
 import socorro.webapi.class_partial as cpart
-import socorrolib.lib.ConfigurationManager as cm
+import socorro.lib.ConfigurationManager as cm
 import socorro.collector.wsgicollector as wscol
-import socorrolib.lib.util as sutil
+import socorro.lib.util as sutil
 #import socorro.webapi.hello as hello
 
 import config.collectorconfig as collectorConfig

--- a/scripts/setup_supersearch_app.py
+++ b/scripts/setup_supersearch_app.py
@@ -16,7 +16,7 @@ from elasticsearch.helpers import bulk
 from configman import Namespace
 from configman.converters import class_converter
 
-from socorrolib.app import generic_app
+from socorro.app import generic_app
 
 
 class SetupSuperSearchApp(generic_app.App):

--- a/scripts/socorro
+++ b/scripts/socorro
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
 
-from socorrolib.app.socorro_app import SocorroWelcomeApp
+from socorro.app.socorro_app import SocorroWelcomeApp
 
 SocorroWelcomeApp.run()

--- a/scripts/submitter.py
+++ b/scripts/submitter.py
@@ -10,9 +10,9 @@ import logging.handlers
 
 import config.submitterconfig as subconf
 
-import socorrolib.lib.ConfigurationManager as configurationManager
+import socorro.lib.ConfigurationManager as configurationManager
 import socorro.collector.submitter as sub
-import socorrolib.lib.util as sutil
+import socorro.lib.util as sutil
 
 import poster
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[],  # use pip -r requirements.txt instead
     entry_points={
         'console_scripts': [
-            'socorro = socorrolib.app.socorro_app:SocorroWelcomeApp.run'
+            'socorro = socorro.app.socorro_app:SocorroWelcomeApp.run'
         ],
     },
     test_suite='nose.collector',

--- a/socorro/analysis/correlations/core_count_rule.py
+++ b/socorro/analysis/correlations/core_count_rule.py
@@ -21,8 +21,8 @@ from socorro.analysis.correlations.correlations_rule_base import (
     CorrelationRule,
     CorrelationsStorageBase,
 )
-from socorrolib.lib.util import DotDict as SocorroDotDict
-from socorrolib.lib.converters import change_default
+from socorro.lib.util import DotDict as SocorroDotDict
+from socorro.lib.converters import change_default
 
 
 #==============================================================================

--- a/socorro/analysis/correlations/correlations_app.py
+++ b/socorro/analysis/correlations/correlations_app.py
@@ -11,11 +11,11 @@ import ujson as json
 from configman import Namespace, class_converter
 from configman.dotdict import DotDict
 
-from socorrolib.app.fetch_transform_save_app import (
+from socorro.app.fetch_transform_save_app import (
     FetchTransformSaveWithSeparateNewCrashSourceApp
 )
 
-from socorrolib.lib.datetimeutil import UTC
+from socorro.lib.datetimeutil import UTC
 from socorro.external.crashstorage_base import CrashIDNotFound
 from socorro.external.postgresql.products import ProductVersions
 from socorro.processor.processor_2015 import rule_sets_from_string
@@ -26,7 +26,7 @@ correlation_rule_sets = [
     [
         "correlation_rules",
         "correlation",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.analysis.correlations.core_count_rule"
         ".CorrelationCoreCountRule, "

--- a/socorro/analysis/correlations/correlations_rule_base.py
+++ b/socorro/analysis/correlations/correlations_rule_base.py
@@ -20,8 +20,8 @@ from configman.converters import (
     class_converter
 )
 
-from socorrolib.lib.transform_rules import Rule
-from socorrolib.lib.util import DotDict as SocorroDotDict
+from socorro.lib.transform_rules import Rule
+from socorro.lib.util import DotDict as SocorroDotDict
 
 
 #------------------------------------------------------------------------------

--- a/socorro/analysis/correlations/interesting_rule.py
+++ b/socorro/analysis/correlations/interesting_rule.py
@@ -14,10 +14,10 @@ from collections import defaultdict
 
 from configman import Namespace
 
-from socorrolib.lib.converters import (
+from socorro.lib.converters import (
     change_default,
 )
-from socorrolib.lib.util import DotDict as SocorroDotDict
+from socorro.lib.util import DotDict as SocorroDotDict
 from socorro.analysis.correlations.correlations_rule_base import (
     CorrelationRule,
     CorrelationsStorageBase,

--- a/socorro/app/example_app.py
+++ b/socorro/app/example_app.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""demonstrates using configman to make a Socorro app"""
+
+# This app can be invoked like this:
+#     .../socorro/app/example_app.py --help
+# set your path to make that simpler
+# set both socorro and configman in your PYTHONPATH
+
+import datetime
+
+from socorro.app.generic_app import App, main
+
+from configman import Namespace
+
+
+#==============================================================================
+class ExampleApp(App):
+    app_name = 'example'
+    app_version = '0.1'
+    app_description = __doc__
+
+    #--------------------------------------------------------------------------
+    # in this section, define any configuration requirements
+    required_config = Namespace()
+    required_config.add_option('name',
+                               default='Wilma',
+                               doc='a name to echo')
+    required_config.add_option('time',
+                               default=datetime.datetime.now(),
+                               doc='the time of day')
+
+    #--------------------------------------------------------------------------
+    # implementing this constructor is only necessary when there is more
+    # initialization to be done before main can be called
+    #def __init__(self, config):
+        #super(ExampleApp,self).__init__(config)
+
+    #--------------------------------------------------------------------------
+    def main(self):
+        # this is where we'd implement the app
+        # the configuraton is already setup as self.config
+        print 'hello, %s. The time is: %s' % (self.config.name,
+                                              self.config.time)
+
+
+if __name__ == '__main__':
+    main(ExampleApp)

--- a/socorro/app/fetch_transform_save_app.py
+++ b/socorro/app/fetch_transform_save_app.py
@@ -1,0 +1,451 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""this is the basis for any app that follows the fetch/transform/save model
+
+* the configman versions of the crash mover and the processor apps will
+  derive from this class
+
+The form of fetch/transform/save, of course, in three parts
+1) fetch - some iterating or streaming function or object fetches packets of
+           from data a source
+2) transform - some function transforms each packet of data into a new form
+3) save - some function or class saves or streams the packet to some data
+           sink.
+
+For the crash mover, the fetch phase is reading new crashes from the
+collector's file system datastore.  The transform phase is the degenerate
+case of identity: no transformation.  The save phase is just sending the
+crashes to HBase.
+
+For the processor, the fetch phase is reading from the new crash queue.  In,
+2012, that's the union of reading a postgres jobs/crash_id table and fetching
+the crash from HBase.  The transform phase is the running of minidump stackwalk
+and production of the processed crash data.  The save phase is the union of
+sending new crash records to Postgres; sending the processed crash to HBase;
+the the submission of the crash_id to Elastic Search."""
+
+import signal
+from functools import partial
+
+from configman import Namespace
+from configman.converters import class_converter
+
+from socorro.lib.task_manager import respond_to_SIGTERM
+from socorro.app.generic_app import App, main  # main not used here, but
+                                               # is imported from generic_app
+                                               # into this scope to offer to
+                                               # apps that derive from the
+                                               # class defined here.
+
+
+#==============================================================================
+class FetchTransformSaveApp(App):
+    """base class for apps that follow the fetch/transform/save model"""
+    app_name = 'generic_fetch_transform_save_app'
+    app_version = '0.1'
+    app_description = __doc__
+
+    required_config = Namespace()
+    # the required config is broken into two parts: the source and the
+    # destination.  Each of those gets assigned a crasnstorage class.
+    required_config.source = Namespace()
+    # For source, the storage class should be one that defines a method
+    # of fetching new crashes through the three storage api methods: the
+    # iterator 'new_crashes' and the accessors 'get_raw_crash' and
+    # 'get_raw_dumps'
+    required_config.source.add_option(
+        'crashstorage_class',
+        doc='the source storage class',
+        default=None,
+        from_string_converter=class_converter
+    )
+    required_config.destination = Namespace()
+    # For destination, the storage class should implement the 'save_raw_crash'
+    # method.  Of course, a subclass may redefine either the source_iterator
+    # or transform methods and therefore completely redefine what api calls
+    # are relevant.
+    required_config.destination.add_option(
+        'crashstorage_class',
+        doc='the destination storage class',
+        default=None,
+        from_string_converter=class_converter
+    )
+    required_config.producer_consumer = Namespace()
+    required_config.producer_consumer.add_option(
+        'producer_consumer_class',
+        doc='the class implements a threaded producer consumer queue',
+        default='socorro.lib.threaded_task_manager.ThreadedTaskManager',
+        from_string_converter=class_converter
+    )
+    required_config.add_option(
+        'number_of_submissions',
+        doc="the number of crashes to submit (all, forever, 1...)",
+        short_form='n',
+        default='forever'
+    )
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def get_application_defaults():
+        """this method allows an app to inject defaults into the configuration
+        that can override defaults not under the direct control of the app.
+        For example, if an app were to use a class that had a config default
+        of X and that was not appropriate as a default for this app, then
+        this method could be used to override that default.
+
+        This is a technique of getting defaults into an app that replaces
+        an older method of going to the configman option and using the
+        'set_default' method with 'force=True'"""
+
+        return {
+            'source.crashstorage_class':
+            'socorro.external.fs.crashstorage.FSPermanentStorage',
+            'destination.crashstorage_class':
+            'socorro.external.fs.crashstorage.FSPermanentStorage',
+        }
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        super(FetchTransformSaveApp, self).__init__(config)
+        self.waiting_func = None
+        # select the iterator type based on the "number_of_submissions" config
+        self.source_iterator = {
+            'forever': self._infinite_iterator,
+            'all': self._all_iterator,
+        }.get(config.number_of_submissions, self._limited_iterator)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # iterator section
+    #
+    # the following methods setup a nested hierarchy of iterators.  Each layer
+    # in the hierarchy adds a feature to the enclosed iterator.
+
+    # The  iterator at the core, the innermost, will yield a list of crash_ids
+    # from some source. A subclass may define its own source and makes it
+    # available by overriding the method "_create_iter".
+    #
+    # That innermost iterator is then wrapped by the "_basic_iterator" method.
+    # this iterator changes the form of the yielded values to the (*args,
+    # **kwargs) as required by the TaskManager.  It also gives derived classes
+    # the oportunity to run callbacks between each iteration or at the point
+    # that the innermost iterator is exhausted.
+    #
+    # The outermost layer of the iterator nesting imposes length limitations
+    # on the iterators.  Controlled by the configuration parameter
+    # "number_of_submissions" this iterator can be limit to an exact number
+    # of iterations, set to run forever, or run only until the natural
+    # exhaustion of the innermost iterator.
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    #--------------------------------------------------------------------------
+    def _create_iter(self):
+        # the actual mechanism of creating the iterator to be overridden in
+        # subclasses based on what they want to iterate over.  In this default,
+        # iteration will come from the crashstorage instance defined as
+        # "source".  This works for the crashmover where the generally used
+        # source is the file system walking class.
+        return self.source.new_crashes()
+
+    #--------------------------------------------------------------------------
+    def _action_between_each_iteration(self):
+        """an action to take after an item has been yielded by the iterator.
+        This method is to be overridden by derived classes"""
+        pass
+
+    #--------------------------------------------------------------------------
+    def _action_after_iteration_completes(self):
+        """an action to be done when the iterator returned by the
+        "_create_iter" method is exhausted.  This method is to be overridden
+        in base classes that might need to do something special at that point.
+        examples may be simple logging, waiting, or resetting the iteration
+        system for the next loop."""
+        pass
+
+    #--------------------------------------------------------------------------
+    def _basic_iterator(self):
+        """this iterator yields individual crash_ids and/or Nones from the
+        iterator specified by the "_create_iter" method. Bare values yielded
+        by the "_create_iter" method get wrapped into an *args, **kwargs form.
+        That form is then used by the task manager as the arguments to the
+        worker function."""
+        for x in self._create_iter():
+            if x is None or isinstance(x, tuple):
+                yield x
+            else:
+                yield ((x,), {})
+            self._action_between_each_iteration()
+        else:
+            # when the iterator is exhausted, yield None as this is an
+            # indicator to some of the clients to take an action.
+            # This is a moribund action, but in this current refactoring
+            # we don't want to change old behavior
+            yield None
+        self._action_after_iteration_completes()
+
+    #--------------------------------------------------------------------------
+    def _infinite_iterator(self):
+        """this iterator wraps the "_basic_iterator" when the configuration
+        specifies that the "number_of_submissions" is set to "forever".
+        Whenever the "_basic_iterator" is exhausted, it is called again to
+        restart the iteration.  It is up to the implementation of the innermost
+        iterator to define what starting over means.  Some iterators may
+        repeat exactly what they did before, while others may iterate over
+        new values"""
+        while True:
+            for crash_id in self._basic_iterator():
+                if self._filter_disallowed_values(crash_id):
+                    continue
+                yield crash_id
+
+    #--------------------------------------------------------------------------
+    def _all_iterator(self):
+        """this is the iterator for the case when "number_of_submissions" is
+        set to "all".  It goes through the innermost iterator exactly once
+        and raises the StopIteration exception when that innermost iterator is
+        exhausted"""
+        for crash_id in self._basic_iterator():
+            if crash_id is None:
+                break
+            yield crash_id
+
+    #--------------------------------------------------------------------------
+    def _limited_iterator(self):
+        """this is the iterator for the case when "number_of_submissions" is
+        set to an integer.  It goes through the innermost iterator exactly the
+        number of times specified by "number_of_submissions"  To do that, it
+        might run the innermost iterator to exhaustion.  If that happens, that
+        innermost iterator is called again to start over.  It is up to the
+        implementation of the innermost iteration to define what starting
+        over means.  Some iterators may repeat exactly what they did before,
+        while others may iterate over new values"""
+        i = 0
+        while True:
+            for crash_id in self._basic_iterator():
+                if self._filter_disallowed_values(crash_id):
+                    continue
+                if crash_id is None:
+                    # it's ok to yield None, however, we don't want it to
+                    # be counted as a yielded value
+                    yield crash_id
+                    continue
+                if i == int(self.config.number_of_submissions):
+                    # break out of inner loop, abandoning the wrapped iter
+                    break
+                i += 1
+                yield crash_id
+            # repeat the quit test, to break out of the outer loop and
+            # if necessary, prevent recycling the wrapped iter
+            if i == int(self.config.number_of_submissions):
+                break
+
+    #--------------------------------------------------------------------------
+    def _filter_disallowed_values(self, current_value):
+        """in this base class there are no disallowed values coming from the
+        iterators.  Other users of these iterator may have some standards and
+        can detect and reject them here"""
+        return False
+
+    #--------------------------------------------------------------------------
+    def transform(
+        self,
+        crash_id,
+        finished_func=(lambda: None),
+    ):
+        try:
+            self._transform(crash_id)
+        finally:
+            # no matter what causes this method to end, we need to make sure
+            # that the finished_func gets called. If the new crash source is
+            # RabbitMQ, this is what removes the job from the queue.
+            try:
+                finished_func()
+            except Exception, x:
+                # when run in a thread, a failure here is not a problem, but if
+                # we're running all in the same thread, a failure here could
+                # derail the the whole processor. Best just log the problem
+                # so that we can continue.
+                self.config.logger.error(
+                    'Error completing job %s: %s',
+                    crash_id,
+                    x,
+                    exc_info=True
+                )
+
+    #--------------------------------------------------------------------------
+    def _transform(self, crash_id):
+        """this default transform function only transfers raw data from the
+        source to the destination without changing the data.  While this may
+        be good enough for the raw crashmover, the processor would override
+        this method to create and save processed crashes"""
+        try:
+            raw_crash = self.source.get_raw_crash(crash_id)
+        except Exception as x:
+            self.config.logger.error(
+                "reading raw_crash: %s",
+                str(x),
+                exc_info=True
+            )
+            raw_crash = {}
+        try:
+            dumps = self.source.get_raw_dumps(crash_id)
+        except Exception as x:
+            self.config.logger.error(
+                "reading dump: %s",
+                str(x),
+                exc_info=True
+            )
+            dumps = {}
+        try:
+            self.destination.save_raw_crash(raw_crash, dumps, crash_id)
+            self.config.logger.info('saved - %s', crash_id)
+        except Exception as x:
+            self.config.logger.error(
+                "writing raw: %s",
+                str(x),
+                exc_info=True
+            )
+        else:
+            try:
+                self.source.remove(crash_id)
+            except Exception as x:
+                self.config.logger.error(
+                    "removing raw: %s",
+                    str(x),
+                    exc_info=True
+                )
+
+    #--------------------------------------------------------------------------
+    def quit_check(self):
+        self.task_manager.quit_check()
+
+    #--------------------------------------------------------------------------
+    def signal_quit(self):
+        self.task_manager.stop()
+
+    #--------------------------------------------------------------------------
+    def _setup_source_and_destination(self):
+        """instantiate the classes that implement the source and destination
+        crash storage systems."""
+        try:
+            self.source = self.config.source.crashstorage_class(
+                self.config.source,
+                quit_check_callback=self.quit_check
+            )
+        except Exception:
+            self.config.logger.critical(
+                'Error in creating crash source',
+                exc_info=True
+            )
+            raise
+        try:
+            self.destination = self.config.destination.crashstorage_class(
+                self.config.destination,
+                quit_check_callback=self.quit_check
+            )
+        except Exception:
+            self.config.logger.critical(
+                'Error in creating crash destination',
+                exc_info=True
+            )
+            raise
+
+    #--------------------------------------------------------------------------
+    def _setup_task_manager(self):
+        """instantiate the threaded task manager to run the producer/consumer
+        queue that is the heart of the processor."""
+        self.config.logger.info('installing signal handers')
+        # set up the signal handler for dealing with SIGTERM. the target should
+        # be this app instance so the signal handler can reach in and set the
+        # quit flag to be True.  See the 'respond_to_SIGTERM' method for the
+        # more information
+        respond_to_SIGTERM_with_logging = partial(
+            respond_to_SIGTERM,
+            target=self
+        )
+        signal.signal(signal.SIGTERM, respond_to_SIGTERM_with_logging)
+        self.task_manager = \
+            self.config.producer_consumer.producer_consumer_class(
+                self.config.producer_consumer,
+                job_source_iterator=self.source_iterator,
+                task_func=self.transform
+            )
+        self.config.executor_identity = self.task_manager.executor_identity
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        try:
+            self.source.close()
+        except AttributeError:
+            # this source class has no close, we can ignore that & move on
+            pass
+        try:
+            self.destination.close()
+        except AttributeError:
+            # this destination class has no close, we can ignore that & move on
+            pass
+
+    #--------------------------------------------------------------------------
+    def main(self):
+        """this main routine sets up the signal handlers, the source and
+        destination crashstorage systems at the  theaded task manager.  That
+        starts a flock of threads that are ready to shepherd crashes from
+        the source to the destination."""
+
+        self._setup_task_manager()
+        self._setup_source_and_destination()
+        self.task_manager.blocking_start(waiting_func=self.waiting_func)
+        self.close()
+        self.config.logger.info('done.')
+
+
+#==============================================================================
+class FetchTransformSaveWithSeparateNewCrashSourceApp(FetchTransformSaveApp):
+    required_config = Namespace()
+    required_config.namespace('new_crash_source')
+    required_config.new_crash_source.add_option(
+        'new_crash_source_class',
+        doc='an iterable that will stream crash_ids needing processing',
+        default='',
+        from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def _create_iter(self):
+        # while the base class ties the iterator to the class specified as the
+        # crash data "source", this class introduces a different stream of
+        # crash_ids in the form of the "new_crash_source_class".  While this is
+        # also typically tied to a crashstorage class, it doesn't have to be
+        # the same class as the "source".  For example, the "source" may be
+        # AmazonS3 but the stream of crash_ids may be from RabbitMQ or a
+        # PG query
+        return self.new_crash_source.new_crashes()
+
+    #--------------------------------------------------------------------------
+    def _setup_source_and_destination(self):
+        """use the base class to setup the source and destinations but add to
+        that setup the instantiation of the "new_crash_source" """
+        super(FetchTransformSaveWithSeparateNewCrashSourceApp, self) \
+            ._setup_source_and_destination()
+        if self.config.new_crash_source.new_crash_source_class:
+            self.new_crash_source = \
+                self.config.new_crash_source.new_crash_source_class(
+                    self.config.new_crash_source,
+                    name=self.app_instance_name,
+                    quit_check_callback=self.quit_check
+                )
+        else:
+            # the configuration failed to provide a "new_crash_source", fall
+            # back to tying the "new_crash_source" to the "source".
+            self.new_crash_source = self.source
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        super(FetchTransformSaveWithSeparateNewCrashSourceApp, self).close()
+        if self.source != self.new_crash_source:
+            try:
+                self.new_crash_source.close()
+            except AttributeError:
+                # the new_crash_source has no close, move on without it
+                pass

--- a/socorro/app/for_application_defaults.py
+++ b/socorro/app/for_application_defaults.py
@@ -1,0 +1,98 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This is an extension to configman for Socorro.  It creates a ValueSource
+object that is also a 'from_string_converter'.  It is tailored to work with
+the Socorro 'application' configuration parameter.  Once configman has made
+a final determination as to which application to actually run, this class
+allows Configman to go to that application and fetch its preferred defaults
+for the rest of options required by that application."""
+
+from configman.converters import str_to_python_object
+from configman.dotdict import DotDict
+
+
+#==============================================================================
+class ApplicationDefaultsProxy(object):
+    """a placeholder class that will induce configman to query the application
+    object for the application's preferred defaults.  """
+
+    def __init__(self):
+        self.application_defaults = DotDict()
+        self.apps = self.find_all_the_apps()
+
+    #--------------------------------------------------------------------------
+    def str_to_application_class(self, an_app_key):
+        """a configman compatible str_to_* converter"""
+        try:
+            app_class = str_to_python_object(self.apps[an_app_key])
+        except KeyError:
+            app_class = str_to_python_object(an_app_key)
+        try:
+            self.application_defaults = DotDict(
+                app_class.get_application_defaults()
+            )
+        except AttributeError:
+            # no get_application_defaults, skip this step
+            pass
+        return app_class
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def find_all_the_apps():
+        """in the future, re-implement this as an automatic discovery service
+        """
+        return {
+            'collector': 'socorro.collector.collector_app.CollectorApp',
+            'collector2015': 'socorro.collector.collector_app.Collector2015App',
+            'crashmover': 'socorro.collector.crashmover_app.CrashMoverApp',
+            'setupdb': 'socorro.external.postgresql.setupdb_app.SocorroDBApp',
+            'submitter': 'socorro.collector.submitter_app.SubmitterApp',
+            # crontabber not yet supported in this environment
+            #'crontabber': 'socorro.cron.crontabber_app.CronTabberApp',
+            'middleware': 'socorro.middleware.middleware_app.MiddlewareApp',
+            'processor': 'socorro.processor.processor_app.ProcessorApp',
+            'fetch': 'socorro.external.fetch_app.FetchApp',
+            'copy_processed':
+                'socorro.collector.crashmover_app.ProcessedCrashCopierApp',
+            'copy_raw_and_processed':
+                'socorro.collector.crashmover_app.RawAndProcessedCopierApp',
+            'reprocess_crashlist':
+                'socorro.external.rabbitmq.reprocess_crashlist.ReprocessCrashlistApp',
+            'purge_rmq':
+            'socorro.external.rabbitmq.purge_queue_app.PurgeRabbitMQQueueApp',
+            'correlations':
+            'socorro.analysis.correlations.correlations_app.CorrelationsApp',
+        }
+
+
+can_handle = (
+    ApplicationDefaultsProxy
+)
+
+
+#==============================================================================
+class ValueSource(object):
+    """This is meant to be used as both a value source and a from string
+    converter.  An instance, as a value source, always returns an empty
+    dictionary from its 'get_values' method.  However, if it gets used as
+    a 'from string' converter, the 'get_values' behavior changes.  Just before
+    the 'from string' converter returns the conversion result, this class calls
+    the method 'get_application_defaults' on it and saves the result.  That
+    saved result becomes the new value for 'get_values' to return.
+
+    The end result is that an app that has a prefered set of defaults can still
+    get them loaded and used even if the app was itself loaded through
+    Configman.
+    """
+
+    #--------------------------------------------------------------------------
+    def __init__(self, source, the_config_manager=None):
+        self.source = source
+
+    #--------------------------------------------------------------------------
+    def get_values(self, config_manager, ignore_mismatches, obj_hook=DotDict):
+        if isinstance(self.source.application_defaults, obj_hook):
+            return self.source.application_defaults
+        return obj_hook(self.source.application_defaults)

--- a/socorro/app/generic_app.py
+++ b/socorro/app/generic_app.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module used to contain the overly complicated definition of the
+Socorro App class definitions.  That system has been moved to socorro_app.py.
+The following two imports into this module are for backwards compatibility.
+"""
+
+from socorro.app.socorro_app import main
+from socorro.app.socorro_app import App
+

--- a/socorro/app/socorro_app.py
+++ b/socorro/app/socorro_app.py
@@ -1,0 +1,510 @@
+#! /usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module defines the class hierarchy for all Socorro applications.
+
+The base of the hierarchy is "SocorroApp" which defines the interface and some
+of the base methods.
+
+Derived from the base "SocorroApp" is the "App" class.  This class adds logging
+configuration requirements to the application.  App is the class from which
+all the Socorro Apps derive.
+
+Also derived from the base class "SocorroApp" is "SocorroWelcomeApp", an app
+that serves as a dispatcher for all other Socorro apps.  Rather than forcing
+the user to know what and where all the other Socorro apps are, this app adds
+an "application" config requirement as a commandline arguement.  The user may
+specify the app name that they want to run.  Running --help on this app, will
+also list all the Socorro Apps.
+
+If a configuration file exists that includes a not-commented-out 'application'
+parameter, it can be give directly to the "SocorroWelomeApp".  In that case,
+the "SocorroWelcomeApp" becomes the app requested in the config file.
+"""
+
+import logging
+import logging.handlers
+import functools
+import signal
+import os
+import sys
+import re
+import threading
+
+import socorro.app.for_application_defaults
+from socorro.app.for_application_defaults import (
+    ApplicationDefaultsProxy,
+)
+
+from configman import (
+    ConfigurationManager,
+    Namespace,
+    RequiredConfig,
+    ConfigFileFutureProxy,
+    environment,
+    command_line,
+)
+from configman.converters import py_obj_to_str
+
+#------------------------------------------------------------------------------
+# every socorro app has a class method called 'get_application_defaults' from
+# which configman extracts the preferred configuration default values.
+#
+# The Socorro App class hierachy will create a 'values_source_list' with the
+# App's preferred config at the base.  These become the defaults over which
+# the configuration values from config file, environment, and command line are
+# overlaid.
+#
+# In the case where the actual app is not specified until configman is already
+# invoked, application defaults cannot be determined until configman
+# has already started the overlay process.  To resolve this
+# chicken/egg problem, we create a ApplicationDefaultsProxy class that stands
+# in values_source list (the list of places that overlay config values come
+# from).  Since the ApplicationDefaultsProxy also serves as the 'from_string'
+# converter for the Application config option, it can know when the target
+# application has been determined, fetch the defaults.  Since the
+# ApplicationDefaultsProxy object is already in the values source list, it can
+# then start providing overlay values immediately.
+
+# Configman knows nothing about how the ApplicationDefaultsProxy object works,
+# so we must regisiter it as a new values overlay source class.  We do that
+# by manually inserting inserting the new class into Configman's
+# handler/dispatcher.  That object associates config sources with modules that
+# are able to implement Configman's overlay handlers.
+from configman.value_sources import type_handler_dispatch
+# register our new type handler with configman
+type_handler_dispatch[ApplicationDefaultsProxy].append(
+   socorro.app.for_application_defaults
+)
+
+#------------------------------------------------------------------------------
+# create the app default proxy object
+application_defaults_proxy = ApplicationDefaultsProxy()
+
+#------------------------------------------------------------------------------
+# for use with SIGHUP for apps that run as daemons
+restart = True
+
+
+#------------------------------------------------------------------------------
+def respond_to_SIGHUP(signal_number, frame, logger=None):
+    """raise the KeyboardInterrupt which will cause the app to effectively
+    shutdown, closing all it resources.  Then, because it sets 'restart' to
+    True, the app will reread all the configuration information, rebuild all
+    of its structures and resources and start running again"""
+    global restart
+    restart = True
+    if logger:
+        logger.info('detected SIGHUP')
+    raise KeyboardInterrupt
+
+
+#--------------------------------------------------------------------------
+def klass_to_pypath(klass):
+    """when a class is defined within the module that is being executed as
+    main, the module name will be specified as '__main__' even though the
+    module actually had its own real name.  This ends up being very confusing
+    to Configman as it tries to refer to a class by its proper module name.
+    This function will convert a class into its properly qualified actual
+    pathname.  This method is used when a Socorro app is actually invoked
+    directly through the file in which the App class is defined.  This allows
+    configman to reimport the class under its proper name and treat it as if
+    it had been run through the SocorroWelcomeApp.  In turn, this allows
+    the application defaults to be fetched from the properly imported class
+    in time for configman use that information as value source."""
+    if klass.__module__ == '__main__':
+        module_path = (
+            sys.modules['__main__']
+            .__file__[:-3]
+        )
+        module_name = ''
+        for a_python_path in sys.path:
+            tentative_pathname = module_path.replace(a_python_path, '')
+            if tentative_pathname != module_path:
+                module_name = (
+                    tentative_pathname.replace('/', '.').strip('.')
+                )
+                break
+        if module_name == '':
+            return py_obj_to_str(klass)
+    else:
+        module_name = klass.__module__
+    return "%s.%s" % (module_name, klass.__name__)
+
+
+#==============================================================================
+class SocorroApp(RequiredConfig):
+    """The base class for all Socorro applications"""
+    app_name = 'SocorroAppBaseClass'
+    app_version = "1.0"
+    app_description = 'base class for app system'
+
+    required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        # give a name to this running instance of the program.
+        self.app_instance_name = self._app_instance_name()
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def get_application_defaults():
+        """this method allows an app to inject defaults into the configuration
+        that can override defaults not under the direct control of the app.
+        For example, if an app were to use a class that had a config default
+        of X and that was not appropriate as a default for this app, then
+        this method could be used to override that default"""
+        return {}
+
+    #--------------------------------------------------------------------------
+    def main(self):  # pragma: no cover
+        """derived classes must override this function with business logic"""
+        raise NotImplementedError(
+            "A definition of 'main' in a derived class is required"
+        )
+
+    #--------------------------------------------------------------------------
+    def _app_instance_name(self):
+        # originally, only the processors had instance names.  By putting this
+        # call here, all the apps have instance names that can be used to
+        # tag output that is traceble back to an app/machine/process.
+        return "%s_%s_%d" % (
+            self.app_name,
+            os.uname()[1].replace('.', '_'),
+            os.getpid()
+        )
+
+    #--------------------------------------------------------------------------
+    @classmethod
+    def run(klass, config_path=None, values_source_list=None):
+        global restart
+        restart = True
+        while restart:
+            # the SIGHUP handler will change that back to True if it wants
+            # the app to restart and run again.
+            restart = False
+            app_exit_code = klass._do_run(
+                config_path=config_path,
+                values_source_list=values_source_list
+            )
+        return app_exit_code
+
+    #--------------------------------------------------------------------------
+    @classmethod
+    def _do_run(klass, config_path=None, values_source_list=None):
+        # while this method is defined here, only derived classes are allowed
+        # to call it.
+        if klass is SocorroApp:
+            raise NotImplementedError(
+                "The SocorroApp class has no useable 'main' method"
+            )
+
+        if config_path is None:
+            config_path = os.environ.get(
+                'DEFAULT_SOCORRO_CONFIG_PATH',
+                './config'
+            )
+
+        if values_source_list is None:
+            values_source_list = [
+                # pull in the application defaults from the 'application'
+                # configman option, once it has been defined
+                application_defaults_proxy,
+                # pull in any configuration file
+                ConfigFileFutureProxy,
+                # get values from the environment
+                environment,
+                # use the command line to get the final overriding values
+                command_line
+            ]
+        elif application_defaults_proxy not in values_source_list:
+            values_source_list = (
+                [application_defaults_proxy] + values_source_list
+            )
+
+        config_definition = klass.get_required_config()
+        if 'application' not in config_definition:
+            # the application option has not been defined.  This means that
+            # the we're likely trying to run one of the applications directly
+            # rather than through the SocorroWelocomApp.  Add the 'application'
+            # option initialized with the target application as the default.
+            application_config = Namespace()
+            application_config.add_option(
+                'application',
+                doc=(
+                    'the fully qualified classname of the app to run'
+                ),
+                default=klass_to_pypath(klass),
+                # the following setting means this option will NOT be
+                # commented out when configman generates a config file
+                likely_to_be_changed=True,
+                from_string_converter=(
+                    application_defaults_proxy.str_to_application_class
+                ),
+            )
+            config_definition = application_config
+
+        config_manager = ConfigurationManager(
+            config_definition,
+            app_name=klass.app_name,
+            app_version=klass.app_version,
+            app_description=klass.app_description,
+            values_source_list=values_source_list,
+            options_banned_from_help=[],
+            config_pathname=config_path
+        )
+
+        def fix_exit_code(code):
+            # some apps don't return a code so you might get None
+            # which isn't good enough to send to sys.exit()
+            if code is None:
+                return 0
+            return code
+
+        with config_manager.context() as config:
+            config.executor_identity = (
+                lambda: threading.currentThread().getName()
+            )
+            try:
+                config_manager.log_config(config.logger)
+                respond_to_SIGHUP_with_logging = functools.partial(
+                    respond_to_SIGHUP,
+                    logger=config.logger
+                )
+                # install the signal handler with logging
+                signal.signal(signal.SIGHUP, respond_to_SIGHUP_with_logging)
+            except KeyError:
+                # config apparently doesn't have 'logger'
+                # install the signal handler without logging
+                signal.signal(signal.SIGHUP, respond_to_SIGHUP)
+
+            # we finally know what app to actually run, instantiate it
+            app_to_run = klass(config)
+            app_to_run.config_manager = config_manager
+            # whew, finally run the app that we wanted
+
+            return_code = fix_exit_code(app_to_run.main())
+            return return_code
+
+
+#==============================================================================
+class LoggerWrapper(object):
+    """This class wraps the standard logger object.  It changes the logged
+    messages to display the 'executor_identity': the thread/greenlet/process
+    that is currently running."""
+
+    #--------------------------------------------------------------------------
+    def __init__(self, logger, config):
+        self.config = config
+        self.logger = logger
+
+    #--------------------------------------------------------------------------
+    def executor_identity(self):
+        try:
+            return " - %s - " % self.config.executor_identity()
+        except KeyError:
+            return " - %s - " % threading.currentThread().getName()
+
+    #--------------------------------------------------------------------------
+    def debug(self, message, *args, **kwargs):
+        self.logger.debug(self.executor_identity() + message, *args, **kwargs)
+
+    #--------------------------------------------------------------------------
+    def info(self, message, *args, **kwargs):
+        self.logger.info(self.executor_identity() + message, *args, **kwargs)
+
+    #--------------------------------------------------------------------------
+    def error(self, message, *args, **kwargs):
+        self.logger.error(self.executor_identity() + message, *args, **kwargs)
+
+    #--------------------------------------------------------------------------
+    def warning(self, message, *args, **kwargs):
+        self.logger.warning(
+            self.executor_identity() + message,
+            *args,
+            **kwargs
+        )
+
+    #--------------------------------------------------------------------------
+    def critical(self, message, *args, **kwargs):
+        self.logger.critical(
+            self.executor_identity() + message,
+            *args,
+            **kwargs
+        )
+
+
+#------------------------------------------------------------------------------
+def setup_logger(config, local_unused, args_unused):
+    """This method is sets up and initializes the logger objects.  It is a
+    function in the form appropriate for a configiman aggregation.  When given
+    to Configman, that library will setup and initialize the logging system
+    automatically and then offer the logger as an object within the
+    configuration object."""
+    try:
+        app_name = config.application.app_name
+    except KeyError:
+        app_name = 'a_socorro_app'
+    logger = logging.getLogger(app_name)
+    # if this is a restart, loggers must be removed before being recreated
+    tear_down_logger(app_name)
+    logger.setLevel(logging.DEBUG)
+    stderr_log = logging.StreamHandler()
+    stderr_log.setLevel(config.logging.stderr_error_logging_level)
+    stderr_format = config.logging.stderr_line_format_string.replace(
+        '{app_name}',
+        app_name
+    )
+    stderr_log_formatter = logging.Formatter(
+        _convert_format_string(stderr_format)
+    )
+    stderr_log.setFormatter(stderr_log_formatter)
+    logger.addHandler(stderr_log)
+
+    syslog = logging.handlers.SysLogHandler(
+        facility=config.logging.syslog_facility_string
+    )
+    syslog.setLevel(config.logging.syslog_error_logging_level)
+    syslog_format = config.logging.syslog_line_format_string.replace(
+        '{app_name}',
+        app_name
+    )
+    syslog_formatter = logging.Formatter(
+        _convert_format_string(syslog_format)
+    )
+    syslog.setFormatter(syslog_formatter)
+    logger.addHandler(syslog)
+
+    wrapped_logger = LoggerWrapper(logger, config)
+    return wrapped_logger
+
+
+#==============================================================================
+class App(SocorroApp):
+    """The base class from which Socorro apps are based"""
+    required_config = Namespace()
+    required_config.namespace('logging')
+    required_config.logging.add_option(
+        'syslog_host',
+        doc='syslog hostname',
+        default='localhost',
+        reference_value_from='resource.logging',
+    )
+    required_config.logging.add_option(
+        'syslog_port',
+        doc='syslog port',
+        default=514,
+        reference_value_from='resource.logging',
+    )
+    required_config.logging.add_option(
+        'syslog_facility_string',
+        doc='syslog facility string ("user", "local0", etc)',
+        default='user',
+        reference_value_from='resource.logging',
+    )
+    required_config.logging.add_option(
+        'syslog_line_format_string',
+        doc='python logging system format for syslog entries',
+        default='{app_name} (pid {process}): '
+                '{asctime} {levelname} - {threadName} - '
+                '{message}',
+        reference_value_from='resource.logging',
+    )
+    required_config.logging.add_option(
+        'syslog_error_logging_level',
+        doc='logging level for the log file (10 - DEBUG, 20 '
+            '- INFO, 30 - WARNING, 40 - ERROR, 50 - CRITICAL)',
+        default=40,
+        reference_value_from='resource.logging',
+    )
+    required_config.logging.add_option(
+        'stderr_line_format_string',
+        doc='python logging system format for logging to stderr',
+        default='{asctime} {levelname} - {app_name} - '
+                '{message}',
+        reference_value_from='resource.logging',
+    )
+    required_config.logging.add_option(
+        'stderr_error_logging_level',
+        doc='logging level for the logging to stderr (10 - '
+            'DEBUG, 20 - INFO, 30 - WARNING, 40 - ERROR, '
+            '50 - CRITICAL)',
+        default=10,
+        reference_value_from='resource.logging',
+    )
+
+    required_config.add_aggregation(
+        'logger',
+        setup_logger
+    )
+
+
+#==============================================================================
+class SocorroWelcomeApp(SocorroApp):
+    required_config = Namespace()
+    required_config.add_option(
+        'application',
+        is_argument=True,
+        doc=(
+            'the name of the app to run (select from: %s)' %
+            ', '.join(sorted(application_defaults_proxy.apps.keys()))
+        ),
+        default=None,
+        # the following setting means this option will NOT be
+        # commented out when configman generates a config file
+        likely_to_be_changed=True,
+        from_string_converter=(
+            application_defaults_proxy.str_to_application_class
+        ),
+    )
+    app_name = "SocorroWelcomeApp"
+    app_version = "1.0"
+    app_description = 'Welcome to Socorro'
+
+    #--------------------------------------------------------------------------
+    def main(self):
+        if (
+            self.config.application
+            and self.config.application.__name__ is not self.__class__.__name__
+        ):
+            requested_app = self.config.application(self.config)
+            # this is where an app that was requested through the use of the
+            # config parameter 'application' is actually run
+            #requested_app.config_manager = self.config_manager
+            return requested_app.main()
+        else:
+            print (
+                "Welcome to Socorro.  To configure Socorro, please see "
+                "https://socorro.readthedocs.io/\n"
+                "use --help with this app to see what you can do here"
+            )
+
+
+#------------------------------------------------------------------------------
+def tear_down_logger(app_name):
+    logger = logging.getLogger(app_name)
+    # must have a copy of the handlers list since we cannot modify the original
+    # list while we're deleting items from that list
+    handlers = [x for x in logger.handlers]
+    for x in handlers:
+        logger.removeHandler(x)
+
+
+#------------------------------------------------------------------------------
+def _convert_format_string(s):
+    """return '%(foo)s %(bar)s' if the input is '{foo} {bar}'"""
+    return re.sub('{(\w+)}', r'%(\1)s', s)
+
+
+#------------------------------------------------------------------------------
+def main(app_class, config_path=None, values_source_list=None):
+    return app_class.run(
+        config_path=config_path,
+        values_source_list=values_source_list
+    )
+
+if __name__ == '__main__':
+    main(SocorroWelcomeApp)

--- a/socorro/collector/collector_app.py
+++ b/socorro/collector/collector_app.py
@@ -10,9 +10,9 @@
 # replace the ".../" with something that makes sense for your environment
 # set both socorro and configman in your PYTHONPATH
 
-from socorrolib.app.generic_app import App, main
+from socorro.app.generic_app import App, main
 from socorro.webapi.class_partial import class_with_partial_init
-from socorrolib.lib.converters import web_services_from_str
+from socorro.lib.converters import web_services_from_str
 
 from configman import Namespace
 from configman.converters import class_converter

--- a/socorro/collector/crashmover_app.py
+++ b/socorro/collector/crashmover_app.py
@@ -6,7 +6,7 @@
 
 from configman import Namespace
 
-from socorrolib.app.fetch_transform_save_app import (
+from socorro.app.fetch_transform_save_app import (
     FetchTransformSaveApp,
     FetchTransformSaveWithSeparateNewCrashSourceApp,
     main
@@ -52,7 +52,7 @@ class ProcessedCrashCopierApp(FetchTransformSaveWithSeparateNewCrashSourceApp):
             'destination.crashstorage_class':
                 'socorro.external.fs.crashstorage.TarFileCrashStore',
             'producer_consumer.producer_consumer_class':
-                'socorrolib.lib.task_manager.TaskManager',
+                'socorro.lib.task_manager.TaskManager',
             'producer_consumer.quit_on_empty_queue': True,
             'new_crash_source.new_crash_source_class':
                 'socorro.processor.timemachine.PGQueryNewCrashSource'

--- a/socorro/collector/submitter_app.py
+++ b/socorro/collector/submitter_app.py
@@ -15,7 +15,7 @@ from os import (
 
 from configman import Namespace
 
-from socorrolib.app.fetch_transform_save_app import (
+from socorro.app.fetch_transform_save_app import (
     FetchTransformSaveWithSeparateNewCrashSourceApp,
     main
 )
@@ -24,7 +24,7 @@ from socorro.external.crashstorage_base import (
     FileDumpsMapping,
 )
 from socorro.external.fs.filesystem import findFileGenerator
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 
 #==============================================================================

--- a/socorro/collector/throttler.py
+++ b/socorro/collector/throttler.py
@@ -8,7 +8,7 @@ import random
 
 from configman import Namespace, RequiredConfig
 
-from socorrolib.lib.ver_tools import normalize
+from socorro.lib.ver_tools import normalize
 
 Compiled_Regular_Expression_Type = type(re.compile(''))
 

--- a/socorro/collector/wsgi_breakpad_collector.py
+++ b/socorro/collector/wsgi_breakpad_collector.py
@@ -4,9 +4,9 @@
 
 import time
 
-from socorrolib.lib.ooid import createNewOoid
+from socorro.lib.ooid import createNewOoid
 from socorro.collector.throttler import ACCEPT, DEFER, DISCARD, IGNORE
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.collector.wsgi_generic_collector import GenericCollectorBase
 
 from configman import Namespace, class_converter

--- a/socorro/collector/wsgi_generic_collector.py
+++ b/socorro/collector/wsgi_generic_collector.py
@@ -10,10 +10,10 @@ import cStringIO
 
 from contextlib import closing
 
-from socorrolib.lib.ooid import createNewOoid
-from socorrolib.lib.util import DotDict
+from socorro.lib.ooid import createNewOoid
+from socorro.lib.util import DotDict
 from socorro.collector.throttler import DISCARD, IGNORE
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.external.crashstorage_base import MemoryDumpsMapping
 
 from configman import RequiredConfig, Namespace, class_converter

--- a/socorro/cron/buildutil.py
+++ b/socorro/cron/buildutil.py
@@ -37,7 +37,7 @@ def insert_build(cursor, product_name, version, platform, build_id, build_type,
 
     logger.info("Trying to insert new release: %s" % str(params))
 
-    sql = """/*  socorrolib.lib.buildutil.insert_build */
+    sql = """/*  socorro.lib.buildutil.insert_build */
         SELECT add_new_release(
             %(product)s,
             %(version)s,

--- a/socorro/cron/crontabber_app.py
+++ b/socorro/cron/crontabber_app.py
@@ -51,7 +51,7 @@ DEFAULT_JOBS = '''
 
 # this class is for eventual support of CronTabber with the universal
 # socorro app.
-from socorrolib.app.socorro_app import App as App
+from socorro.app.socorro_app import App as App
 
 
 #==============================================================================

--- a/socorro/cron/dailyUrl.py
+++ b/socorro/cron/dailyUrl.py
@@ -18,7 +18,7 @@ import contextlib
 logger = logging.getLogger("dailyUrlDump")
 
 import socorro.database.database as sdb
-import socorrolib.lib.util as util
+import socorro.lib.util as util
 
 from socorro.database.cachedIdAccess import IdCache
 

--- a/socorro/cron/jobs/bugzilla.py
+++ b/socorro/cron/jobs/bugzilla.py
@@ -11,7 +11,7 @@ from configman import Namespace
 from crontabber.base import BaseCronApp
 from crontabber.mixins import with_postgres_transactions
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.external.postgresql.dbapi2_util import (
     single_row_sql,
     execute_query_fetchall,

--- a/socorro/cron/jobs/daily_url.py
+++ b/socorro/cron/jobs/daily_url.py
@@ -17,7 +17,7 @@ from crontabber.mixins import (
     with_single_postgres_transaction
 )
 from socorro.database.cachedIdAccess import IdCache
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 SQL = """
 select

--- a/socorro/cron/jobs/ftpscraper.py
+++ b/socorro/cron/jobs/ftpscraper.py
@@ -21,8 +21,8 @@ from crontabber.mixins import (
 
 from socorro.cron import buildutil
 
-from socorrolib.app.socorro_app import App, main
-from socorrolib.lib.datetimeutil import string_to_datetime
+from socorro.app.socorro_app import App, main
+from socorro.lib.datetimeutil import string_to_datetime
 
 
 class ScrapersMixin(object):

--- a/socorro/cron/jobs/missingsymbols.py
+++ b/socorro/cron/jobs/missingsymbols.py
@@ -8,7 +8,7 @@ from crontabber.base import BaseCronApp
 from crontabber.mixins import with_postgres_transactions
 
 from socorro.external.postgresql.missing_symbols import MissingSymbols
-from socorrolib.app.socorro_app import App, main
+from socorro.app.socorro_app import App, main
 
 
 @with_postgres_transactions()

--- a/socorro/cron/jobs/reprocessingjobs.py
+++ b/socorro/cron/jobs/reprocessingjobs.py
@@ -13,7 +13,7 @@ from socorro.external.postgresql.dbapi2_util import (
     execute_query_iter,
     execute_no_results,
 )
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 
 @using_postgres()

--- a/socorro/database/database.py
+++ b/socorro/database/database.py
@@ -11,7 +11,7 @@ import functools as ft
 
 db_module = psycopg2
 
-import socorrolib.lib.util as util
+import socorro.lib.util as util
 
 #=================================================================================================================
 class SQLDidNotReturnSingleValue (Exception):
@@ -121,7 +121,7 @@ def transaction_execute_with_retry (database_connection_pool, sql, parameters=No
 class LoggingCursor(psycopg2.extensions.cursor):
   """Use as cursor_factory when getting cursor from connection:
   ...
-  cursor = connection.cursor(cursor_factory = socorrolib.lib.pyscopghelper.LoggingCursor)
+  cursor = connection.cursor(cursor_factory = socorro.lib.pyscopghelper.LoggingCursor)
   cursor.setLogger(someLogger)
   ...
   """

--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -14,8 +14,8 @@ import boto.exception
 from configman import Namespace, RequiredConfig, class_converter
 from configman.converters import str_to_boolean
 
-from socorrolib.lib.converters import change_default
-from socorrolib.lib.ooid import dateFromOoid
+from socorro.lib.converters import change_default
+from socorro.lib.ooid import dateFromOoid
 
 
 class KeyNotFound(Exception):

--- a/socorro/external/boto/crash_data.py
+++ b/socorro/external/boto/crash_data.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from socorrolib.lib import external_common, MissingArgumentError
+from socorro.lib import external_common, MissingArgumentError
 from socorro.external.boto.crashstorage import (
     BotoS3CrashStorage,
     CrashIDNotFound,

--- a/socorro/external/boto/crashstorage.py
+++ b/socorro/external/boto/crashstorage.py
@@ -6,7 +6,7 @@ import json
 import time
 
 import json_schema_reducer
-from socorrolib.lib.converters import change_default
+from socorro.lib.converters import change_default
 
 from configman import Namespace
 from configman.converters import class_converter, py_obj_to_str
@@ -71,7 +71,7 @@ class BotoCrashStorage(CrashStorageBase):
     )
     required_config.add_option(
         'json_object_hook',
-        default='socorrolib.lib.util.DotDict',
+        default='socorro.lib.util.DotDict',
         from_string_converter=class_converter,
     )
 

--- a/socorro/external/crash_data_base.py
+++ b/socorro/external/crash_data_base.py
@@ -5,14 +5,14 @@
 # XXX this is now deprecated and can be deleted.
 # See https://bugzilla.mozilla.org/show_bug.cgi?id=1299465
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     ResourceNotFound,
     ResourceUnavailable,
     ServiceUnavailable
 )
 from socorro.external.crashstorage_base import CrashIDNotFound
-from socorrolib.lib import external_common
+from socorro.lib import external_common
 
 
 class CrashDataBase(object):

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -12,7 +12,7 @@ import os
 import collections
 import datetime
 
-from socorrolib.lib.util import DotDict as SocorroDotDict
+from socorro.lib.util import DotDict as SocorroDotDict
 
 from configman import Namespace, RequiredConfig
 from configman.converters import classes_in_namespaces_converter, \
@@ -21,7 +21,7 @@ from configman.dotdict import DotDict as ConfigmanDotDict
 
 
 def socorrodotdict_to_dict(sdotdict):
-    """Takes a socorrolib.lib.util.DotDict and returns a dict
+    """Takes a socorro.lib.util.DotDict and returns a dict
 
     This does a complete object traversal converting all instances of the
     things named DotDict to dict so it's deep-copyable.

--- a/socorro/external/es/base.py
+++ b/socorro/external/es/base.py
@@ -6,7 +6,7 @@ import datetime
 
 from configman import Namespace, class_converter
 
-from socorrolib.app.generic_app import App
+from socorro.app.generic_app import App
 
 
 class ElasticsearchConfig(App):

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -13,8 +13,8 @@ from configman.converters import class_converter, list_converter
 
 from socorro.external.crashstorage_base import CrashStorageBase
 from socorro.external.es.index_creator import IndexCreator
-from socorrolib.lib.converters import change_default
-from socorrolib.lib.datetimeutil import string_to_datetime
+from socorro.lib.converters import change_default
+from socorro.lib.datetimeutil import string_to_datetime
 from socorro.external.crashstorage_base import Redactor
 
 

--- a/socorro/external/es/index_cleaner.py
+++ b/socorro/external/es/index_cleaner.py
@@ -8,7 +8,7 @@ import re
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 
 
 class IndexCleaner(RequiredConfig):

--- a/socorro/external/es/query.py
+++ b/socorro/external/es/query.py
@@ -7,7 +7,7 @@ import elasticsearch
 import json
 import re
 
-from socorrolib.lib import (
+from socorro.lib import (
     BadArgumentError,
     DatabaseError,
     MissingArgumentError,
@@ -15,7 +15,7 @@ from socorrolib.lib import (
 )
 from socorro.external.es.base import ElasticsearchBase
 from socorro.external.es.supersearch import BAD_INDEX_REGEX
-from socorrolib.lib import datetimeutil, external_common
+from socorro.lib import datetimeutil, external_common
 
 
 class Query(ElasticsearchBase):

--- a/socorro/external/es/super_search_fields.py
+++ b/socorro/external/es/super_search_fields.py
@@ -5,13 +5,13 @@
 import datetime
 import elasticsearch
 
-from socorrolib.lib import (
+from socorro.lib import (
     BadArgumentError,
     MissingArgumentError,
     ResourceNotFound,
 )
 from socorro.external.es.base import ElasticsearchBase
-from socorrolib.lib import datetimeutil, external_common
+from socorro.lib import datetimeutil, external_common
 
 
 ES_CUSTOM_ANALYZERS = {

--- a/socorro/external/es/supersearch.py
+++ b/socorro/external/es/supersearch.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl import A, F, Q, Search
-from socorrolib.lib import (
+from socorro.lib import (
     BadArgumentError,
     MissingArgumentError,
     datetimeutil,

--- a/socorro/external/fetch_app.py
+++ b/socorro/external/fetch_app.py
@@ -3,7 +3,7 @@ import json
 from functools import partial
 
 from configman import Namespace, class_converter
-from socorrolib.app.socorro_app import App, main
+from socorro.app.socorro_app import App, main
 
 
 #==============================================================================

--- a/socorro/external/fs/crashstorage.py
+++ b/socorro/external/fs/crashstorage.py
@@ -23,9 +23,9 @@ from socorro.external.crashstorage_base import (
     FileDumpsMapping,
     MemoryDumpsMapping
 )
-from socorrolib.lib.ooid import dateFromOoid, depthFromOoid
-from socorrolib.lib.datetimeutil import utc_now
-from socorrolib.lib.util import DotDict
+from socorro.lib.ooid import dateFromOoid, depthFromOoid
+from socorro.lib.datetimeutil import utc_now
+from socorro.lib.util import DotDict
 
 
 def dates_to_strings_for_json(obj):

--- a/socorro/external/http/correlations.py
+++ b/socorro/external/http/correlations.py
@@ -13,7 +13,7 @@ from cStringIO import StringIO
 
 import requests
 
-from socorrolib.lib import external_common
+from socorro.lib import external_common
 
 
 class DownloadError(Exception):

--- a/socorro/external/postgresql/adi.py
+++ b/socorro/external/postgresql/adi.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 
-from socorrolib.lib import MissingArgumentError, external_common
+from socorro.lib import MissingArgumentError, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 
 

--- a/socorro/external/postgresql/backfill.py
+++ b/socorro/external/postgresql/backfill.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     external_common,

--- a/socorro/external/postgresql/base.py
+++ b/socorro/external/postgresql/base.py
@@ -9,7 +9,7 @@ import logging
 
 import psycopg2
 
-from socorrolib.lib import DatabaseError
+from socorro.lib import DatabaseError
 
 from socorro.external.postgresql.dbapi2_util import (
     execute_query_fetchall,

--- a/socorro/external/postgresql/bugs.py
+++ b/socorro/external/postgresql/bugs.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     external_common,

--- a/socorro/external/postgresql/correlations.py
+++ b/socorro/external/postgresql/correlations.py
@@ -5,7 +5,7 @@
 import logging
 
 from socorro.external.postgresql.base import PostgreSQLBase
-from socorrolib.lib import datetimeutil, external_common, BadArgumentError
+from socorro.lib import datetimeutil, external_common, BadArgumentError
 
 
 class Correlations(PostgreSQLBase):

--- a/socorro/external/postgresql/crash_migration_app.py
+++ b/socorro/external/postgresql/crash_migration_app.py
@@ -9,7 +9,7 @@ from PostgreSQL to another database.
 By default, it is configured to move crashes from PostgreSQL to Elasticsearch.
 '''
 
-from socorrolib.app.fetch_transform_save_app import main
+from socorro.app.fetch_transform_save_app import main
 from socorro.collector.crashmover_app import RawAndProcessedCopierApp
 from socorro.external.crashstorage_base import CrashIDNotFound
 from socorro.external.postgresql.crashstorage import PostgreSQLCrashStorage

--- a/socorro/external/postgresql/crashes.py
+++ b/socorro/external/postgresql/crashes.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     datetimeutil,
@@ -541,7 +541,7 @@ class Crashes(PostgreSQLBase):
     def get_exploitability(self, **kwargs):
         """Return a list of exploitable crash reports.
 
-        See socorrolib.lib.external_common.parse_arguments() for all filters.
+        See socorro.lib.external_common.parse_arguments() for all filters.
         """
         now = datetimeutil.utc_now().date()
         lastweek = now - datetime.timedelta(weeks=1)

--- a/socorro/external/postgresql/crashstorage.py
+++ b/socorro/external/postgresql/crashstorage.py
@@ -25,7 +25,7 @@ from configman import (
     class_converter
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorrolib.lib.datetimeutil import uuid_to_date, JsonDTEncoder
+from socorro.lib.datetimeutil import uuid_to_date, JsonDTEncoder
 from socorro.external.postgresql.dbapi2_util import (
     SQLDidNotReturnSingleValue,
     single_value_sql,

--- a/socorro/external/postgresql/field.py
+++ b/socorro/external/postgresql/field.py
@@ -5,7 +5,7 @@
 import json
 import logging
 
-from socorrolib.lib import MissingArgumentError, external_common
+from socorro.lib import MissingArgumentError, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 
 

--- a/socorro/external/postgresql/gccrashes.py
+++ b/socorro/external/postgresql/gccrashes.py
@@ -4,7 +4,7 @@
 
 import datetime
 
-from socorrolib.lib import MissingArgumentError, datetimeutil, external_common
+from socorro.lib import MissingArgumentError, datetimeutil, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 
 

--- a/socorro/external/postgresql/graphics_devices.py
+++ b/socorro/external/postgresql/graphics_devices.py
@@ -4,7 +4,7 @@
 
 import psycopg2
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     external_common,

--- a/socorro/external/postgresql/graphics_report.py
+++ b/socorro/external/postgresql/graphics_report.py
@@ -6,7 +6,7 @@ import datetime
 import logging
 
 from socorro.external.postgresql.base import PostgreSQLBase
-from socorrolib.lib import external_common
+from socorro.lib import external_common
 
 
 logger = logging.getLogger("webapi")

--- a/socorro/external/postgresql/missing_symbols.py
+++ b/socorro/external/postgresql/missing_symbols.py
@@ -6,7 +6,7 @@ import datetime
 import logging
 
 from socorro.external.postgresql.base import PostgreSQLBase
-from socorrolib.lib import external_common
+from socorro.lib import external_common
 
 
 logger = logging.getLogger("webapi")

--- a/socorro/external/postgresql/new_crash_source.py
+++ b/socorro/external/postgresql/new_crash_source.py
@@ -6,10 +6,10 @@ from datetime import timedelta
 
 from configman import Namespace, RequiredConfig, class_converter
 
-from socorrolib.lib.converters import (
+from socorro.lib.converters import (
     change_default,
 )
-from socorrolib.lib.datetimeutil import (
+from socorro.lib.datetimeutil import (
     utc_now,
     string_to_datetime,
 )

--- a/socorro/external/postgresql/product_build_types.py
+++ b/socorro/external/postgresql/product_build_types.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from socorrolib.lib import MissingArgumentError, external_common
+from socorro.lib import MissingArgumentError, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 
 

--- a/socorro/external/postgresql/products.py
+++ b/socorro/external/postgresql/products.py
@@ -9,9 +9,9 @@ import itertools
 
 import psycopg2
 
-from socorrolib.lib.datetimeutil import string_to_datetime
+from socorro.lib.datetimeutil import string_to_datetime
 from socorro.external.postgresql.base import add_param_to_dict, PostgreSQLBase
-from socorrolib.lib import datetimeutil, external_common
+from socorro.lib import datetimeutil, external_common
 from .dbapi2_util import single_row_sql
 
 

--- a/socorro/external/postgresql/releases.py
+++ b/socorro/external/postgresql/releases.py
@@ -5,7 +5,7 @@
 import logging
 import psycopg2
 
-from socorrolib.lib import (
+from socorro.lib import (
     DatabaseError,
     MissingArgumentError,
     external_common,

--- a/socorro/external/postgresql/report.py
+++ b/socorro/external/postgresql/report.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     datetimeutil,

--- a/socorro/external/postgresql/service_base.py
+++ b/socorro/external/postgresql/service_base.py
@@ -12,7 +12,7 @@ from .dbapi2_util import (
     execute_no_results,
     single_value_sql,
 )
-from socorrolib.lib import DatabaseError
+from socorro.lib import DatabaseError
 from socorro.webapi.webapiService import DataserviceWebServiceBase
 
 

--- a/socorro/external/postgresql/setupdb_app.py
+++ b/socorro/external/postgresql/setupdb_app.py
@@ -25,7 +25,7 @@ from sqlalchemy import create_engine, exc
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.schema import CreateTable
 
-from socorrolib.app.socorro_app import App, main
+from socorro.app.socorro_app import App, main
 from socorro.external.postgresql import staticdata, fakedata
 from socorro.external.postgresql.connection_context import (
     get_field_from_pg_database_url

--- a/socorro/external/postgresql/signature_first_date.py
+++ b/socorro/external/postgresql/signature_first_date.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from socorrolib.lib import MissingArgumentError, external_common
+from socorro.lib import MissingArgumentError, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 
 

--- a/socorro/external/postgresql/signature_summary.py
+++ b/socorro/external/postgresql/signature_summary.py
@@ -5,7 +5,7 @@
 import datetime
 import logging
 
-from socorrolib.lib import BadArgumentError, external_common
+from socorro.lib import BadArgumentError, external_common
 from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.external.postgresql.util import Util
 

--- a/socorro/external/postgresql/signature_urls.py
+++ b/socorro/external/postgresql/signature_urls.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     external_common,

--- a/socorro/external/postgresql/tcbs.py
+++ b/socorro/external/postgresql/tcbs.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger("webapi")
 
 import socorro.database.database as db
-from socorrolib.lib import BadArgumentError, datetimeutil, util, sqlutils
+from socorro.lib import BadArgumentError, datetimeutil, util, sqlutils
 
 import datetime
 

--- a/socorro/external/postgresql/util.py
+++ b/socorro/external/postgresql/util.py
@@ -6,7 +6,7 @@ import logging
 
 from socorro.external.postgresql.base import PostgreSQLBase
 
-import socorrolib.lib.external_common as external_common
+import socorro.lib.external_common as external_common
 
 logger = logging.getLogger("webapi")
 

--- a/socorro/external/rabbitmq/crashstorage.py
+++ b/socorro/external/rabbitmq/crashstorage.py
@@ -15,7 +15,7 @@ from configman import (
     class_converter
 )
 from configman.dotdict import DotDict
-from socorrolib.lib.converters import change_default
+from socorro.lib.converters import change_default
 from socorro.external.rabbitmq.connection_context import (
     ConnectionContext,
     ConnectionContextPooled,

--- a/socorro/external/rabbitmq/priorityjobs.py
+++ b/socorro/external/rabbitmq/priorityjobs.py
@@ -7,7 +7,7 @@
 import pika
 from pika.exceptions import ChannelClosed
 
-from socorrolib.lib import MissingArgumentError, external_common
+from socorro.lib import MissingArgumentError, external_common
 
 
 class Priorityjobs(object):

--- a/socorro/external/rabbitmq/purge_queue_app.py
+++ b/socorro/external/rabbitmq/purge_queue_app.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from configman import Namespace, class_converter
-from socorrolib.app.socorro_app import App
+from socorro.app.socorro_app import App
 FAIL = 1
 SUCCESS = 0
 

--- a/socorro/external/rabbitmq/reprocess_crashlist.py
+++ b/socorro/external/rabbitmq/reprocess_crashlist.py
@@ -6,7 +6,7 @@ import pika
 import logging
 
 from configman import Namespace
-from socorrolib.app.generic_app import App, main  # main not used here, but
+from socorro.app.generic_app import App, main  # main not used here, but
 
 
 # To run this script in production:

--- a/socorro/external/statsd/statsd_rule_benchmark.py
+++ b/socorro/external/statsd/statsd_rule_benchmark.py
@@ -47,8 +47,8 @@ from socorro.external.statsd.statsd_base import (
 ##    statsd_prefix=processor
 ##    active_list=act  # <-- very important
 
-from socorrolib.lib.transform_rules import Rule
-from socorrolib.lib.converters import change_default
+from socorro.lib.transform_rules import Rule
+from socorro.lib.converters import change_default
 
 from configman import Namespace, class_converter
 

--- a/socorro/lib/__init__.py
+++ b/socorro/lib/__init__.py
@@ -1,0 +1,68 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""common library code for socorro modules"""
+
+
+class InsertionError(Exception):
+    """When an insertion into a storage system failed. """
+    pass
+
+
+class DatabaseError(Exception):
+    """When querying a storage system failed. """
+    pass
+
+
+class MissingArgumentError(Exception):
+    """When a mandatory argument is missing or empty. """
+    def __init__(self, arg):
+        self.arg = arg
+
+    def __str__(self):
+        try:
+            msg = "Mandatory parameter(s) '%s' is missing or empty." \
+                % self.arg
+            return msg
+        except Exception:
+            pass
+
+
+class BadArgumentError(Exception):
+    """When a mandatory argument has a bad value. """
+    def __init__(self, param, received=None, expected=None, msg=None):
+        self.param = param
+        self.msg = msg
+        self.received = received
+        self.expected = expected
+
+    def __str__(self):
+        if self.msg is not None:
+            return self.msg
+
+        try:
+            msg = "Bad value for parameter(s) '%s'" % self.param
+            if self.received is not None:
+                msg = msg + " got '%s'" % self.received
+            if self.expected is not None:
+                msg = msg + " expected '%s'" % self.expected
+            return msg
+        except Exception:
+            pass
+
+
+class ResourceNotFound(Exception):
+    """When a resource could not be found in a storage system. """
+    pass
+
+
+class ResourceUnavailable(Exception):
+    """When a resource could not be found in a storage system because it is
+    not ready yet (but could be accessible later). """
+    pass
+
+
+class ServiceUnavailable(Exception):
+    """When a service is requested but cannot be found"""
+    pass

--- a/socorro/lib/buildtype.py
+++ b/socorro/lib/buildtype.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from sqlalchemy import types
+
+
+class BuildTypeType(types.UserDefinedType):
+    name = 'build_type'
+
+    def get_col_spec(self):
+        return 'build_type'
+
+    def bind_processor(self, dialect):
+        return lambda value: value
+
+    def result_processor(self, dialect, coltype):
+        return lambda value: value
+
+    def __repr__(self):
+        return 'build_type'
+
+class BuildTypeEnumType(types.UserDefinedType):
+    name = 'build_type_enum'
+
+    def get_col_spec(self):
+        return 'build_type_enum'
+
+    def bind_processor(self, dialect):
+        return lambda value: value
+
+    def result_processor(self, dialect, coltype):
+        return lambda value: value
+
+    def __repr__(self):
+        return 'build_type_enum'

--- a/socorro/lib/citexttype.py
+++ b/socorro/lib/citexttype.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from sqlalchemy import types
+
+
+class CitextType(types.UserDefinedType):
+    name = 'citext'
+
+    def get_col_spec(self):
+        return 'CITEXT'
+
+    def bind_processor(self, dialect):
+        return lambda value: value
+
+    def result_processor(self, dialect, coltype):
+        return lambda value: value
+
+    def __repr__(self):
+        return "citext"

--- a/socorro/lib/context_tools.py
+++ b/socorro/lib/context_tools.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+from contextlib import contextmanager
+from socorro.lib.util import FakeLogger
+
+
+#--------------------------------------------------------------------------
+@contextmanager
+def temp_file_context(raw_dump_path, logger=None):
+    """this contextmanager implements conditionally deleting a pathname
+    at the end of a context if the pathname indicates that it is a temp
+    file by having the word 'TEMPORARY' embedded in it."""
+    try:
+        yield raw_dump_path
+    finally:
+        if 'TEMPORARY' in raw_dump_path:
+            try:
+                os.unlink(raw_dump_path)
+            except OSError:
+                if logger is None:
+                    logger = FakeLogger()
+                logger.warning(
+                    'unable to delete %s. manual deletion is required.',
+                    raw_dump_path,
+                    exc_info=True
+                )

--- a/socorro/lib/converters.py
+++ b/socorro/lib/converters.py
@@ -1,0 +1,218 @@
+import ujson
+
+from configman import RequiredConfig, Namespace, class_converter
+
+
+#------------------------------------------------------------------------------
+def _default_list_splitter(class_list_str):
+    return [x.strip() for x in class_list_str.split(',') if x.strip()]
+
+
+#------------------------------------------------------------------------------
+def _default_class_extractor(list_element):
+    return list_element
+
+
+#------------------------------------------------------------------------------
+def str_to_classes_in_namespaces_converter(
+        template_for_namespace="%(name)s",
+        list_splitter_fn=_default_list_splitter,
+        class_extractor=_default_class_extractor,
+        name_of_class_option='qualified_class_name',
+        instantiate_classes=False,
+):
+    """
+    parameters:
+        template_for_namespace - a template for the names of the namespaces
+                                 that will contain the classes and their
+                                 associated required config options.  There are
+                                 two template variables available: %(name)s -
+                                 the name of the class to be contained in the
+                                 namespace; %(index)d - the sequential index
+                                 number of the namespace.
+        list_converter - a function that will take the string list of classes
+                         and break it up into a sequence if individual elements
+        class_extractor - a function that will return the string version of
+                          a classname from the result of the list_converter
+    """
+
+    # -------------------------------------------------------------------------
+    def class_list_converter(class_list_str):
+        """This function becomes the actual converter used by configman to
+        take a string and convert it into the nested sequence of Namespaces,
+        one for each class in the list.  It does this by creating a proxy
+        class stuffed with its own 'required_config' that's dynamically
+        generated."""
+        if isinstance(class_list_str, basestring):
+            class_str_list = list_splitter_fn(class_list_str)
+        else:
+            raise TypeError('must be derivative of a basestring')
+
+        # =====================================================================
+        class InnerClassList(RequiredConfig):
+            """This nested class is a proxy list for the classes.  It collects
+            all the config requirements for the listed classes and places them
+            each into their own Namespace.
+            """
+            # we're dynamically creating a class here.  The following block of
+            # code is actually adding class level attributes to this new class
+
+            # 1st requirement for configman
+            required_config = Namespace()
+
+            # to help the programmer know what Namespaces we added
+            subordinate_namespace_names = []
+
+            # save the template for future reference
+            namespace_template = template_for_namespace
+
+            # for display
+            original_input = class_list_str.replace('\n', '\\n')
+
+            # for each class in the class list
+            class_list = []
+            for namespace_index, class_list_element in enumerate(
+                class_str_list
+            ):
+                a_class = class_converter(
+                    class_extractor(class_list_element)
+                )
+
+                # figure out the Namespace name
+                namespace_name_dict = {
+                    'name': a_class.__name__,
+                    'index': namespace_index
+                }
+                namespace_name = template_for_namespace % namespace_name_dict
+                class_list.append((a_class.__name__, a_class, namespace_name))
+                subordinate_namespace_names.append(namespace_name)
+                # create the new Namespace
+                required_config.namespace(namespace_name)
+                a_class_namespace = required_config[namespace_name]
+                a_class_namespace.add_option(
+                    name_of_class_option,
+                    doc='fully qualified classname',
+                    default=class_list_element,
+                    from_string_converter=class_converter,
+                    likely_to_be_changed=True,
+                )
+
+            @classmethod
+            def to_str(cls):
+                """this method takes this inner class object and turns it back
+                into the original string of classnames.  This is used
+                primarily as for the output of the 'help' option"""
+                return "'%s'" % cls.original_input
+
+        return InnerClassList  # result of class_list_converter
+
+    return class_list_converter  # result of classes_in_namespaces_converter
+
+
+#------------------------------------------------------------------------------
+def web_services_from_str(
+    list_splitter_fn=ujson.loads,
+):
+    """
+    parameters:
+        list_splitter_fn - a function that will take the json compatible string
+            rerpesenting a list of mappings.
+    """
+
+    # -------------------------------------------------------------------------
+    def class_list_converter(collector_services_str):
+        """This function becomes the actual converter used by configman to
+        take a string and convert it into the nested sequence of Namespaces,
+        one for each class in the list.  It does this by creating a proxy
+        class stuffed with its own 'required_config' that's dynamically
+        generated."""
+        if isinstance(collector_services_str, basestring):
+            all_collector_services = list_splitter_fn(collector_services_str)
+        else:
+            raise TypeError('must be derivative of a basestring')
+
+        # =====================================================================
+        class InnerClassList(RequiredConfig):
+            """This nested class is a proxy list for the classes.  It collects
+            all the config requirements for the listed classes and places them
+            each into their own Namespace.
+            """
+            # we're dynamically creating a class here.  The following block of
+            # code is actually adding class level attributes to this new class
+
+            # 1st requirement for configman
+            required_config = Namespace()
+
+            # to help the programmer know what Namespaces we added
+            subordinate_namespace_names = []
+
+            # for display
+            original_input = collector_services_str.replace('\n', '\\n')
+
+            # for each class in the class list
+            service_list = []
+            for namespace_index, collector_service_element in enumerate(
+                all_collector_services
+            ):
+                service_name = collector_service_element['name']
+                service_uri = collector_service_element['uri']
+                service_implementation_class = class_converter(
+                    collector_service_element['service_implementation_class']
+                )
+
+                service_list.append(
+                    (
+                        service_name,
+                        service_uri,
+                        service_implementation_class,
+                    )
+                )
+                subordinate_namespace_names.append(service_name)
+                # create the new Namespace
+                required_config.namespace(service_name)
+                a_class_namespace = required_config[service_name]
+                a_class_namespace.add_option(
+                    "service_implementation_class",
+                    doc='fully qualified classname for a class that implements'
+                        'the action associtated with the URI',
+                    default=service_implementation_class,
+                    from_string_converter=class_converter,
+                    likely_to_be_changed=True,
+                )
+                a_class_namespace.add_option(
+                    "uri",
+                    doc='uri for this service',
+                    default=service_uri,
+                    likely_to_be_changed=True,
+                )
+
+            @classmethod
+            def to_str(cls):
+                """this method takes this inner class object and turns it back
+                into the original string of classnames.  This is used
+                primarily as for the output of the 'help' option"""
+                return "'%s'" % cls.original_input
+
+        return InnerClassList  # result of class_list_converter
+
+    return class_list_converter  # result of classes_in_namespaces_converter
+
+
+#------------------------------------------------------------------------------
+def change_default(
+    kls,
+    key,
+    new_default,
+    new_converter=None,
+    new_reference_value=None,
+):
+    """return a new configman Option object that is a copy of an existing one,
+    giving the new one a different default value"""
+    an_option = kls.get_required_config()[key].copy()
+    an_option.default = new_default
+    if new_converter:
+        an_option.from_string_converter = new_converter
+    if new_reference_value:
+        an_option.reference_value_from = new_reference_value
+    return an_option
+

--- a/socorro/lib/datetimeutil.py
+++ b/socorro/lib/datetimeutil.py
@@ -1,0 +1,171 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+import datetime
+import isodate  # 3rd party
+import json
+
+UTC = isodate.UTC
+
+
+def datetimeFromISOdateString(s):
+    """Take an ISO date string of the form YYYY-MM-DDTHH:MM:SS.S
+    and convert it into an instance of datetime.datetime
+    """
+    return string_to_datetime(s)
+
+
+def strHoursToTimeDelta(hoursAsString):
+    return datetime.timedelta(hours=int(hoursAsString))
+
+
+def utc_now():
+    """Return a timezone aware datetime instance in UTC timezone
+
+    This funciton is mainly for convenience. Compare:
+
+        >>> from datetimeutil import utc_now
+        >>> utc_now()
+        datetime.datetime(2012, 1, 5, 16, 42, 13, 639834,
+          tzinfo=<isodate.tzinfo.Utc object at 0x101475210>)
+
+    Versus:
+
+        >>> import datetime
+        >>> from datetimeutil import UTC
+        >>> datetime.datetime.now(UTC)
+        datetime.datetime(2012, 1, 5, 16, 42, 13, 639834,
+          tzinfo=<isodate.tzinfo.Utc object at 0x101475210>)
+
+    """
+    return datetime.datetime.now(UTC)
+
+
+def string_to_datetime(date):
+    """Return a datetime.datetime instance with tzinfo.
+    I.e. a timezone aware datetime instance.
+
+    Acceptable formats for input are:
+
+        * 2012-01-10T12:13:14
+        * 2012-01-10T12:13:14.98765
+        * 2012-01-10T12:13:14.98765+03:00
+        * 2012-01-10T12:13:14.98765Z
+        * 2012-01-10 12:13:14
+        * 2012-01-10 12:13:14.98765
+        * 2012-01-10 12:13:14.98765+03:00
+        * 2012-01-10 12:13:14.98765Z
+
+    But also, some more odd ones (probably because of legacy):
+
+        * 2012-01-10
+        * ['2012-01-10', '12:13:14']
+
+    """
+    if date is None:
+        return None
+    if isinstance(date, datetime.datetime):
+        if not date.tzinfo:
+            date = date.replace(tzinfo=UTC)
+        return date
+    if isinstance(date, list):
+        date = 'T'.join(date)
+    if isinstance(date, basestring):
+        if len(date) <= len('2000-01-01'):
+            return (datetime.datetime
+                    .strptime(date, '%Y-%m-%d')
+                    .replace(tzinfo=UTC))
+        else:
+            try:
+                parsed = isodate.parse_datetime(date)
+            except ValueError:
+                # e.g. '2012-01-10 12:13:14Z' becomes '2012-01-10T12:13:14Z'
+                parsed = isodate.parse_datetime(
+                    re.sub('(\d)\s(\d)', r'\1T\2', date)
+                )
+            if not parsed.tzinfo:
+                parsed = parsed.replace(tzinfo=UTC)
+            return parsed
+    raise ValueError("date not a parsable string")
+
+
+def date_to_string(date):
+    """Transform a date or datetime object into a string and return it.
+
+    Examples:
+    >>> date_to_string(datetime.datetime(2012, 1, 3, 12, 23, 34, tzinfo=UTC))
+    '2012-01-03T12:23:34+00:00'
+    >>> date_to_string(datetime.datetime(2012, 1, 3, 12, 23, 34))
+    '2012-01-03T12:23:34'
+    >>> date_to_string(datetime.date(2012, 1, 3))
+    '2012-01-03'
+
+    """
+    if isinstance(date, datetime.datetime):
+        # Create an ISO 8601 datetime string
+        date_str = date.strftime('%Y-%m-%dT%H:%M:%S')
+        tzstr = date.strftime('%z')
+        if tzstr:
+            # Yes, this is ugly. And no, I haven't found a better way to have a
+            # truly ISO 8601 datetime with timezone in Python.
+            date_str = '%s%s:%s' % (date_str, tzstr[0:3], tzstr[3:5])
+    elif isinstance(date, datetime.date):
+        # Create an ISO 8601 date string
+        date_str = date.strftime('%Y-%m-%d')
+    else:
+        raise TypeError('Argument is not a date or datetime. ')
+
+    return date_str
+
+
+def uuid_to_date(uuid, century='20'):
+    """Return a date created from the last 6 digits of a uuid.
+
+    Arguments:
+        uuid The unique identifier to parse.
+        century The first 2 digits to assume in the year. Default is '20'.
+
+    Examples:
+        >>> uuid_to_date('e8820616-1462-49b6-9784-e99a32120201')
+        datetime.date(2012, 2, 1)
+
+        >>> uuid_to_date('e8820616-1462-49b6-9784-e99a32120201', '18')
+        datetime.date(1812, 2, 1)
+
+    """
+    day = int(uuid[-2:])
+    month = int(uuid[-4:-2])
+    year = int('%s%s' % (century, uuid[-6:-4]))
+
+    return datetime.date(year=year, month=month, day=day)
+
+
+class JsonDTEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.strftime("%Y-%m-%d %H:%M:%S.%f")
+        return json.JSONEncoder.default(self, obj)
+
+
+def datestring_to_weekly_partition(date_str):
+    """Return a string representing a weekly partition from a date.
+
+    Our partitions start on Mondays.
+
+    Example:
+        date = '2015-01-09'
+        weekly_partition = '2014-01-05'
+    """
+
+    if isinstance(date_str, datetime.datetime):
+        d = date_str
+    elif date_str == 'now':
+        d = datetime.datetime.now().date()
+    else:
+        d = datetime.datetime.strptime(date_str, '%Y-%m-%d').date()
+
+    last_monday = d + datetime.timedelta(0 - d.weekday())
+
+    return last_monday.strftime('%Y%m%d')

--- a/socorro/lib/external_common.py
+++ b/socorro/lib/external_common.py
@@ -1,0 +1,186 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Common functions for external modules.
+"""
+
+import json
+import datetime
+
+from socorro.lib import BadArgumentError
+from socorro.lib.util import DotDict
+import socorro.lib.datetimeutil as dtutil
+
+
+def parse_arguments(filters, arguments, modern=False):
+    """
+    Return a dict of parameters.
+    Take a list of filters and for each try to get the corresponding
+    value in arguments or a default value. Then check that value's type.
+    The @modern parameter indicates how the arguments should be
+    interpreted. The old way is that you always specify a list and in
+    the list you write the names of types as strings. I.e. instad of
+    `str` you write `'str'`.
+    The modern way allows you to specify arguments by real Python types
+    and entering it as a list means you accept and expect it to be a list.
+    For example, using the modern way:
+        filters = [
+            ("param1", "default", [str]),
+            ("param2", None, int),
+            ("param3", ["list", "of", 4, "values"], [str])
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345
+        }
+        =>
+        {
+            "param1": ["value1"],
+            "param2": 0,
+            "param3": ["list", "of", "4", "values"]
+        }
+    And an example for the old way:
+        filters = [
+            ("param1", "default", ["list", "str"]),
+            ("param2", None, "int"),
+            ("param3", ["list", "of", 4, "values"], ["list", "str"])
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345
+        }
+        =>
+        {
+            "param1": ["value1"],
+            "param2": 0,
+            "param3": ["list", "of", "4", "values"]
+        }
+    The reason for having the modern and the non-modern way is
+    transition of legacy code. One day it will all be the modern way.
+    """
+    params = DotDict()
+
+    for i in filters:
+        count = len(i)
+        param = None
+
+        if count <= 1:
+            param = arguments.get(i[0])
+        else:
+            param = arguments.get(i[0], i[1])
+
+        # proceed and do the type checking
+        if count >= 3:
+            types = i[2]
+
+            if modern:
+                if isinstance(types, list) and param is not None:
+                    assert len(types) == 1
+                    if not isinstance(param, list):
+                        param = [param]
+                    param = [check_type(x, types[0]) for x in param]
+                else:
+                    param = check_type(param, types)
+            else:
+                if not isinstance(types, list):
+                    types = [types]
+
+                for t in reversed(types):
+                    if t == "list" and not isinstance(param, list):
+                        if param is None or param == '':
+                            param = []
+                        else:
+                            param = [param]
+                    elif t == "list" and isinstance(param, list):
+                        continue
+                    elif isinstance(param, list) and "list" not in types:
+                        param = " ".join(param)
+                        param = check_type(param, t)
+                    elif isinstance(param, list):
+                        param = [check_type(x, t) for x in param]
+                    else:
+                        param = check_type(param, t)
+
+        params[i[0]] = param
+    return params
+
+
+def check_type(param, datatype):
+    """
+    Make sure that param is of type datatype and return it.
+    If param is None, return it.
+    If param is an instance of datatype, return it.
+    If param is not an instance of datatype and is not None, cast it as
+    datatype and return it.
+    """
+    if param is None:
+        return param
+
+    if getattr(datatype, 'clean', None) and callable(datatype.clean):
+        try:
+            return datatype.clean(param)
+        except ValueError:
+            raise BadArgumentError(param)
+
+    elif isinstance(datatype, str):
+        # You've given it something like `'bool'` as a string.
+        # This is the legacy way of doing it.
+        datatype = {
+            'str': str,
+            'bool': bool,
+            'float': float,
+            'date': datetime.date,
+            'datetime': datetime.datetime,
+            'timedelta': datetime.timedelta,
+            'json': 'json',  # exception
+            'int': int,
+        }[datatype]
+
+    if datatype is str and not isinstance(param, basestring):
+        try:
+            param = str(param)
+        except ValueError:
+            param = str()
+
+    elif datatype is int and not isinstance(param, int):
+        try:
+            param = int(param)
+        except ValueError:
+            param = int()
+
+    elif datatype is bool and not isinstance(param, bool):
+        param = str(param).lower() in ("true", "t", "1", "y", "yes")
+
+    elif (
+        datatype is datetime.datetime and
+        not isinstance(param, datetime.datetime)
+    ):
+        try:
+            param = dtutil.string_to_datetime(param)
+        except ValueError:
+            param = None
+
+    elif datatype is datetime.date and not isinstance(param, datetime.date):
+        try:
+            param = dtutil.string_to_datetime(param).date()
+        except ValueError:
+            param = None
+
+    elif (
+        datatype is datetime.timedelta and
+        not isinstance(param, datetime.timedelta)
+    ):
+        try:
+            param = dtutil.strHoursToTimeDelta(param)
+        except ValueError:
+            param = None
+
+    elif datatype == "json" and isinstance(param, basestring):
+        try:
+            param = json.loads(param)
+        except ValueError:
+            param = None
+
+    return param

--- a/socorro/lib/httpclient.py
+++ b/socorro/lib/httpclient.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import httplib
+
+
+class HttpClient(object):
+    """Class for doing HTTP requests to any server. Encapsulate python's httplib.
+    """
+
+    def __init__(self, host, port, timeout=None):
+        """Set the host, port and optional timeout for all HTTP requests ran by
+        this client.
+        """
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def __enter__(self):
+        self.conn = httplib.HTTPConnection(self.host, self.port,
+                                           timeout=self.timeout)
+
+    def __exit__(self, type, value, traceback):
+        self.conn.close()
+
+    def _process_response(self):
+        """Return a JSON result after an HTTP Request.
+
+        Process the response of an HTTP Request and make it a JSON error if
+        it failed. Otherwise return the response's content.
+
+        """
+        response = self.conn.getresponse()
+        if response.status == 200 or response.status == 201:
+            data = response.read()
+        else:
+            data = {
+                "error":  {
+                    "code": response.status,
+                    "reason": response.reason,
+                    "data": response.read()
+                }
+            }
+
+        return data
+
+    def get(self, url):
+        """Send a HTTP GET request to a URL and return the result.
+        """
+        self.conn.request("GET", url)
+        return self._process_response()
+
+    def post(self, url, data):
+        """Send a HTTP POST request to a URL and return the result.
+        """
+        headers = {
+            "Content-type": "application/x-www-form-urlencoded",
+            "Accept": "text/json"
+        }
+        self.conn.request("POST", url, data, headers)
+        return self._process_response()
+
+    def put(self, url, data=None):
+        """Send a HTTP PUT request to a URL and return the result.
+        """
+        self.conn.request("PUT", url, data)
+        return self._process_response()
+
+    def delete(self, url):
+        """Send a HTTP DELETE request to a URL and return the result.
+        """
+        self.conn.request("DELETE", url)
+        return self._process_response()

--- a/socorro/lib/jsontype.py
+++ b/socorro/lib/jsontype.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from sqlalchemy import types
+
+
+class JsonType(types.UserDefinedType):
+    name = 'json'
+
+    def get_col_spec(self):
+        return 'JSON'
+
+    def bind_processor(self, dialect):
+        return lambda value: value
+
+    def result_processor(self, dialect, coltype):
+        return lambda value: value
+
+    def __repr__(self):
+        return "json"

--- a/socorro/lib/migrations.py
+++ b/socorro/lib/migrations.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+migrations.py
+Utility functions that work with Alembic
+Includes classes that define custom types we use that aren't
+defined in SQLAlchemy yet.
+"""
+
+import os
+import warnings
+
+
+def get_local_filepath(filename):
+    """
+    Helper for finding our raw SQL files locally.
+
+    Expects files to be in:
+        $SOCORRO_PATH/socorro/external/postgresql/raw_sql/procs/
+    """
+    procs_dir = os.path.normpath(os.path.join(
+        __file__,
+        '../../',
+        'external/postgresql/raw_sql/procs'
+    ))
+    return os.path.join(procs_dir, filename)
+
+
+def load_stored_proc(op, filelist):
+    """
+    Takes the alembic op object as arguments and a list of files as arguments
+    Load and run CREATE OR REPLACE function commands from files
+    """
+    for filename in filelist:
+        sqlfile = get_local_filepath(filename)
+        # Capturing "file not exists" here rather than allowing
+        # an exception to be thrown. Some of the rollback scripts
+        # would otherwise throw unhelpful exceptions when a SQL
+        # file is removed from the repo.
+        if not os.path.isfile(sqlfile):
+            warnings.warn(
+                "Did not find %r. Continuing migration." % sqlfile,
+                UserWarning,
+                2
+            )
+            continue
+        with open(sqlfile, 'r') as stored_proc:
+            op.execute(stored_proc.read())
+
+
+def fix_permissions(op, tablename):
+    """
+    Takes a table name and an alembic op object as arguments
+    Updates table permissions to make the table owned by breakpad_rw
+    """
+    op.execute("ALTER TABLE %s OWNER TO breakpad_rw" % tablename)

--- a/socorro/lib/ooid.py
+++ b/socorro/lib/ooid.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# OOID is "Our opaque ID"
+import datetime as dt
+import uuid as uu
+
+from socorro.lib.datetimeutil import utc_now, UTC
+
+defaultDepth = 2
+oldHardDepth = 4
+
+def createNewOoid(timestamp=None, depth=None):
+  """Create a new Ooid for a given time, to be stored at a given depth
+  timestamp: the year-month-day is encoded in the ooid. If none, use current day
+  depth: the expected storage depth is encoded in the ooid. If non, use the defaultDepth
+  returns a new opaque id string holding 24 random hex digits and encoded date and depth info
+  """
+  if not timestamp:
+    timestamp = utc_now().date()
+  if not depth:
+    depth = defaultDepth
+  assert depth <= 4 and depth >=1
+  uuid = str(uu.uuid4())
+  return "%s%d%02d%02d%02d" %(uuid[:-7],depth,timestamp.year%100,timestamp.month,timestamp.day)
+
+def uuidToOoid(uuid,timestamp=None, depth= None):
+  """ Create an ooid from a 32-hex-digit string in regular uuid format.
+  uuid: must be uuid in expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxx7777777
+  timestamp: the year-month-day is encoded in the ooid. If none, use current day
+  depth: the expected storage depth is encoded in the ooid. If non, use the defaultDepth
+  returns a new opaque id string holding the first 24 digits of the provided uuid and encoded date and depth info
+  """
+  if not timestamp:
+    timestamp = utc_now().date()
+  if not depth:
+    depth = defaultDepth
+  assert depth <= 4 and depth >=1
+  return "%s%d%02d%02d%02d" %(uuid[:-7],depth,timestamp.year%100,timestamp.month,timestamp.day)
+
+def dateAndDepthFromOoid(ooid):
+  """ Extract the encoded date and expected storage depth from an ooid.
+  ooid: The ooid from which to extract the info
+  returns (datetime(yyyy,mm,dd),depth) if the ooid is in expected format else (None,None)
+  """
+  year = month = day = None
+  try:
+    day = int(ooid[-2:])
+  except:
+    return None,None
+  try:
+    month = int(ooid[-4:-2])
+  except:
+    return None,None
+  try:
+    year = 2000 + int(ooid[-6:-4])
+    depth = int(ooid[-7])
+    if not depth: depth = oldHardDepth
+    return (dt.datetime(year,month,day,tzinfo=UTC),depth)
+  except:
+    return None,None
+  return None,None
+
+def depthFromOoid(ooid):
+  """Extract the encoded expected storage depth from an ooid.
+  ooid: The ooid from which to extract the info
+  returns expected depth if the ooid is in expected format else None
+  """
+  return dateAndDepthFromOoid(ooid)[1]
+
+def dateFromOoid(ooid):
+  """Extract the encoded date from an ooid.
+  ooid: The ooid from which to extract the info
+  returns encoded date if the ooid is in expected format else None
+  """
+  return dateAndDepthFromOoid(ooid)[0]
+
+

--- a/socorro/lib/prioritize.py
+++ b/socorro/lib/prioritize.py
@@ -1,0 +1,158 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class Node(object):
+  """
+  Node is a generic node in a directed graph. It contains an item, a set of parents and a list of children
+  It is not possible to have the same parent or child more than once (no duplicate edges). It is possible to
+  have a parent whose child is also its parent, or longer cycles. If you do that, its your own problem.
+  """
+  def __init__(self,item=None):
+    """You may create an empty Node or a Node that already has an item"""
+    self.item = item
+    self.children = []
+    self.parents = set()
+
+  def addChild(self,item):
+    """
+    When you add a child to a Node, you are adding yourself as a parent to the child
+    You cannot have the same node as a child more than once.
+    If you add a Node, it is used. If you add a non-node, a new child Node is created. Thus: You cannot
+    add a child as an item which is a Node. (You can, however, construct such a node, and add it as a child)
+    """
+    if not isinstance(item,Node):
+      item = Node(item)
+    if item in self.children:
+      return item
+    self.children.append(item)
+    item.parents.add(self)
+    return item
+
+  def addParent(self,item):
+    """
+    When you add a parent to a Node, you are adding yourself as a child to the parent.
+    You cannot have the same node as a parent more than once.
+    If you add a Node, it is used. If you add a non-node, a new parent Node is created. Thus: You cannot
+    add a parent as an item which is a Node. (You can, however, construct such a node, and add it as a parent)
+    """
+    if not isinstance(item,Node):
+      item = Node(item)
+    self.parents.add(item)
+    if not self in item.children:
+      item.children.append(self)
+    return item
+
+  def findChild(self,item):
+    """ Do a top down search for the item in a node, and return the first node found, else None. """
+    return FindChildVisitor(item).visit(self)
+
+  def __str__(self):
+    children = [x.item for x in self.children]
+    parents =  set([x.item for x in self.parents])
+    return "<node: %s<- %s ->%s>"%(parents,self.item,children)
+
+class FindChildVisitor(object):
+  """Do a top down search for a particular item. Stop traversing when that item is found"""
+  def __init__(self,item):
+    self.item = item
+    self.marks = set()
+    self.child = None
+  def visit(self,node):
+    if node in self.marks: return self.child
+    if self.item == node.item:
+      self.child = node
+    if self.child:
+      return self.child
+    self.marks.add(node)
+    for c in node.children:
+      self.child = self.visit(c)
+      if self.child:
+        return self.child
+    return self.child
+
+class BottomUpVisitor(object):
+  """Visit each child before visiting self, retaining a list of visited Nodes in self.history"""
+  def __init__(self):
+    self.history = []
+    self.marks = set()
+    self.cycleMark = set()
+  def visit(self,node):
+    if node in self.cycleMark:
+      return
+    self.cycleMark.add(node)
+    for c in node.children:
+      self.visit(c)
+    if not node in self.marks:
+      self.history.append(node)
+      self.marks.add(node)
+
+class TopDownVisitor(object):
+  """Visit self before visiting each child, retaining a list of visited Nodes in self.history"""
+  def __init__(self):
+    self.history = []
+    self.marks = set()
+  def visit(self,node):
+    if node in self.marks:
+      return
+    self.history.append(node)
+    self.marks.add(node)
+    for c in node.children:
+      self.visit(c)
+
+def makeDependencyMap(aMap):
+  """
+  create a dependency data structure as follows:
+  - Each key in aMap represents an item that depends on each item in the iterable which is that key's value
+  - Each Node represents an item which is a precursor to its parents and depends on its children
+  Returns a map whose keys are the items described in aMap and whose values are the dependency (sub)tree for that item
+  Thus, for aMap = {a:(b,c), b:(d,), c:[]},
+  returns {a:Node(a),b:Node(b),c:Node(c),d:Node(d)} where
+     - Node(a) has no parent and children: Node(b) and Node(c)
+     - Node(b) has parent: Node(a) and child: Node(d)
+     - Node(c) has parent: Node(a) and no child
+     - Node(d) which was not a key in aMap was created. It has parent: Node(b) and no child
+  This map is used to find the precursors for a given item by using BottomUpVisitor on the Node associated with that item
+  """
+  index = {}
+  for i in aMap.keys():
+    iNode = index.get(i,None)
+    if not iNode:
+      iNode = Node(i)
+      index[i] = iNode
+    for c in aMap[i]:
+      cNode = index.get(c,None)
+      if not cNode:
+        cNode = Node(c)
+        index[c] = cNode
+      iNode.addChild(cNode)
+  return index
+
+def debugTreePrint(node,pfx="->"):
+  """Purely a debugging aid: Ascii-art picture of a tree descended from node"""
+  print pfx,node.item
+  for c in node.children:
+    debugTreePrint(c,"  "+pfx)
+
+def dependencyOrder(aMap, aList = None):
+  """
+  Given descriptions of dependencies in aMap and an optional list of items in aList
+  if not aList, aList = aMap.keys()
+  Returns a list containing each element of aList and all its precursors so that every precursor of
+  any element in the returned list is seen before that dependent element.
+  If aMap contains cycles, something will happen. It may not be pretty...
+  """
+  dependencyMap = makeDependencyMap(aMap)
+  outputList = []
+  if not aList:
+    aList = aMap.keys()
+  items = []
+  v = BottomUpVisitor()
+  for item in aList:
+    try:
+      v.visit(dependencyMap[item])
+    except KeyError:
+      outputList.append(item)
+  outputList = [x.item for x in v.history]+outputList
+  return outputList
+

--- a/socorro/lib/sqlutils.py
+++ b/socorro/lib/sqlutils.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from psycopg2.extensions import adapt
+
+
+def quote_value(value):
+    """return the value ready to be used as a value in a SQL string.
+
+    For example you can safely do this:
+
+        cursor.execute('select * from table where key = %s' % quote_value(val))
+
+    and you don't have to worry about possible SQL injections.
+    """
+    adapted = adapt(value)
+    if hasattr(adapted, 'getquoted'):
+        adapted = adapted.getquoted()
+    return adapted

--- a/socorro/lib/statistics.py
+++ b/socorro/lib/statistics.py
@@ -1,0 +1,87 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+"""
+
+from statsd import StatsClient
+
+from configman import RequiredConfig, Namespace
+
+def str_to_list(string_list):
+    item_list = []
+    for x in string_list.split(','):
+        item_list.append(x.strip())
+    return item_list
+
+
+class StatisticsForStatsd(RequiredConfig):
+    """This class is a wrapper around statsd adding a simple configman
+    compatible interface and stats naming scheme.  Code using this class
+    will distrubute `incr` calls with names associated with them.  When
+    ever an `incr` call is encountered, the name will be paired with the
+    name of the statsd names and the increment action fired off.
+
+    This class will only send stats `incr` calls for names that appear in
+    the configuration parameter `active_counters_list`.  This enables counters
+    to be turned on and off at configuration time."""
+
+    required_config = Namespace()
+    required_config.add_option(
+        'statsd_host',
+        doc='the hostname of statsd',
+        default='',
+        reference_value_from='resource.statsd',
+    )
+    required_config.add_option(
+        'statsd_port',
+        doc='the port number for statsd',
+        default=8125,
+        reference_value_from='resource.statsd',
+    )
+    required_config.add_option(
+        'prefix',
+        doc='a string to be used as the prefix for statsd names',
+        default='',
+        reference_value_from='resource.statsd',
+    )
+    required_config.add_option(
+        'active_counters_list',
+        default='',
+        #default='restarts, jobs, criticals, errors, mdsw_failures',
+        doc='a comma delimeted list of counters',
+        from_string_converter=str_to_list,
+        reference_value_from='resource.statsd',
+    )
+
+    def __init__(self, config, name):
+        super(StatisticsForStatsd, self).__init__()
+        self.config = config
+        if config.prefix and name:
+            self.prefix = '.'.join((config.prefix, name))
+        elif config.prefix:
+            self.prefix = config.prefix
+        elif name:
+            self.prefix = name
+        else:
+            self.prefix = ''
+        self.statsd = StatsClient(
+            config.statsd_host,
+            config.statsd_port,
+            self.prefix
+        )
+
+    def incr(self, name):
+        if (
+            self.config.statsd_host
+            and name in self.config.active_counters_list
+        ):
+            if self.prefix and name:
+                name = '.'.join((self.prefix, name))
+            elif self.prefix:
+                name = self.prefix
+            elif not name:
+                name = 'unknown'
+            self.statsd.incr(name)
+

--- a/socorro/lib/task_manager.py
+++ b/socorro/lib/task_manager.py
@@ -1,0 +1,197 @@
+import time
+import threading
+import os
+
+from configman import RequiredConfig, Namespace
+from configman.converters import class_converter
+
+#------------------------------------------------------------------------------
+def default_task_func(a_param):
+    """This default consumer function just doesn't do anything.  It is a
+    placeholder just to demonstrate the api and not really for any other
+    purpose"""
+    pass
+
+
+#------------------------------------------------------------------------------
+def default_iterator():
+    """This default producer's iterator yields the integers 0 through 9 and
+    then yields none forever thereafter.  It is a placeholder to demonstrate
+    the  api and not used for anything in a real system."""
+    for x in range(10):
+        yield ((x,), {})
+    while True:
+        yield None
+
+#------------------------------------------------------------------------------
+def respond_to_SIGTERM(signal_number, frame, target=None):
+    """ these classes are instrumented to respond to a KeyboardInterrupt by
+    cleanly shutting down.  This function, when given as a handler to for
+    a SIGTERM event, will make the program respond to a SIGTERM as neatly
+    as it responds to ^C.
+
+    This function is used in registering a signal handler from the signal
+    module.  It should be registered for any signal for which the desired
+    behavior is to kill the application:
+        signal.signal(signal.SIGTERM, respondToSIGTERM)
+        signal.signal(signal.SIGHUP, respondToSIGTERM)
+
+    parameters:
+        signal_number - unused in this function but required by the api.
+        frame - unused in this function but required by the api.
+        target - an instance of a class that has a member called 'task_manager'
+                 that is a derivative of the TaskManager class below.
+    """
+    if target:
+        target.config.logger.info('detected SIGTERM')
+        # by setting the quit flag to true, any calls to the 'quit_check'
+        # method that is so liberally passed around in this framework will
+        # result in raising the quit exception.  The current quit exception
+        # is KeyboardInterrupt
+        target.task_manager.quit = True
+    else:
+        raise KeyboardInterrupt
+
+
+#==============================================================================
+class TaskManager(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+      'idle_delay',
+      default=7,
+      doc='the delay in seconds if no job is found'
+    )
+    required_config.add_option(
+      'quit_on_empty_queue',
+      default=False,
+      doc='stop if the queue is empty'
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config,
+                 job_source_iterator=default_iterator,
+                 task_func=default_task_func):
+        """
+        parameters:
+            job_source_iterator - an iterator to serve as the source of data.
+                                  it can be of the form of a generator or
+                                  iterator; a function that returns an
+                                  iterator; a instance of an iterable object;
+                                  or a class that when instantiated with a
+                                  config object can be iterated.  The iterator
+                                  must yield a tuple consisting of a
+                                  function's tuple of args and, optionally, a
+                                  mapping of kwargs.
+                                  Ex:  (('a', 17), {'x': 23})
+            task_func - a function that will accept the args and kwargs yielded
+                        by the job_source_iterator"""
+        super(TaskManager, self).__init__()
+        self.config = config
+        self._pid = os.getpid()
+        self.logger = config.logger
+        self.job_param_source_iter = job_source_iterator
+        self.task_func = task_func
+        self.quit = False
+        self.logger.debug('TaskManager finished init')
+
+    #--------------------------------------------------------------------------
+    def quit_check(self):
+        """this is the polling function that the threads periodically look at.
+        If they detect that the quit flag is True, then a KeyboardInterrupt
+        is raised which will result in the threads dying peacefully"""
+        if self.quit:
+            raise KeyboardInterrupt
+
+    #--------------------------------------------------------------------------
+    def _get_iterator(self):
+        """The iterator passed in can take several forms: a class that can be
+        instantiated and then iterated over; a function that when called
+        returns an iterator; an actual iterator/generator or an iterable
+        collection.  This function sorts all that out and returns an iterator
+        that can be used"""
+        try:
+            return self.job_param_source_iter(self.config)
+        except TypeError:
+            try:
+                return self.job_param_source_iter()
+            except TypeError:
+                return self.job_param_source_iter
+
+    #--------------------------------------------------------------------------
+    def _responsive_sleep(self, seconds, wait_log_interval=0, wait_reason=''):
+        """When there is litte work to do, the queuing thread sleeps a lot.
+        It can't sleep for too long without checking for the quit flag and/or
+        logging about why it is sleeping.
+
+        parameters:
+            seconds - the number of seconds to sleep
+            wait_log_interval - while sleeping, it is helpful if the thread
+                                periodically announces itself so that we
+                                know that it is still alive.  This number is
+                                the time in seconds between log entries.
+            wait_reason - the is for the explaination of why the thread is
+                          sleeping.  This is likely to be a message like:
+                          'there is no work to do'.
+
+        This was also partially motivated by old versions' of Python inability
+        to KeyboardInterrupt out of a long sleep()."""
+
+        for x in xrange(int(seconds)):
+            self.quit_check()
+            if wait_log_interval and not x % wait_log_interval:
+                self.logger.info('%s: %dsec of %dsec',
+                                 wait_reason,
+                                 x,
+                                 seconds)
+                self.quit_check()
+            time.sleep(1.0)
+
+    #--------------------------------------------------------------------------
+    def blocking_start(self, waiting_func=None):
+        """this function starts the task manager running to do tasks.  The
+        waiting_func is normally used to do something while other threads
+        are running, but here we don't have other threads.  So the waiting
+        func will never get called.  I can see wanting this function to be
+        called at least once after the end of the task loop."""
+        self.logger.debug('threadless start')
+        try:
+            for job_params in self._get_iterator():  # may never raise
+                                                     # StopIteration
+                self.config.logger.debug('received %r', job_params)
+                self.quit_check()
+                if job_params is None:
+                    if self.config.quit_on_empty_queue:
+                        raise KeyboardInterrupt
+                    self.logger.info("there is nothing to do.  Sleeping "
+                                     "for %d seconds" %
+                                     self.config.idle_delay)
+                    self._responsive_sleep(self.config.idle_delay)
+                    continue
+                self.quit_check()
+                try:
+                    args, kwargs = job_params
+                except ValueError:
+                    args = job_params
+                    kwargs = {}
+                try:
+                    self.task_func(*args, **kwargs)
+                except Exception:
+                    self.config.logger.error("Error in processing a job",
+                                             exc_info=True)
+        except KeyboardInterrupt:
+            self.logger.debug('queuingThread gets quit request')
+        finally:
+            self.quit = True
+            self.logger.debug("ThreadlessTaskManager dies quietly")
+
+    #--------------------------------------------------------------------------
+    def executor_identity(self):
+        """this function is likely to be called via the configuration parameter
+        'executor_identity' at the root of the self.config attribute of the
+        application.  It is most frequently used in the Pooled
+        ConnectionContext classes to ensure that connections aren't shared
+        between threads, greenlets, or whatever the unit of execution is.
+        This is useful for maintaining transactional integrity on a resource
+        connection."""
+        return "%s-%s" % (self._pid, threading.currentThread().getName())
+

--- a/socorro/lib/threaded_task_manager.py
+++ b/socorro/lib/threaded_task_manager.py
@@ -1,0 +1,362 @@
+"""This module defines classes that implements a threaded
+producer/consumer system.  A single iterator thread pushes jobs into an
+internal queue while a flock of consumer/worker threads do the jobs.  A job
+consists of a function and the data applied to the function."""
+
+import time
+import threading
+import Queue
+
+from configman import RequiredConfig, Namespace
+from configman.converters import class_converter
+
+from socorro.lib.task_manager import (
+    default_task_func,
+    default_iterator,
+    TaskManager
+)
+
+
+#==============================================================================
+class ThreadedTaskManager(TaskManager):
+    """Given an iterator over a sequence of job parameters and a function,
+    this class will execute the function in a set of threads."""
+    required_config = Namespace()
+    required_config.add_option(
+      'idle_delay',
+      default=7,
+      doc='the delay in seconds if no job is found'
+    )
+    # how does one choose how many threads to use?  Keep the number low if your
+    # application is compute bound.  You can raise it if your app is i/o
+    # bound.  The best thing to do is to test the through put of your app with
+    # several values.  For Socorro, we've found that setting this value to the
+    # number of processor cores in the system gives the best throughput.
+    required_config.add_option(
+      'number_of_threads',
+      default=4,
+      doc='the number of threads'
+    )
+    # there is wisdom is setting the maximum queue size to be no more than
+    # twice the number of threads.  By keeping the threads starved, the
+    # queing thread will be blocked more more frequently.  Once an item
+    # is in the queue, there may be no way to fetch it again if disaster
+    # strikes and this app quits or fails.  Potentially anything left in
+    # the queue could be lost.  Limiting the queue size insures minimal
+    # damage in a worst case scenario.
+    required_config.add_option(
+      'maximum_queue_size',
+      default=8,
+      doc='the maximum size of the internal queue'
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config,
+                 job_source_iterator=default_iterator,
+                 task_func=default_task_func):
+        """the constructor accepts the function that will serve as the data
+        source iterator and the function that the threads will execute on
+        consuming the data.
+
+        parameters:
+            job_source_iterator - an iterator to serve as the source of data.
+                                  it can be of the form of a generator or
+                                  iterator; a function that returns an
+                                  iterator; a instance of an iterable object;
+                                  or a class that when instantiated with a
+                                  config object can be iterated.  The iterator
+                                  must yield a tuple consisting of a
+                                  function's tuple of args and, optionally, a
+                                  mapping of kwargs.
+                                  Ex:  (('a', 17), {'x': 23})
+            task_func - a function that will accept the args and kwargs yielded
+                        by the job_source_iterator"""
+        super(ThreadedTaskManager, self).__init__(
+            config,
+            job_source_iterator,
+            task_func
+        )
+        self.thread_list = []  # the thread object storage
+        self.number_of_threads = config.number_of_threads
+        self.task_queue = Queue.Queue(config.maximum_queue_size)
+
+    #--------------------------------------------------------------------------
+    def start(self):
+        """this function will start the queing thread that executes the
+        iterator and feeds jobs into the queue.  It also starts the worker
+        threads that just sit and wait for items to appear on the queue. This
+        is a non blocking call, so the executing thread is free to do other
+        things while the other threads work."""
+        self.logger.debug('start')
+        # start each of the task threads.
+        for x in range(self.number_of_threads):
+            # each thread is given the config object as well as a reference to
+            # this manager class.  The manager class is where the queue lives
+            # and the task threads will refer to it to get their next jobs.
+            new_thread = TaskThread(self.config, self.task_queue)
+            self.thread_list.append(new_thread)
+            new_thread.start()
+        self.queuing_thread = threading.Thread(
+          name="QueuingThread",
+          target=self._queuing_thread_func
+        )
+        self.queuing_thread.start()
+
+    #--------------------------------------------------------------------------
+    def wait_for_completion(self, waiting_func=None):
+        """This is a blocking function call that will wait for the queuing
+        thread to complete.
+
+        parameters:
+            waiting_func - this function will be called every one second while
+                           waiting for the queuing thread to quit.  This allows
+                           for logging timers, status indicators, etc."""
+        self.logger.debug("waiting to join queuingThread")
+        self._responsive_join(self.queuing_thread, waiting_func)
+
+    #--------------------------------------------------------------------------
+    def stop(self):
+        """This function will tell all threads to quit.  All threads
+        periodically look at the value of quit.  If they detect quit is True,
+        then they commit ritual suicide.  After setting the quit flag, this
+        function will wait for the queuing thread to quit."""
+        self.quit = True
+        self.wait_for_completion()
+
+    #--------------------------------------------------------------------------
+    def blocking_start(self, waiting_func=None):
+        """this function is just a wrapper around the start and
+        wait_for_completion methods.  It starts the queuing thread and then
+        waits for it to complete.  If run by the main thread, it will detect
+        the KeyboardInterrupt exception (which is what SIGTERM and SIGHUP
+        have been translated to) and will order the threads to die."""
+        try:
+            self.start()
+            self.wait_for_completion(waiting_func)
+            # it only ends if someone hits  ^C or sends SIGHUP or SIGTERM -
+            # any of which will get translated into a KeyboardInterrupt
+        except KeyboardInterrupt:
+            while True:
+                try:
+                    self.stop()
+                    break
+                except KeyboardInterrupt:
+                    self.logger.warning('We heard you the first time.  There '
+                                   'is no need for further keyboard or signal '
+                                   'interrupts.  We are waiting for the '
+                                   'worker threads to stop.  If this app '
+                                   'does not halt soon, you may have to send '
+                                   'SIGKILL (kill -9)')
+
+    #--------------------------------------------------------------------------
+    def wait_for_empty_queue(self, wait_log_interval=0, wait_reason=''):
+        """Sit around and wait for the queue to become empty
+
+        parameters:
+            wait_log_interval - while sleeping, it is helpful if the thread
+                                periodically announces itself so that we
+                                know that it is still alive.  This number is
+                                the time in seconds between log entries.
+            wait_reason - the is for the explaination of why the thread is
+                          sleeping.  This is likely to be a message like:
+                          'there is no work to do'."""
+        seconds = 0
+        while True:
+            if self.task_queue.empty():
+                break
+            self.quit_check()
+            if wait_log_interval and not seconds % wait_log_interval:
+                self.logger.info('%s: %dsec so far',
+                                 wait_reason,
+                                 seconds)
+                self.quit_check()
+            seconds += 1
+            time.sleep(1.0)
+
+    #--------------------------------------------------------------------------
+    def _responsive_join(self, thread, waiting_func=None):
+        """similar to the responsive sleep, a join function blocks a thread
+        until some other thread dies.  If that takes a long time, we'd like to
+        have some indicaition as to what the waiting thread is doing.  This
+        method will wait for another thread while calling the waiting_func
+        once every second.
+
+        parameters:
+            thread - an instance of the TaskThread class representing the
+                     thread to wait for
+            waiting_func - a function to call every second while waiting for
+                           the thread to die"""
+        while True:
+            try:
+                thread.join(1.0)
+                if not thread.isAlive():
+                    break
+                if waiting_func:
+                    waiting_func()
+            except KeyboardInterrupt:
+                self.logger.debug('quit detected by _responsive_join')
+                self.quit = True
+
+    #--------------------------------------------------------------------------
+    def _kill_worker_threads(self):
+        """This function coerces the consumer/worker threads to kill
+        themselves.  When called by the queuing thread, one death token will
+        be placed on the queue for each thread.  Each worker thread is always
+        looking for the death token.  When it encounters it, it immediately
+        runs to completion without drawing anything more off the queue.
+
+        This is a blocking call.  The thread using this function will wait for
+        all the worker threads to die."""
+        for x in range(self.number_of_threads):
+            self.task_queue.put((None, None))
+        self.logger.debug("waiting for standard worker threads to stop")
+        for t in self.thread_list:
+            t.join()
+
+    #--------------------------------------------------------------------------
+    def _queuing_thread_func(self):
+        """This is the function responsible for reading the iterator and
+        putting contents into the queue.  It loops as long as there are items
+        in the iterator.  Should something go wrong with this thread, or it
+        detects the quit flag, it will calmly kill its workers and then
+        quit itself."""
+        self.logger.debug('_queuing_thread_func start')
+        try:
+            for job_params in self._get_iterator():  # may never raise
+                                                     # StopIteration
+                self.config.logger.debug('received %r', job_params)
+                if job_params is None:
+                    if self.config.quit_on_empty_queue:
+                        self.wait_for_empty_queue(
+                            wait_log_interval=10,
+                            wait_reason='waiting for queue to drain'
+                        )
+                        raise KeyboardInterrupt
+                    self.logger.info("there is nothing to do.  Sleeping "
+                                     "for %d seconds" %
+                                     self.config.idle_delay)
+                    self._responsive_sleep(self.config.idle_delay)
+                    continue
+                self.quit_check()
+                #self.logger.debug("queuing job %s", job_params)
+                self.task_queue.put((self.task_func, job_params))
+        except Exception:
+            self.logger.error('queuing jobs has failed', exc_info=True)
+        except KeyboardInterrupt:
+            self.logger.debug('queuingThread gets quit request')
+        finally:
+            self.logger.debug("we're quitting queuingThread")
+            self._kill_worker_threads()
+            self.logger.debug("all worker threads stopped")
+            # now that we've killed all the workers, we can set the quit flag
+            # to True.  This will cause any other threads to die and shut down
+            # the application.  Originally, the setting of this flag was at the
+            # start of this "finally" block.  However, that meant that the
+            # workers would abort their currently running jobs.  In the case of
+            # of the natural ending of an application where an iterater ran to
+            # exhaustion, the workers would die before completing their tasks.
+            # Moving the setting of the flag to this location allows the
+            # workers to finish and then the app shuts down.
+            self.quit = True
+
+    #--------------------------------------------------------------------------
+    def executor_identity(self):
+        """this function is likely to be called via the configuration parameter
+        'executor_identity' at the root of the self.config attribute of the
+        application.  It is most frequently used in the Pooled
+        ConnectionContext classes to ensure that connections aren't shared
+        between threads, greenlets, or whatever the unit of execution is.
+        This is useful for maintaining transactional integrity on a resource
+        connection."""
+        return threading.currentThread().getName()
+
+
+#==============================================================================
+class ThreadedTaskManagerWithConfigSetup(ThreadedTaskManager):
+    """Given an iterator over a sequence of job parameters and a function,
+    this class will execute the the function in a set of threads.
+
+    Rather than accepting the job_source_iterator and task function as
+    constructor arguments, this class gets those values from configuration.
+    """
+    required_config = Namespace()
+    required_config = Namespace()
+    required_config.add_option(
+      'job_source_iterator',
+      default=default_iterator,
+      doc='an iterator or callable that will '
+      'return an iterator',
+      from_string_converter=class_converter
+    )
+    required_config.add_option(
+      'task_func',
+      default=default_task_func,
+      doc='a callable that accomplishes a task',
+      from_string_converter=class_converter
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        """Create the ThreadedTaskManager with config options rather than
+        functions passed into the constructor."""
+        super(ThreadedTaskManagerWithConfigSetup, self).__init__(
+          config=config,
+          job_source_iterator=config.job_source_iterator,
+          task_func=config.task_func)
+
+
+#==============================================================================
+class TaskThread(threading.Thread):
+    """This class represents a worker thread for the TaskManager class"""
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config, task_queue):
+        """Initialize a new thread.
+
+        parameters:
+            config - the configuration from configman
+            task_queue - a reference to the queue from which to fetch jobs
+        """
+        super(TaskThread, self).__init__()
+        self.task_queue = task_queue
+        self.config = config
+
+    #--------------------------------------------------------------------------
+    def _get_name(self):
+        return threading.currentThread().getName()
+
+    #--------------------------------------------------------------------------
+    def run(self):
+        """The main routine for a thread's work.
+
+        The thread pulls tasks from the task queue and executes them until it
+        encounters a death token.  The death token is a tuple of two Nones.
+        """
+        try:
+            quit_request_detected = False
+            while True:
+                function, arguments = self.task_queue.get()
+                if function is None:
+                    # this allows us to watch the threads die and identify
+                    # threads that may be hanging or deadlocked
+                    self.config.logger.info('quits')
+                    break
+                if quit_request_detected:
+                    continue
+                try:
+                    try:
+                        args, kwargs = arguments
+                    except ValueError:
+                        args = arguments
+                        kwargs = {}
+                    function(*args, **kwargs)  # execute the task
+                except Exception:
+                    self.config.logger.error("Error in processing a job",
+                                             exc_info=True)
+                except KeyboardInterrupt:  # TODO: can probably go away
+                    self.config.logger.info('quit request detected')
+                    quit_request_detected = True
+                    #thread.interrupt_main()  # only needed if signal handler
+                                             # not registered
+        except Exception:
+            self.config.logger.critical("Failure in task_queue", exc_info=True)

--- a/socorro/lib/threadlib.py
+++ b/socorro/lib/threadlib.py
@@ -1,0 +1,137 @@
+#!/usr/bin/python
+# Copyright (c) 2004-2005 Oregon State University - Open Source Lab
+# All rights reserved.
+
+# $Id$
+# $HeadURL$
+
+# This is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 2 of the License, or (at your option)
+# any later version.
+
+# This software is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+
+# You should have received a copy of the GNU General Public License
+# along with this software; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#
+# Copyright 2005 by Oregon State Univeristy Open Source Lab
+#
+#    This file is part of OSUOSL Sentry Application of the Bouncer Project
+#
+#    The OSUOSL Sentry Application is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    The OSUOSL Sentry Application is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with The OSUOSL Sentry Application; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Written by K "Lars" Lohn 2/05
+
+import threading
+import Queue
+import traceback
+import sys
+
+#======================
+# T a s k M a n a g e r
+#======================
+class TaskManager(object):
+  """This class serves as a manager for a set of threads.
+
+  Based very loosely on: http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/203871
+  """
+  #----------------
+  # _ _ i n i t _ _
+  #----------------
+  def __init__ (self, numberOfThreads, maxQueueSize=0):
+    """Initialize and start all threads"""
+    self.threadList = []
+    self.numberOfThreads = numberOfThreads
+    self.taskQueue = Queue.Queue(maxQueueSize)
+    for x in range(numberOfThreads):
+      newThread = TaskManagerThread(self)
+      self.threadList.append(newThread)
+      newThread.start()
+
+  #--------------
+  # n e w T a s k
+  #--------------
+
+  def newTask (self, task, args=None):
+    """Add a task to be executed by a thread
+
+    The input is a tuple with these components:
+        task - a function to be run by a thread
+        args - a tuple of arguments to be passed to the function
+    """
+    self.taskQueue.put((task, args))
+
+  #----------------------------------
+  # w a i t F o r C o m p l e t i o n
+  #----------------------------------
+  def waitForCompletion (self):
+    """Wait for all threads to complete their work
+
+    The worker threads are told to quit when they receive a task
+    that is a tuple of (None, None).  This routine puts as many of
+    those tuples in the task queue as there are threads.  As soon as
+    a thread receives one of these tuples, it dies.
+    """
+    for x in range(self.numberOfThreads):
+      self.taskQueue.put((None, None))
+    for t in self.threadList:
+      # print "attempting to join %s" % t.getName()
+      t.join()
+
+
+#==================================
+# T a s k M a n a g e r T h r e a d
+#==================================
+class TaskManagerThread(threading.Thread):
+  """This class represents a worker thread for the TaskManager class"""
+
+  #----------------
+  # _ _ i n i t _ _
+  #----------------
+  def __init__(self, manager):
+    """Initialize a new thread.
+    """
+    super(TaskManagerThread, self).__init__()
+    self.manager = manager
+
+  #------
+  # r u n
+  #------
+  def run(self):
+    """The main routine for a thread's work.
+
+    The thread pulls tasks from the manager's task queue and executes
+    them until it encounters a task with a function that is None.
+    """
+    try:
+      while True:
+        aFunction, arguments = self.manager.taskQueue.get()
+        if aFunction is None:
+          break
+        aFunction(arguments)
+    except KeyboardInterrupt:
+      import thread
+      print >>sys.stderr, "%s caught KeyboardInterrupt" % threading.currentThread().getName()
+      thread.interrupt_main()
+    except Exception, x:
+      print >>sys.stderr, "Something BAD happened in %s:" % threading.currentThread().getName()
+      traceback.print_exc(file=sys.stderr)
+      print >>sys.stderr, x
+

--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -1,0 +1,568 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+import configman
+import collections
+import inspect
+
+from configman import RequiredConfig, Namespace
+from configman.dotdict import DotDict
+from configman.converters import to_str
+
+from socorro.lib.converters import (
+    str_to_classes_in_namespaces_converter,
+)
+
+#------------------------------------------------------------------------------
+# support methods
+
+# a regular expression that will parse out all pairs in the form:
+#   a=b, c=d, e=f
+kw_list_re = re.compile('([^ =]+) *= *("[^"]*"|[^ ]*)')
+
+
+#------------------------------------------------------------------------------
+def kw_str_parse(a_string):
+    """convert a string in the form 'a=b, c=d, e=f' to a dict"""
+    try:
+        return dict((k, eval(v.rstrip(',')))
+                    for k, v in kw_list_re.findall(a_string))
+    except (AttributeError, TypeError):
+        if isinstance(a_string, collections.Mapping):
+            return a_string
+        return {}
+
+
+#==============================================================================
+class Rule(RequiredConfig):
+    """the base class for Support Rules.  It provides the framework for the
+    rules 'predicate', 'action', and 'version' as well as utilites to help
+    rules do their jobs."""
+    required_config = Namespace()
+    required_config.add_option(
+        'chatty',
+        doc='should this rule announce what it is doing?',
+        default=False,
+    )
+
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config=None, quit_check_callback=None):
+        self.config = config
+        self.quit_check_callback = quit_check_callback
+
+    #--------------------------------------------------------------------------
+    def predicate(self, *args, **kwargs):
+        """the default predicate for Support Classifiers invokes any derivied
+        _predicate function, trapping any exceptions raised in the process.  We
+        are obligated to catch these exceptions to give subsequent rules the
+        opportunity to act.  An error during the predicate application is a
+        failure of the rule, not a failure of the classification system itself
+        """
+        try:
+            return self._predicate(*args, **kwargs)
+        except Exception, x:
+            self.config.logger.debug(
+                'Rule %s predicicate failed because of "%s"',
+                to_str(self.__class__),
+                x,
+                exc_info=True
+            )
+            return False
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, *args, **kwargs):
+        """"The default support classifier predicate just returns True.  We
+        want all the support classifiers run.
+
+        returns:
+            True - this rule should be applied
+            False - this rule should not be applied
+        """
+        return True
+
+    #--------------------------------------------------------------------------
+    def action(self, *args, **kwargs):
+        """the default action for Support Classifiers invokes any derivied
+        _action function, trapping any exceptions raised in the process.  We
+        are obligated to catch these exceptions to give subsequent rules the
+        opportunity to act and perhaps mitigate the error.  An error during the
+        action application is a failure of the rule, not a failure of the
+        classification system itself."""
+        try:
+            return self._action(*args, **kwargs)
+        except KeyError, x:
+            self.config.logger.debug(
+                'Rule %s action failed because of missing key "%s"',
+                to_str(self.__class__),
+                x,
+            )
+        except Exception, x:
+            self.config.logger.debug(
+                'Rule %s action failed because of "%s"',
+                to_str(self.__class__),
+                x,
+                exc_info=True
+            )
+        return False
+
+    #--------------------------------------------------------------------------
+    def _action(self, *args, **kwargs):
+        """Rules derived from this base class ought to override this method
+        with an actual classification rule.  Successful application of this
+        method should include a call to '_add_classification'.
+
+        returns:
+            True - this rule was applied successfully and no further rules
+                   should be applied
+            False - this rule did not succeed and further rules should be
+                    tried
+        """
+        return True
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        """This method should be overridden in a derived class."""
+        return '0.0'
+
+    #--------------------------------------------------------------------------
+    def act(self, *args, **kwargs):
+        """gather a rules parameters together and run the predicate. If that
+        returns True, then go on and run the action function
+
+        returns:
+            a tuple indicating the results of applying the predicate and the
+            action function:
+               (False, None) - the predicate failed, action function not run
+               (True, True) - the predicate and action functions succeeded
+               (True, False) - the predicate succeeded, but the action function
+                               failed"""
+        if self.predicate(*args, **kwargs):
+            bool_result = self.action(*args, **kwargs)
+            return (True, bool_result)
+        else:
+            return (False, None)
+
+
+#==============================================================================
+class TransformRule(Rule):
+    """a pairing of two functions with default parameters to be used as
+    transformation rule."""
+    #--------------------------------------------------------------------------
+    def __init__(self, predicate,
+                       predicate_args,
+                       predicate_kwargs,
+                       action,
+                       action_args,
+                       action_kwargs,
+                       config=None):
+        """construct a new predicate/action rule pair.
+        input parameters:
+            pedicate - the name of a function to serve as a predicate.  The
+                       function must accept two dicts followed by any number
+                       of constant args or kwargs.  Alternatively, this could
+                       be a classname for a class that has a method called
+                       'predicate' with the aforementioned charactistics
+            predicate_args - arguments to be passed on to the predicate
+                             function in addition to the two required dicts.
+            predicate_kwargs - kwargs to be passed on to the predicate
+                               function in addition to the two required dicts.
+            action - the name of a function to be run if the predicate returns
+                     True.  The method must accept two dicts followed by
+                     any number of args or kwargs.    Alternatively, this could
+                     be a classname for a class that has a method called
+                     'predicate' with the aforementioned charactistics
+            action_args - arguments to be passed on to the action function
+                          in addition to the two required dicts
+            action_kwargs - kwargs to be passed on to the action function in
+                            addition to the two required dicts
+        """
+        try:
+            self.predicate = configman.converters.class_converter(predicate)
+        except TypeError:
+            # conversion failed, let's assume it was already function or a
+            # callable object
+            self.predicate = predicate
+        if inspect.isclass(self.predicate):
+            # the predicate is a class, instantiate it and set the predicate
+            # function to the object's 'predicate' method
+            self._predicate_implementation = self.predicate(config)
+            self.predicate = self._predicate_implementation.predicate
+        else:
+            self._predicate_implementation = type(self.predicate)
+
+        try:
+            if predicate_args in ('', None):
+                self.predicate_args = ()
+            elif isinstance(predicate_args, tuple):
+                self.predicate_args = predicate_args
+            else:
+                self.predicate_args = tuple(
+                    [eval(x.strip()) for x in predicate_args.split(',')]
+                )
+        except AttributeError:
+            self.predicate_args = ()
+
+        self.predicate_kwargs = kw_str_parse(predicate_kwargs)
+        try:
+            self.action = configman.class_converter(action)
+        except TypeError:
+            # the conversion failed, let's assume that the action was passed in
+            # as something callable.
+            self.action = action
+        if inspect.isclass(self.action):
+            # the action is actually a class, go on and instantiate it, then
+            # assign the 'action' to be the object's 'action' method
+            if self._predicate_implementation.__class__ is self.action:
+                # if the predicate and the action are implemented in the same
+                # class, only instantiate one copy.
+                self._action_implementation = self._predicate_implementation
+            else:
+                self._action_implementation = self.action(config)
+            self.action = self._action_implementation.action
+
+        try:
+            if action_args in ('', None):
+                self.action_args = ()
+            elif isinstance(action_args, tuple):
+                self.action_args = action_args
+            else:
+                self.action_args = tuple(
+                    [eval(x.strip()) for x in action_args.split(',')]
+                )
+        except AttributeError:
+            self.action_args = ()
+        self.action_kwargs = kw_str_parse(action_kwargs)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def function_invocation_proxy(fn, proxy_args, proxy_kwargs):
+        """execute the fuction if it is one, else evaluate the fn as a boolean
+        and return that value.
+
+        Sometimes rather than providing a predicate, we just give the value of
+        True.  This is shorthand for writing a predicate that always returns
+        true."""
+        try:
+            return fn(*proxy_args, **proxy_kwargs)
+        except TypeError:
+            return bool(fn)
+
+    #--------------------------------------------------------------------------
+    def act(self, *args, **kwargs):
+        """gather a rules parameters together and run the predicate. If that
+        returns True, then go on and run the action function
+
+        returns:
+            a tuple indicating the results of applying the predicate and the
+            action function:
+               (False, None) - the predicate failed, action function not run
+               (True, True) - the predicate and action functions succeeded
+               (True, False) - the predicate succeeded, but the action function
+                               failed"""
+        pred_args = tuple(args) + tuple(self.predicate_args)
+        pred_kwargs = kwargs.copy()
+        pred_kwargs.update(self.predicate_kwargs)
+        if self.function_invocation_proxy(self.predicate,
+                                          pred_args,
+                                          pred_kwargs):
+            act_args = tuple(args) + tuple(self.action_args)
+            act_kwargs = kwargs.copy()
+            act_kwargs.update(self.action_kwargs)
+            bool_result = self.function_invocation_proxy(self.action, act_args,
+                                                         act_kwargs)
+            return (True, bool_result)
+        else:
+            return (False, None)
+
+    #--------------------------------------------------------------------------
+    def __eq__(self, another):
+        if isinstance(another, TransformRule):
+            return self.__dict__ == another.__dict__
+        else:
+            return False
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        self.config.logger.debug('null close on rule %s', self.__class__)
+        pass
+
+#==============================================================================
+class TransformRuleSystem(RequiredConfig):
+    """A collection of TransformRules that can be applied together"""
+    required_config = Namespace()
+    required_config.add_option(
+        name='rules_list',
+        default=[],
+        from_string_converter=str_to_classes_in_namespaces_converter()
+    )
+    required_config.add_option(
+        'chatty_rules',
+        doc='should the rules announce what they are doing?',
+        default=False,
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config=None, quit_check=None):
+        if quit_check:
+            self._quit_check = quit_check
+        else:
+            self._quit_check = self._null_quit_check
+        self.rules = []
+        if not config:
+            config = DotDict()
+        if 'chatty_rules' not in config:
+            config.chatty_rules = False
+        self.config = config
+        if "rules_list" in config:
+            self.tag = config.tag
+            self.act = getattr(self, config.action)
+            list_of_rules = config.rules_list.class_list
+
+            for a_rule_class_name, a_rule_class, ns_name in list_of_rules:
+                try:
+                    self.rules.append(
+                        a_rule_class(config[ns_name])
+                    )
+                except KeyError, x:
+                    self.rules.append(
+                        a_rule_class(config)
+                    )
+
+    #--------------------------------------------------------------------------
+    def _null_quit_check(self):
+        "a no-op method to do nothing if no quit check method has been defined"
+        pass
+
+    #--------------------------------------------------------------------------
+    def load_rules(self, an_iterable):
+        """cycle through a collection of Transform rule tuples loading them
+        into the TransformRuleSystem"""
+        self.rules = [
+            TransformRule(*x, config=self.config) for x in an_iterable
+        ]
+
+    #--------------------------------------------------------------------------
+    def append_rules(self, an_iterable):
+        """add rules to the TransformRuleSystem"""
+        self.rules.extend(
+            TransformRule(*x, config=self.config) for x in an_iterable
+        )
+
+    #--------------------------------------------------------------------------
+    def apply_all_rules(self, *args, **kwargs):
+        """cycle through all rules and apply them all without regard to
+        success or failure
+
+        returns:
+             True - since success or failure is ignored"""
+        for x in self.rules:
+            self._quit_check()
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    'apply_all_rules: %s',
+                    to_str(x.__class__)
+                )
+            predicate_result, action_result = x.act(*args, **kwargs)
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    '               : pred - %s; act - %s',
+                    predicate_result,
+                    action_result
+                )
+        return True
+
+    #--------------------------------------------------------------------------
+    def apply_until_action_succeeds(self, *args, **kwargs):
+        """cycle through all rules until an action is run and succeeds
+
+        returns:
+           True - if an action is run and succeeds
+           False - if no action succeeds"""
+        for x in self.rules:
+            self._quit_check()
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    'apply_until_action_succeeds: %s',
+                    to_str(x.__class__)
+                )
+            predicate_result, action_result = x.act(*args, **kwargs)
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    '                           : pred - %s; act - %s',
+                    predicate_result,
+                    action_result
+                )
+            if action_result:
+                return True
+        return False
+
+    #--------------------------------------------------------------------------
+    def apply_until_action_fails(self, *args, **kwargs):
+        """cycle through all rules until an action is run and fails
+
+        returns:
+            True - an action ran and it failed
+            False - no action ever failed"""
+        for x in self.rules:
+            self._quit_check()
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    'apply_until_action_fails: %s',
+                    to_str(x.__class__)
+                )
+            predicate_result, action_result = x.act(*args, **kwargs)
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    '                        : pred - %s; act - %s',
+                    predicate_result,
+                    action_result
+                )
+            if not action_result:
+                return True
+        return False
+
+    #--------------------------------------------------------------------------
+    def apply_until_predicate_succeeds(self, *args, **kwargs):
+        """cycle through all rules until a predicate returns True
+
+        returns:
+            True - an action ran and it succeeded
+            False - an action ran and it failed
+            None - no predicate ever succeeded"""
+        for x in self.rules:
+            self._quit_check()
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    'apply_until_predicate_succeeds: %s',
+                    to_str(x.__class__)
+                )
+            predicate_result, action_result = x.act(*args, **kwargs)
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    '                              : pred - %s; act - %s',
+                    predicate_result,
+                    action_result
+                )
+            if predicate_result:
+                return action_result
+        return None
+
+    #--------------------------------------------------------------------------
+    def apply_until_predicate_fails(self, *args, **kwargs):
+        """cycle through all rules until a predicate returns False
+
+        returns:
+            False - a predicate ran and it failed
+            None - no predicate ever failed"""
+        for x in self.rules:
+            self._quit_check()
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    'apply_until_predicate_fails: %s',
+                    to_str(x.__class__)
+                )
+            predicate_result, action_result = x.act(*args, **kwargs)
+            if self.config.chatty_rules:
+                self.config.logger.debug(
+                    '                           : pred - %s; act - %s',
+                    predicate_result,
+                    action_result
+                )
+            if not predicate_result:
+                return False
+        return None
+
+    #--------------------------------------------------------------------------
+    def close(self):
+        for a_rule in self.rules:
+            try:
+                self.config.logger.debug('trying to close %s', to_str(a_rule.__class__))
+                close_method = a_rule.close
+            except AttributeError:
+                self.config.logger.debug('%s has no close',  to_str(a_rule.__class__))
+                # no close method mean no need to close
+                continue
+            close_method()
+
+
+#------------------------------------------------------------------------------
+# Useful rule predicates and actions
+#------------------------------------------------------------------------------
+# (True, '', '', copy_key_value, '', 'source_key=sally, destination_key=fred')
+def copy_value_action(source, destination,
+                      source_key=None, destination_key=None):
+    """copy a key from a mapping source to a mapping destination"""
+    destination[destination_key] = source[source_key]
+
+
+#------------------------------------------------------------------------------
+# (True, '', '',
+#  format_new_value, '', 'destination_key='Version', format_str=%(Version)sesr'
+#  )
+def format_new_value_action(source, destination, destination_key='',
+                            format_str=''):
+    """replace a mapping destination with a string formatted from the
+    mapping source.
+
+    parameters:
+        source - a mapping to use as a source
+        destination - a mapping to use as the destination
+        destination_key - the key in the destination to insert/replace
+        format - a string in standard python format form"""
+    destination[destination_key] = format_str % source
+
+
+# (eq_constant_predicate, '', 'source_key="fred", value="wilma"', ...)
+#------------------------------------------------------------------------------
+def eq_constant_predicate(source, destination, source_key='', value=''):
+    """a predicate to test equality between a source key and a constant
+
+    parameters:
+        source - the source of the value to test
+        destination - not used
+        source_key - the key into the source to use for the test
+        value - the constant to check for equality"""
+    return source[source_key] == value
+
+
+# (eq_key_predicate, '', 'left_mapping_key="fred", right_mapping_key="wilma"',
+# ...)
+#------------------------------------------------------------------------------
+def eq_key_predicate(
+    left_mapping,
+    right_mapping,
+    left_mapping_key='',
+    right_mapping_key=''
+):
+    """a predicate to test equality between a left mapping key and a
+   right mapping key
+
+    parameters:
+        left_mapping - the mapping containing the first value to test
+        right_mapping - the mapping containing the second value
+        left_mapping_key - the key into the source for the first value
+        right_mapping_key - the key into the second data source"""
+    return left_mapping[left_mapping_key] == right_mapping[right_mapping_key]
+
+
+# (is_not_null_predicate, '', 'key="fred",
+# ...)
+#------------------------------------------------------------------------------
+def is_not_null_predicate(
+    raw_crash, dumps, processed_crash, processor, key=''
+):
+    """a predicate that converts the key'd source to boolean.
+
+    parameters:
+        raw_crash - dict
+        dumps - placeholder in a fat interface - unused
+        processed_crash - placeholder in a fat interface - unused
+        processor - placeholder in a fat interface - unused
+    """
+    try:
+        return bool(raw_crash[key])
+    except KeyError:
+        return False

--- a/socorro/lib/util.py
+++ b/socorro/lib/util.py
@@ -1,0 +1,226 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import sys
+import traceback
+import datetime
+import cStringIO
+import threading
+import collections
+
+import logging
+l = logging.getLogger('webapi')
+
+#=================================================================================================================
+class FakeLogger(object):
+  loggingLevelNames = { logging.DEBUG: "DEBUG",
+                        logging.INFO: "INFO",
+                        logging.WARNING: "WARNING",
+                        logging.ERROR: "ERROR",
+                        logging.CRITICAL: "CRITICAL",
+                        logging.FATAL: "FATAL"
+                      }
+  def createLogMessage(self,*x):
+    try:
+      loggingLevelString = FakeLogger.loggingLevelNames[x[0]]
+    except KeyError:
+      loggingLevelString = "Level[%s]" % str(x[0])
+    message = x[1] % x[2:]
+    return '%s %s' % (loggingLevelString, message)
+  def log(self,*x,**kwargs):
+    print >>sys.stderr, self.createLogMessage(*x)
+  def debug(self,*x,**kwargs): self.log(logging.DEBUG, *x)
+  def info(self,*x,**kwargs): self.log(logging.INFO, *x)
+  def warning(self,*x,**kwargs): self.log(logging.WARNING, *x)
+  warn = warning
+  def error(self,*x,**kwargs): self.log(logging.ERROR, *x)
+  def critical(self,*x,**kwargs): self.log(logging.CRITICAL, *x)
+  fatal = critical
+
+
+#=================================================================================================================
+class SilentFakeLogger(object):
+  def log(self,*x,**kwargs): pass
+  def debug(self,*x,**kwargs): pass
+  def info(self,*x,**kwargs): pass
+  def warning(self,*x,**kwargs): pass
+  def error(self,*x,**kwargs): pass
+  def critical(self,*x,**kwargs): pass
+  def fatal(self,*x,**kwargs):pass
+
+#=================================================================================================================
+class StringLogger(FakeLogger):
+  def __init__(self):
+    super(StringLogger, self).__init__()
+    self.messages = []
+  def log(self,*x,**kwargs):
+    message = self.createLogMessage(*x)
+    self.messages.append(message)
+  def getMessages(self):
+    log = '\n'.join(self.messages)
+    self.messages = []
+    return log
+
+
+#=================================================================================================================
+# logging routines
+
+#-----------------------------------------------------------------------------------------------------------------
+def setupLoggingHandlers(logger, config):
+  stderrLog = logging.StreamHandler()
+  stderrLog.setLevel(config.stderrErrorLoggingLevel)
+  stderrLogFormatter = logging.Formatter(config.stderrLineFormatString)
+  stderrLog.setFormatter(stderrLogFormatter)
+  logger.addHandler(stderrLog)
+
+  syslog = logging.handlers.SysLogHandler(facility=config.syslogFacilityString)
+  syslog.setLevel(config.syslogErrorLoggingLevel)
+  syslogFormatter = logging.Formatter(config.syslogLineFormatString)
+  syslog.setFormatter(syslogFormatter)
+  logger.addHandler(syslog)
+
+#-----------------------------------------------------------------------------------------------------------------
+def echoConfig(logger, config):
+  logger.info("current configuration:")
+  for value in str(config).split('\n'):
+    logger.info('%s', value)
+
+#-----------------------------------------------------------------------------------------------------------------
+loggingReportLock = threading.RLock()
+
+#-----------------------------------------------------------------------------------------------------------------
+def reportExceptionAndContinue(logger=FakeLogger(), loggingLevel=logging.ERROR, ignoreFunction=None, showTraceback=True):
+  try:
+    exceptionType, exception, tracebackInfo = sys.exc_info()
+    if ignoreFunction and ignoreFunction(exceptionType, exception, tracebackInfo):
+      return
+    if exceptionType in (KeyboardInterrupt, SystemExit):
+      raise  exception
+    loggingReportLock.acquire()   #make sure these multiple log entries stay together
+    try:
+      logger.log(loggingLevel, "Caught Error: %s", exceptionType)
+      logger.log(loggingLevel, str(exception))
+      if showTraceback:
+        logger.log(loggingLevel, "trace back follows:")
+        for aLine in traceback.format_exception(exceptionType, exception, tracebackInfo):
+          logger.log(loggingLevel, aLine.strip())
+    finally:
+      loggingReportLock.release()
+  except Exception, x:
+    print >>sys.stderr, x
+
+#-----------------------------------------------------------------------------------------------------------------
+def reportExceptionAndAbort(logger, showTraceback=True):
+  reportExceptionAndContinue(logger, logging.CRITICAL, showTraceback=showTraceback)
+  logger.critical("cannot continue - quitting")
+  raise SystemExit
+
+#=================================================================================================================
+# utilities
+#-----------------------------------------------------------------------------------------------------------------
+def emptyFilter(x):
+  return (x, None)[x==""]
+
+#-----------------------------------------------------------------------------------------------------------------
+def limitStringOrNone(aString, maxLength):
+  try:
+    return aString[:maxLength]
+  except TypeError:
+    return None
+
+#-----------------------------------------------------------------------------------------------------------------
+def lookupLimitedStringOrNone(aDict, aKey, maxLength):
+  try:
+    return limitStringOrNone(aDict[aKey], maxLength)
+  except KeyError:
+    return None
+
+#-----------------------------------------------------------------------------------------------------------------
+def lookupStringOrEmptyString(aDict, aKey):
+  try:
+    return aDict[aKey]
+  except KeyError:
+    return ''
+
+#-----------------------------------------------------------------------------------------------------------------
+def backoffSecondsGenerator():
+  seconds = [10, 30, 60, 120, 300]
+  for x in seconds:
+    yield x
+  while True:
+    yield seconds[-1]
+
+#=================================================================================================================
+class DotDict(dict):
+  __getattr__= dict.__getitem__
+  __setattr__= dict.__setitem__
+  __delattr__= dict.__delitem__
+
+#=================================================================================================================
+class CachingIterator(object):
+  #-----------------------------------------------------------------------------------------------------------------
+  def __init__(self, anIterator):
+    self.theIterator = anIterator
+    self.cache = []
+    self.secondaryLimitedSizeCache = collections.deque()
+    self.secondaryCacheMaximumSize = 11
+    self.secondaryCacheSize = 0
+    self.useSecondary = False
+  #-----------------------------------------------------------------------------------------------------------------
+  def close(self):
+    self.theIterator.close()
+  #-----------------------------------------------------------------------------------------------------------------
+  def __iter__(self):
+    #try:  #to be used in Python 2.5 or greater
+      for x in self.theIterator:
+        if self.useSecondary:
+          if self.secondaryCacheSize == self.secondaryCacheMaximumSize:
+            self.secondaryLimitedSizeCache.popleft()
+            self.secondaryLimitedSizeCache.append(x)
+          else:
+            self.secondaryLimitedSizeCache.append(x)
+            self.secondaryCacheSize += 1
+        else:
+          self.cache.append(x)
+        yield x
+    #finally:
+    #  self.stopUsingSecondaryCache()
+  #-----------------------------------------------------------------------------------------------------------------
+  def useSecondaryCache(self):
+    self.useSecondary = True
+  #-----------------------------------------------------------------------------------------------------------------
+  def stopUsingSecondaryCache(self):
+    self.useSecondary = False
+    self.cache.extend(self.secondaryLimitedSizeCache)
+    self.secondaryCacheSize = 0
+    self.secondaryLimitedSizeCache = collections.deque()
+
+#=================================================================================================================
+class StrCachingIterator(CachingIterator):
+  #-----------------------------------------------------------------------------------------------------------------
+  def __init__(self, anIterator):
+    super(StrCachingIterator, self).__init__(anIterator)
+  #-----------------------------------------------------------------------------------------------------------------
+  def __iter__(self):
+    #try:  #to be used in Python 2.5 or greater
+      for x in self.theIterator:
+        y = repr(x)[1:-3]  #warning expecting a '\n' on the end of every line
+        if self.useSecondary:
+          if self.secondaryCacheSize == self.secondaryCacheMaximumSize:
+            self.secondaryLimitedSizeCache.popleft()
+            self.secondaryLimitedSizeCache.append(y)
+          else:
+            self.secondaryLimitedSizeCache.append(y)
+            self.secondaryCacheSize += 1
+        else:
+          self.cache.append(y)
+        yield y
+    #finally:
+    #  self.stopUsingSecondaryCache()
+
+#-----------------------------------------------------------------------------------------------------------------
+import signal
+# Don't know why this isn't available by importing signal, but not.
+signalNameFromNumberMap = dict( ( (getattr(signal,x),x) for x in dir(signal) if (x.startswith('SIG') and not x.startswith('SIG_')) ) )
+

--- a/socorro/lib/ver_tools.py
+++ b/socorro/lib/ver_tools.py
@@ -1,0 +1,173 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""A function and supporting structure to turn Mozilla version strings into
+a sortable normalized format.
+
+Pubic Functions:
+
+normalize - given a version in a string, this function returns a list of
+            normalized version parts of the abcd format outlined in
+            https://developer.mozilla.org/en/Toolkit_version_format
+            Two lists are comparable using standard relational operators:
+            <,>,!=,==, etc.
+
+compare - an old style __cmp__ comparitor for two version strings
+
+denormalize - the opposite of normalize.  Given a list in the format returned
+              by the normalize function, this function turns it back into
+              a string representation
+"""
+
+import re
+import itertools
+
+# got a better memoizer?  feel free to replace...
+def _memoizeArgsOnly (max_cache_size=1000):
+    """Python 2.4 compatible memoize decorator.
+    It creates a cache that has a maximum size.  If the cache exceeds the max,
+    it is thrown out and a new one made.  With such behavior, it is wise to set
+    the cache just a little larger that the maximum expected need.
+
+    Parameters:
+      max_cache_size - the size to which a cache can grow
+
+    Limitations:
+      The cache works only on args, not kwargs
+    """
+    def wrapper (f):
+        def fn (*args):
+            try:
+                return fn.cache[args]
+            except KeyError:
+                if fn.count >= max_cache_size:
+                    fn.cache = {}
+                    fn.count = 0
+                fn.cache[args] = result = f(*args)
+                fn.count += 1
+                return result
+        fn.cache = {}
+        fn.count = 0
+        return fn
+    return wrapper
+memoize = _memoizeArgsOnly  # to allow for easy replacement of the memoize
+                            # decorator used below
+
+# a regular expression to match the 'abcd' format defined in
+# https://developer.mozilla.org/en/Toolkit_version_format
+_version_part_re = re.compile("(\d*)([a-zA-Z]*)(\d*)([a-zA-Z]*)$")
+
+# the alphabetic parts of a version string should sort to the high end if
+# missing.  This allows version '3.6' to sort as greater than '3.6b1'
+# set to a high value greater than any expected string fragment to
+# be found in a real version string
+_padding_high_string = 'zzzzzz'
+
+# Mozilla versions consist of repeating 4-tuples in the pattern of
+# int, string, int, string.  Because the output of the normalize
+# function is a list and lists when compared for equailty must be of the
+# same length, this list is used as an extension to any normalized
+# version lists that are shorter than a standard.  See the max_version_parts
+# parameter of the normalize function for the length.
+_padding_list = [0, _padding_high_string, 0, _padding_high_string]
+
+# Conversion of the 4-tuples to numeric or lexically comparable values
+# are handled with some helper functions.  Missing numbers are to sort
+# low, while missing strings are to sort high.
+def _str_to_int(x):
+    """given a string, this function converts to an int"""
+    if x == None or x == '':
+        return 0
+    return int(x)
+
+def _str_to_high_str(x):
+    """given a string, this funtion converts the special values '' and None
+    to the special value 'zzzzzz'.  This is used to insure empty values have
+    a high sort order"""
+    if x == None or x == '':
+        return _padding_high_string
+    return x
+
+# this function does the opposite of the previous two.  Given ints or
+# strings, it returns the null string for zero ints and the _padding_high_string
+def _convert_to_str(x):
+    if x == 0 or x == _padding_high_string:
+        return ''
+    return str(x)
+
+# corresponding to the int, string, int, string pattern of the 4-tuple
+# this tuple allows the groups found by a regular expression to be
+# conveniently converted.
+_normalize_fn_list = (_str_to_int, _str_to_high_str,
+                      _str_to_int, _str_to_high_str)
+
+# for converstion the other way
+_denormalize_fn_list = (_convert_to_str, _convert_to_str,
+                        _convert_to_str, _convert_to_str)
+
+class NotAVersionException(Exception):
+    """An exception raised by the class VersionComparer if given a string
+    outside the standards of a version string as specified by the regular
+    expression _version_part_re"""
+    pass
+
+@memoize(1000)
+def normalize(version_string, max_version_parts=4):
+    """turn a string representing a version into a normalized version list.
+    Version lists are directly comparable using standard operators such as
+    >, <, ==, etc.
+
+    Parameters:
+      version_string - such as '3.5' or '3.6.3plugin3'
+      max_version_parts - version strings are comprised of a series of 4 tuples.
+                          This should be set to the maximum number of 4 tuples
+                          in a version string.
+    """
+    version_list = []
+    for part_count, version_part in enumerate(version_string.split('.')):
+        try:
+            groups = _version_part_re.match(version_part).groups()
+        except Exception, x:
+            raise NotAVersionException(version_string)
+        version_list.extend(t(x) for x, t in zip(groups, _normalize_fn_list))
+    version_list.extend(_padding_list * (max_version_parts - part_count - 1))
+    return version_list
+
+@memoize(1000)
+def _do_denormalize (version_tuple):
+    """separate action function to allow for the memoize decorator.  Lists,
+    the most common thing passed in to the 'denormalize' below are not hashable.
+    """
+    version_parts_list = []
+    for parts_tuple in itertools.imap(None,*([iter(version_tuple)]*4)):
+        version_part = ''.join(fn(x) for fn, x in
+                               zip(_denormalize_fn_list, parts_tuple))
+        if version_part:
+            version_parts_list.append(version_part)
+    return '.'.join(version_parts_list)
+
+def denormalize (version_list):
+    """the opposite of the normalize function.  Given a tuple representing a
+    normalized version, return a single minimal length string equivalent.
+    Because of the ambiguities of zero valued numeric parts, this function
+    may return a string shorter than the one that was originally normalized.
+    As it says in https://developer.mozilla.org/en/Toolkit_version_format,
+    3 == 3. == 3.0 == 3.0.0
+
+    Parameters:
+        version_list - a list of the form [int, str, int, str]+
+    """
+    return _do_denormalize (tuple(version_list))
+
+@memoize(1000)
+def compare (v1, v2):
+    """old style __cmp__ function returning -1, 0, 1"""
+    v1_norm = normalize(v1)
+    v2_norm = normalize(v2)
+    if v1_norm < v2_norm:
+        return -1
+    if v1_norm > v2_norm:
+        return 1
+    return 0
+

--- a/socorro/middleware/middleware_app.py
+++ b/socorro/middleware/middleware_app.py
@@ -16,8 +16,8 @@ import time
 import web
 import ujson
 
-from socorrolib.app.generic_app import App, main
-from socorrolib.lib import (
+from socorro.app.generic_app import App, main
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     ResourceNotFound,

--- a/socorro/middleware/search_common.py
+++ b/socorro/middleware/search_common.py
@@ -9,12 +9,12 @@ Common functions for search-related external modules.
 import datetime
 import json
 
-from socorrolib.lib import (
+from socorro.lib import (
     BadArgumentError,
     MissingArgumentError,
     datetimeutil,
 )
-import socorrolib.lib.external_common as extern
+import socorro.lib.external_common as extern
 
 
 """Operators description:

--- a/socorro/processor/breakpad_pipe_to_json.py
+++ b/socorro/processor/breakpad_pipe_to_json.py
@@ -66,7 +66,7 @@ dump into a json format.
 }
 """
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 
 #==============================================================================

--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -11,10 +11,10 @@ from collections import Mapping
 from configman import Namespace
 from configman.dotdict import DotDict as ConfigmanDotDict
 
-from socorrolib.lib.converters import change_default
+from socorro.lib.converters import change_default
 
-from socorrolib.lib.util import DotDict
-from socorrolib.lib.transform_rules import Rule
+from socorro.lib.util import DotDict
+from socorro.lib.transform_rules import Rule
 
 
 #------------------------------------------------------------------------------

--- a/socorro/processor/general_transform_rules.py
+++ b/socorro/processor/general_transform_rules.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from socorrolib.lib.transform_rules import Rule
+from socorro.lib.transform_rules import Rule
 
 
 #==============================================================================

--- a/socorro/processor/hybrid_processor.py
+++ b/socorro/processor/hybrid_processor.py
@@ -20,15 +20,15 @@ import gzip
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.external.postgresql.dbapi2_util import (
     execute_query_fetchall,
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorrolib.lib.transform_rules import TransformRuleSystem
-from socorrolib.lib.datetimeutil import datetimeFromISOdateString, UTC
-from socorrolib.lib.ooid import dateFromOoid
-from socorrolib.lib.util import (
+from socorro.lib.transform_rules import TransformRuleSystem
+from socorro.lib.datetimeutil import datetimeFromISOdateString, UTC
+from socorro.lib.ooid import dateFromOoid
+from socorro.lib.util import (
     DotDict,
     emptyFilter,
     CachingIterator
@@ -185,7 +185,7 @@ class HybridCrashProcessor(RequiredConfig):
     required_config.namespace('statistics')
     required_config.statistics.add_option(
         'stats_class',
-        default='socorrolib.lib.statistics.StatisticsForStatsd',
+        default='socorro.lib.statistics.StatisticsForStatsd',
         doc='name of a class that will gather statistics',
         from_string_converter=class_converter
     )

--- a/socorro/processor/legacy_new_crash_source.py
+++ b/socorro/processor/legacy_new_crash_source.py
@@ -11,7 +11,7 @@ from socorro.external.postgresql.dbapi2_util import (
     single_value_sql
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 
 
 #==============================================================================

--- a/socorro/processor/legacy_processor.py
+++ b/socorro/processor/legacy_processor.py
@@ -16,16 +16,16 @@ from contextlib import closing, contextmanager
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.external.postgresql.dbapi2_util import (
     execute_no_results,
     execute_query_fetchall,
 )
 from socorro.external.postgresql.connection_context import ConnectionContext
-from socorrolib.lib.transform_rules import TransformRuleSystem
-from socorrolib.lib.datetimeutil import datetimeFromISOdateString, UTC
-from socorrolib.lib.ooid import dateFromOoid
-from socorrolib.lib.util import (
+from socorro.lib.transform_rules import TransformRuleSystem
+from socorro.lib.datetimeutil import datetimeFromISOdateString, UTC
+from socorro.lib.ooid import dateFromOoid
+from socorro.lib.util import (
     DotDict,
     emptyFilter,
     StrCachingIterator
@@ -199,7 +199,7 @@ class LegacyCrashProcessor(RequiredConfig):
     required_config.namespace('statistics')
     required_config.statistics.add_option(
         'stats_class',
-        default='socorrolib.lib.statistics.StatisticsForStatsd',
+        default='socorro.lib.statistics.StatisticsForStatsd',
         doc='name of a class that will gather statistics',
         from_string_converter=class_converter
     )

--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -2,7 +2,7 @@ import ujson
 from configman import Namespace
 
 from socorro.processor.processor_2015 import Processor2015
-from socorrolib.lib.converters import change_default
+from socorro.lib.converters import change_default
 
 #------------------------------------------------------------------------------
 # these are the steps that define processing a crash at Mozilla.
@@ -13,7 +13,7 @@ mozilla_processor_rule_sets = [
     [   # rules to change the internals of the raw crash
         "raw_transform",
         "processor.json_rewrite",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.mozilla_transform_rules.ProductRewrite,"
         "socorro.processor.mozilla_transform_rules.ESRVersionRewrite,"
@@ -25,7 +25,7 @@ mozilla_processor_rule_sets = [
     [   # rules to transform a raw crash into a processed crash
         "raw_to_processed_transform",
         "processer.raw_to_processed",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.general_transform_rules.IdentifierRule, "
         "socorro.processor.breakpad_transform_rules"
@@ -43,7 +43,7 @@ mozilla_processor_rule_sets = [
     [   # post processing of the processed crash
         "processed_transform",
         "processer.processed",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.breakpad_transform_rules.CrashingThreadRule, "
         "socorro.processor.general_transform_rules.CPUInfoRule, "
@@ -68,7 +68,7 @@ mozilla_processor_rule_sets = [
     [   # a set of classifiers for support
         "support_classifiers",
         "processor.support_classifiers",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_until_action_succeeds",
         "socorro.processor.support_classifiers.BitguardClassifier, "
         "socorro.processor.support_classifiers.OutOfDateClassifier"
@@ -76,7 +76,7 @@ mozilla_processor_rule_sets = [
     [   # a set of classifiers to help with jit crashes
         "jit_classifiers",
         "processor.jit_classifiers",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.breakpad_transform_rules.JitCrashCategorizeRule, "
         "socorro.processor.signature_utilities.SignatureJitCategory, "
@@ -84,7 +84,7 @@ mozilla_processor_rule_sets = [
     [   # a set of special request classifiers
         "skunk_classifiers",
         "processor.skunk_classifiers",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_until_action_succeeds",
         "socorro.processor.skunk_classifiers.DontConsiderTheseFilter, "
         # currently not in use, anticipated to be re-enabled in the future

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -18,14 +18,14 @@ from configman.converters import (
     str_to_python_object,
 )
 
-from socorrolib.lib.ooid import dateFromOoid
-from socorrolib.lib.transform_rules import Rule
-from socorrolib.lib.datetimeutil import (
+from socorro.lib.ooid import dateFromOoid
+from socorro.lib.transform_rules import Rule
+from socorro.lib.datetimeutil import (
     UTC,
     datetimeFromISOdateString,
     datestring_to_weekly_partition
 )
-from socorrolib.lib.context_tools import temp_file_context
+from socorro.lib.context_tools import temp_file_context
 
 from socorro.external.postgresql.dbapi2_util import (
     execute_query_fetchall,

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -14,9 +14,9 @@ from configman.dotdict import DotDict as OrderedDotDict
 from configman.converters import (
     str_to_python_object,
 )
-from socorrolib.lib.converters import str_to_classes_in_namespaces_converter
-from socorrolib.lib.datetimeutil import utc_now
-from socorrolib.lib.util import DotDict
+from socorro.lib.converters import str_to_classes_in_namespaces_converter
+from socorro.lib.datetimeutil import utc_now
+from socorro.lib.util import DotDict
 
 
 # Rule sets are defined as lists of lists (or tuples).  As they will be loaded
@@ -37,26 +37,26 @@ from socorrolib.lib.util import DotDict
 #    rule list: a comma delimited list of fully qualified class names that
 #               implement the individual transformation rules.  The API that
 #               these classes must conform to is defined by the rule base class
-#               socorrolib.lib.transform_rules.Rule
+#               socorro.lib.transform_rules.Rule
 default_rule_set = [
     [   # rules to change the internals of the raw crash
         "raw_transform",  # name of the rule
         "processor.json_rewrite",  # a tag in a dotted-form
-        "socorrolib.lib.transform_rules.TransformRuleSystem",  # rule set class
+        "socorro.lib.transform_rules.TransformRuleSystem",  # rule set class
         "apply_all_rules",  # rule set class method to apply rules
         ""  # comma delimited list of fully qualified rule class names
     ],
     [   # rules to transform a raw crash into a processed crash
         "raw_to_processed_transform",
         "processer.raw_to_processed",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         ""
     ],
     [   # post processing of the processed crash
         "processed_transform",
         "processer.processed",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         ""
     ],

--- a/socorro/processor/processor_app.py
+++ b/socorro/processor/processor_app.py
@@ -13,12 +13,12 @@ import raven
 from configman import Namespace
 from configman.converters import class_converter
 
-from socorrolib.app.fetch_transform_save_app import (
+from socorro.app.fetch_transform_save_app import (
     FetchTransformSaveWithSeparateNewCrashSourceApp,
     main
 )
 from socorro.external.crashstorage_base import CrashIDNotFound
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.external.fs.crashstorage import FSDatedPermanentStorage
 
 

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -10,7 +10,7 @@ from itertools import islice
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
 
-from socorrolib.lib.transform_rules import Rule
+from socorro.lib.transform_rules import Rule
 
 from socorro import siglists
 

--- a/socorro/processor/skunk_classifiers.py
+++ b/socorro/processor/skunk_classifiers.py
@@ -55,8 +55,8 @@ import datetime
 from configman import Namespace, class_converter
 from configman.converters import arbitrary_object_to_string
 
-from socorrolib.lib.util import DotDict
-from socorrolib.lib.transform_rules import Rule
+from socorro.lib.util import DotDict
+from socorro.lib.transform_rules import Rule
 
 
 #==============================================================================

--- a/socorro/processor/socorrolite_processor_2015.py
+++ b/socorro/processor/socorrolite_processor_2015.py
@@ -1,7 +1,7 @@
 import ujson
 
 from socorro.processor.processor_2015 import Processor2015
-from socorrolib.lib.converters import change_default
+from socorro.lib.converters import change_default
 
 from configman import Namespace
 
@@ -14,14 +14,14 @@ socorrolite_processor_rule_sets = [
     [   # rules to change the internals of the raw crash
         "raw_transform",
         "processor.json_rewrite",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         ""
     ],
     [   # rules to transform a raw crash into a processed crash
         "raw_to_processed_transform",
         "processer.raw_to_processed",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.general_transform_rules.IdentifierRule, "
         "socorro.processor.breakpad_transform_rules.BreakpadStackwalkerRule, "
@@ -30,7 +30,7 @@ socorrolite_processor_rule_sets = [
     [   # post processing of the processed crash
         "processed_transform",
         "processer.processed",
-        "socorrolib.lib.transform_rules.TransformRuleSystem",
+        "socorro.lib.transform_rules.TransformRuleSystem",
         "apply_all_rules",
         "socorro.processor.breakpad_transform_rules.CrashingThreadRule, "
         "socorro.processor.signature_utilities.SignatureGenerationRule,"

--- a/socorro/processor/support_classifiers.py
+++ b/socorro/processor/support_classifiers.py
@@ -22,9 +22,9 @@ the support classifcation rules live here.
 from configman import Namespace
 from configman.converters import to_str
 
-from socorrolib.lib.ver_tools import normalize
-from socorrolib.lib.util import DotDict
-from socorrolib.lib.transform_rules import Rule
+from socorro.lib.ver_tools import normalize
+from socorro.lib.util import DotDict
+from socorro.lib.transform_rules import Rule
 
 from sys import maxint
 

--- a/socorro/processor/timemachine.py
+++ b/socorro/processor/timemachine.py
@@ -7,9 +7,9 @@
 
 from datetime import timedelta, datetime
 
-from socorrolib.lib.transform_rules import Rule
+from socorro.lib.transform_rules import Rule
 from socorro.external.postgresql.dbapi2_util import execute_query_fetchall
-from socorrolib.lib.datetimeutil import string_to_datetime, date_to_string
+from socorro.lib.datetimeutil import string_to_datetime, date_to_string
 
 from configman import Namespace, RequiredConfig, class_converter
 from configman.converters import str_to_timedelta, to_str

--- a/socorro/unittest/app/test_for_application_defaults.py
+++ b/socorro/unittest/app/test_for_application_defaults.py
@@ -1,0 +1,110 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_, ok_
+
+from configman import class_converter
+from configman.dotdict import DotDict
+
+from socorro.unittest.testbase import TestCase
+from socorro.app.for_application_defaults import (
+    ApplicationDefaultsProxy,
+    ValueSource,
+)
+from socorro.app.socorro_app import App
+
+
+#==============================================================================
+# for use in a later test
+class SomeApp(App):
+    @classmethod
+    def get_application_defaults(klass):
+        defaults = DotDict()
+        defaults.alpha = 17
+        defaults.beta = 23
+        return defaults
+
+
+#==============================================================================
+class TestApplicationDefaultsProxy(TestCase):
+
+    def setUp(self):
+        self.proxy = ApplicationDefaultsProxy()
+
+    def test_app_converter(self):
+        # temp shim, cannot load the socorro classes to test
+        #eq_(
+        #   self.proxy.str_to_application_class('collector'),
+        #   class_converter('socorro.collector.collector_app.CollectorApp')
+        #)
+        #eq_(
+        #   self.proxy.str_to_application_class('crashmover'),
+        #   class_converter('socorro.collector.crashmover_app.CrashMoverApp')
+        #)
+        #eq_(
+        #   self.proxy.str_to_application_class('submitter'),
+        #   class_converter('socorro.collector.submitter_app.SubmitterApp')
+        #)
+        #eq_(
+            #self.proxy.str_to_application_class('crontabber'),
+            #class_converter('socorro.cron.crontabber_app.CronTabberApp')
+        #)
+        #eq_(
+        #   self.proxy.str_to_application_class('middleware'),
+        #  class_converter('socorro.middleware.middleware_app.MiddlewareApp')
+        #)
+        #eq_(
+        #    self.proxy.str_to_application_class('processor'),
+        #    class_converter('socorro.processor.processor_app.ProcessorApp')
+        #)
+        #eq_(
+        #    self.proxy.str_to_application_class(
+        #        'socorro.external.hb.hbase_client.HBaseClientApp'
+        #    ),
+        #  class_converter('socorro.external.hb.hbase_client.HBaseClientApp')
+        #)
+        pass
+
+    def test_application_defaults(self):
+        new_proxy = ApplicationDefaultsProxy()
+        eq_(new_proxy.application_defaults, DotDict())
+
+        new_proxy.str_to_application_class(
+            'socorro.unittest.app.test_for_application_defaults.SomeApp'
+        )
+
+        eq_(
+            dict(new_proxy.application_defaults),
+            {
+                'alpha': 17,
+                'beta': 23,
+            }
+        )
+
+
+#==============================================================================
+class TestValueSource(TestCase):
+
+    def test_get_values(self):
+        new_proxy = ApplicationDefaultsProxy()
+        vs = ValueSource(new_proxy)
+        eq_(
+            vs.get_values(None, None, dict),
+            {}
+        )
+        eq_(
+            vs.get_values(None, None, DotDict),
+            DotDict()
+        )
+        new_proxy.str_to_application_class(
+            'socorro.unittest.app.test_for_application_defaults.SomeApp'
+        )
+        eq_(
+            vs.get_values(None, None, dict),
+            {
+                'alpha': 17,
+                'beta': 23,
+            }
+        )
+        ok_(isinstance(vs.get_values(None, None, DotDict), DotDict))

--- a/socorro/unittest/app/test_generic_app.py
+++ b/socorro/unittest/app/test_generic_app.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from types import FunctionType
+
+from nose.tools import eq_, ok_
+
+from socorro.unittest.testbase import TestCase
+
+from socorro.app.generic_app import main
+from socorro.app.generic_app import App
+
+from socorro.app.socorro_app import SocorroApp
+from socorro.app.socorro_app import App as SApp
+
+
+#==============================================================================
+class TestGenericAppModule(TestCase):
+
+    def test_exsistance(self):
+        ok_(issubclass(App, SocorroApp))
+        eq_(App, SApp)
+        ok_(isinstance(main, FunctionType))

--- a/socorro/unittest/app/test_generic_fetch_transform_save_app.py
+++ b/socorro/unittest/app/test_generic_fetch_transform_save_app.py
@@ -1,0 +1,308 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_, ok_, assert_raises
+from mock import Mock
+
+from socorro.app.fetch_transform_save_app import FetchTransformSaveApp
+from socorro.lib.threaded_task_manager import ThreadedTaskManager
+from socorro.lib.task_manager import TaskManager
+from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.unittest.testbase import TestCase
+
+
+class TestFetchTransformSaveApp(TestCase):
+
+    def test_bogus_source_iter_and_worker(self):
+        class TestFTSAppClass(FetchTransformSaveApp):
+            def __init__(self, config):
+                super(TestFTSAppClass, self).__init__(config)
+                self.the_list = []
+
+            def _setup_source_and_destination(self):
+                self.source = Mock()
+                self.destination = Mock()
+                pass
+
+            def _create_iter(self):
+                for x in xrange(5):
+                    yield ((x,), {})
+
+            def transform(self, anItem):
+                self.the_list.append(anItem)
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'number_of_submissions': 'all',
+          'source': DotDict({'crashstorage_class': None}),
+          'destination': DotDict({'crashstorage_class': None}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          TaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = TestFTSAppClass(config)
+        fts_app.main()
+        ok_(len(fts_app.the_list) == 5,
+                        'expected to do 5 inserts, '
+                          'but %d were done instead' % len(fts_app.the_list))
+        ok_(sorted(fts_app.the_list) == range(5),
+                        'expected %s, but got %s' % (range(5),
+                                                     sorted(fts_app.the_list)))
+
+    def test_bogus_source_and_destination(self):
+        class NonInfiniteFTSAppClass(FetchTransformSaveApp):
+            def _basic_iterator(self):
+                for x in self.source.new_crashes():
+                    yield ((x,), {})
+
+        class FakeStorageSource(object):
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict({'1234': DotDict({'ooid': '1234',
+                                                       'Product': 'FireSquid',
+                                                       'Version': '1.0'}),
+                                      '1235': DotDict({'ooid': '1235',
+                                                       'Product': 'ThunderRat',
+                                                       'Version': '1.0'}),
+                                      '1236': DotDict({'ooid': '1236',
+                                                       'Product': 'Caminimal',
+                                                       'Version': '1.0'}),
+                                      '1237': DotDict({'ooid': '1237',
+                                                       'Product': 'Fennicky',
+                                                       'Version': '1.0'}),
+                                     })
+                self.number_of_close_calls = 0
+
+            def get_raw_crash(self, ooid):
+                return self.store[ooid]
+
+            def get_raw_dumps(self, ooid):
+                return {'upload_file_minidump': 'this is a fake dump'}
+
+            def new_crashes(self):
+                for k in self.store.keys():
+                    yield k
+
+            def close(self):
+                self.number_of_close_calls += 1
+
+        class FakeStorageDestination(object):
+
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict()
+                self.dumps = DotDict()
+                self.number_of_close_calls = 0
+
+            def save_raw_crash(self, raw_crash, dump, crash_id):
+                self.store[crash_id] = raw_crash
+                self.dumps[crash_id] = dump
+
+            def close(self):
+                self.number_of_close_calls += 1
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'number_of_submissions': 'all',
+          'source': DotDict({'crashstorage_class':
+                                 FakeStorageSource}),
+          'destination': DotDict({'crashstorage_class':
+                                     FakeStorageDestination}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = NonInfiniteFTSAppClass(config)
+        fts_app.main()
+
+        source = fts_app.source
+        destination = fts_app.destination
+
+        eq_(source.store, destination.store)
+        eq_(len(destination.dumps), 4)
+        eq_(destination.dumps['1237'],
+                         source.get_raw_dumps('1237'))
+        # ensure that each storage system had its close called
+        eq_(source.number_of_close_calls, 1)
+        eq_(destination.number_of_close_calls, 1)
+
+
+    def test_source_iterator(self):
+
+        faked_finished_func =  Mock()
+
+        class FakeStorageSource(object):
+
+            def __init__(self):
+                self.first = True
+
+            def new_crashes(self):
+                if self.first:
+                    # make the iterator act as if exhausted on the very
+                    # first try
+                    self.first = False
+                else:
+                    for k in range(999):
+                        # ensure that both forms (a single value or the
+                        # (args, kwargs) form are accepted.)
+                        if k % 4:
+                            yield k
+                        else:
+                            yield (
+                                (k, ),
+                                {"finished_func": faked_finished_func}
+                            )
+                    for k in range(2):
+                        yield None
+
+        class FakeStorageDestination(object):
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict()
+                self.dumps = DotDict()
+
+            def save_raw_crash(self, raw_crash, dump, crash_id):
+                self.store[crash_id] = raw_crash
+                self.dumps[crash_id] = dump
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'number_of_submissions': 'forever',
+          'source': DotDict({'crashstorage_class':
+                                 FakeStorageSource}),
+          'destination': DotDict({'crashstorage_class':
+                                     FakeStorageDestination}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = FetchTransformSaveApp(config)
+        fts_app.source = FakeStorageSource()
+        fts_app.destination = FakeStorageDestination
+        error_detected = False
+        no_finished_function_counter = 0
+        for x, y in zip(xrange(1002), (a for a in fts_app.source_iterator())):
+            if x == 0:
+                # the iterator is exhausted on the 1st try and should have
+                # yielded a None before starting over
+                ok_(y is None)
+            elif x < 1000:
+                if x - 1 != y[0][0] and not error_detected:
+                    error_detected = True
+                    eq_(x, y,'iterator fails on iteration %d: %s' % (x, y))
+                # invoke that finished func to ensure that we've got the
+                # right object
+                try:
+                    y[1]['finished_func']()
+                except KeyError:
+                    no_finished_function_counter += 1
+            else:
+                if y is not None and not error_detected:
+                    error_detected = True
+                    ok_(x is None, 'iterator fails on iteration %d: %s' % (x, y))
+        eq_(faked_finished_func.call_count, 999 - no_finished_function_counter)
+
+    def test_no_source(self):
+
+        class FakeStorageDestination(object):
+
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict()
+                self.dumps = DotDict()
+
+            def save_raw_crash(self, raw_crash, dump, crash_id):
+                self.store[crash_id] = raw_crash
+                self.dumps[crash_id] = dump
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'number_of_submissions': 'forever',
+          'source': DotDict({'crashstorage_class':
+                                 None}),
+          'destination': DotDict({'crashstorage_class':
+                                     FakeStorageDestination}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+        })
+
+        fts_app = FetchTransformSaveApp(config)
+
+        assert_raises(TypeError, fts_app.main)
+
+    def test_no_destination(self):
+        class FakeStorageSource(object):
+            def __init__(self, config, quit_check_callback):
+                self.store = DotDict({'1234': DotDict({'ooid': '1234',
+                                                       'Product': 'FireSquid',
+                                                       'Version': '1.0'}),
+                                      '1235': DotDict({'ooid': '1235',
+                                                       'Product': 'ThunderRat',
+                                                       'Version': '1.0'}),
+                                      '1236': DotDict({'ooid': '1236',
+                                                       'Product': 'Caminimal',
+                                                       'Version': '1.0'}),
+                                      '1237': DotDict({'ooid': '1237',
+                                                       'Product': 'Fennicky',
+                                                       'Version': '1.0'}),
+                                     })
+
+            def get_raw_crash(self, ooid):
+                return self.store[ooid]
+
+            def get_raw_dump(self, ooid):
+                return 'this is a fake dump'
+
+            def new_ooids(self):
+                for k in self.store.keys():
+                    yield k
+
+
+
+        logger = SilentFakeLogger()
+        config = DotDict({
+          'logger': logger,
+          'number_of_threads': 2,
+          'maximum_queue_size': 2,
+          'number_of_submissions': 'forever',
+          'source': DotDict({'crashstorage_class':
+                                 FakeStorageSource}),
+          'destination': DotDict({'crashstorage_class':
+                                     None}),
+          'producer_consumer': DotDict({'producer_consumer_class':
+                                          ThreadedTaskManager,
+                                        'logger': logger,
+                                        'number_of_threads': 1,
+                                        'maximum_queue_size': 1}
+                                      )
+
+        })
+
+        fts_app = FetchTransformSaveApp(config)
+
+        assert_raises(TypeError, fts_app.main)

--- a/socorro/unittest/app/test_socorro_app.py
+++ b/socorro/unittest/app/test_socorro_app.py
@@ -1,0 +1,192 @@
+import mock
+from nose.tools import eq_, ok_, assert_raises
+from socorro.unittest.testbase import TestCase
+
+from configman import (
+    class_converter,
+    Namespace,
+    command_line,
+    ConfigFileFutureProxy,
+)
+from configman.dotdict import DotDict
+
+from socorro.app.socorro_app import (
+    SocorroApp,
+    SocorroWelcomeApp,
+    main,
+    klass_to_pypath,
+)
+from socorro.app.for_application_defaults import ApplicationDefaultsProxy
+
+
+#==============================================================================
+class TestSocorroApp(TestCase):
+
+    #--------------------------------------------------------------------------
+    def test_instantiation(self):
+        config = DotDict()
+        sa = SocorroApp(config)
+
+        eq_(sa.get_application_defaults(), {})
+        assert_raises(NotImplementedError, sa.main)
+        assert_raises(NotImplementedError, sa._do_run)
+
+    #--------------------------------------------------------------------------
+    def test_run(self):
+        class SomeOtherApp(SocorroApp):
+            @classmethod
+            def _do_run(klass, config_path=None, values_source_list=None):
+                klass.config_path = config_path
+                return 17
+
+        eq_(SomeOtherApp._do_run(), 17)
+        ok_(SomeOtherApp.config_path is None)
+        x = SomeOtherApp.run()
+        eq_(x, 17)
+
+    #--------------------------------------------------------------------------
+    def test_run_with_alternate_config_path(self):
+        class SomeOtherApp(SocorroApp):
+            @classmethod
+            def _do_run(klass, config_path=None, values_source_list=None):
+                klass.values_source_list = values_source_list
+                klass.config_path = config_path
+                return 17
+
+        eq_(SomeOtherApp._do_run('my/path'), 17)
+        eq_(SomeOtherApp.config_path, 'my/path')
+        x = SomeOtherApp.run('my/other/path')
+        eq_(x, 17)
+        eq_(SomeOtherApp.config_path, 'my/other/path')
+
+    #--------------------------------------------------------------------------
+    def test_run_with_alternate_values_source_list(self):
+        class SomeOtherApp(SocorroApp):
+            @classmethod
+            def _do_run(klass, config_path=None, values_source_list=None):
+                klass.values_source_list = values_source_list
+                klass.config_path = config_path
+                return 17
+
+        eq_(SomeOtherApp._do_run('my/path', [{}, {}]), 17)
+        eq_(SomeOtherApp.config_path, 'my/path')
+        eq_(SomeOtherApp.values_source_list, [{}, {}])
+        x = SomeOtherApp.run('my/other/path', [])
+        eq_(x, 17)
+        eq_(SomeOtherApp.config_path, 'my/other/path')
+        eq_(SomeOtherApp.values_source_list, [])
+
+
+    #--------------------------------------------------------------------------
+    def test_do_run(self):
+        config = DotDict()
+        with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
+            cm.return_value.context.return_value = mock.MagicMock()
+            with mock.patch('socorro.app.socorro_app.signal') as s:
+                class SomeOtherApp(SocorroApp):
+                    app_name='SomeOtherApp'
+                    app_verision='1.2.3'
+                    app_description='a silly app'
+                    def main(self):
+                        ok_(
+                            self.config
+                            is cm.return_value.context.return_value.__enter__
+                                 .return_value
+                        )
+                        return 17
+
+                result = main(SomeOtherApp)
+                args = cm.call_args_list
+                args, kwargs = args[0]
+                ok_(isinstance(args[0], Namespace))
+                ok_(isinstance(kwargs['values_source_list'], list))
+                eq_(kwargs['app_name'], SomeOtherApp.app_name)
+                eq_(kwargs['app_version'], SomeOtherApp.app_version)
+                eq_(kwargs['app_description'], SomeOtherApp.app_description)
+                eq_(kwargs['config_pathname'], './config')
+                ok_(kwargs['values_source_list'][-1], command_line)
+                ok_(isinstance(kwargs['values_source_list'][-2], DotDict))
+                ok_(kwargs['values_source_list'][-3] is ConfigFileFutureProxy)
+                ok_(isinstance(
+                    kwargs['values_source_list'][0],
+                    ApplicationDefaultsProxy
+                ))
+                eq_(result, 17)
+
+    #--------------------------------------------------------------------------
+    def test_do_run_with_alternate_class_path(self):
+        config = DotDict()
+        with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
+            cm.return_value.context.return_value = mock.MagicMock()
+            with mock.patch('socorro.app.socorro_app.signal') as s:
+                class SomeOtherApp(SocorroApp):
+                    app_name='SomeOtherApp'
+                    app_verision='1.2.3'
+                    app_description='a silly app'
+                    def main(self):
+                        ok_(
+                            self.config
+                            is cm.return_value.context.return_value.__enter__
+                                 .return_value
+                        )
+                        return 17
+
+                result = main(SomeOtherApp, 'my/other/path')
+
+                args = cm.call_args_list
+                args, kwargs = args[0]
+                ok_(isinstance(args[0], Namespace))
+                ok_(isinstance(kwargs['values_source_list'], list))
+                eq_(kwargs['app_name'], SomeOtherApp.app_name)
+                eq_(kwargs['app_version'], SomeOtherApp.app_version)
+                eq_(kwargs['app_description'], SomeOtherApp.app_description)
+                eq_(kwargs['config_pathname'], 'my/other/path')
+                ok_(kwargs['values_source_list'][-1], command_line)
+                ok_(isinstance(kwargs['values_source_list'][-2], DotDict))
+                ok_(kwargs['values_source_list'][-3] is ConfigFileFutureProxy)
+                ok_(isinstance(
+                    kwargs['values_source_list'][0],
+                    ApplicationDefaultsProxy
+                ))
+                eq_(result, 17)
+
+
+    #--------------------------------------------------------------------------
+    def test_do_run_with_alternate_values_source_list(self):
+        config = DotDict()
+        with mock.patch('socorro.app.socorro_app.ConfigurationManager') as cm:
+            cm.return_value.context.return_value = mock.MagicMock()
+            with mock.patch('socorro.app.socorro_app.signal') as s:
+                class SomeOtherApp(SocorroApp):
+                    app_name='SomeOtherApp'
+                    app_verision='1.2.3'
+                    app_description='a silly app'
+                    def main(self):
+                        ok_(
+                            self.config
+                            is cm.return_value.context.return_value.__enter__
+                                 .return_value
+                        )
+                        return 17
+
+                result = main(
+                    SomeOtherApp,
+                    config_path='my/other/path',
+                    values_source_list=[{"a": 1}, {"b": 2}]
+                )
+
+                args = cm.call_args_list
+                args, kwargs = args[0]
+                ok_(isinstance(args[0], Namespace))
+                eq_(kwargs['app_name'], SomeOtherApp.app_name)
+                eq_(kwargs['app_version'], SomeOtherApp.app_version)
+                eq_(kwargs['app_description'], SomeOtherApp.app_description)
+                eq_(kwargs['config_pathname'], 'my/other/path')
+                ok_(isinstance(kwargs['values_source_list'], list))
+                ok_(isinstance(
+                    kwargs['values_source_list'][0],
+                    ApplicationDefaultsProxy
+                ))
+                eq_(kwargs['values_source_list'][1], {"a": 1})
+                eq_(kwargs['values_source_list'][2], {"b": 2})
+                eq_(result, 17)

--- a/socorro/unittest/collector/test_crash_mover_app.py
+++ b/socorro/unittest/collector/test_crash_mover_app.py
@@ -6,8 +6,8 @@ from nose.tools import eq_, ok_, assert_raises
 from mock import Mock
 
 from socorro.collector.crashmover_app import CrashMoverApp
-from socorrolib.lib.threaded_task_manager import ThreadedTaskManager
-from socorrolib.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.threaded_task_manager import ThreadedTaskManager
+from socorro.lib.util import DotDict, SilentFakeLogger
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/collector/test_throttler.py
+++ b/socorro/unittest/collector/test_throttler.py
@@ -5,7 +5,7 @@
 import re
 import mock
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.collector.throttler import (
   LegacyThrottler,
   ACCEPT,

--- a/socorro/unittest/cron/jobs/test_clean_missing_symbols.py
+++ b/socorro/unittest/cron/jobs/test_clean_missing_symbols.py
@@ -3,7 +3,7 @@ import datetime
 from nose.tools import eq_
 from crontabber.app import CronTabber
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,

--- a/socorro/unittest/cron/jobs/test_clean_raw_adi.py
+++ b/socorro/unittest/cron/jobs/test_clean_raw_adi.py
@@ -3,7 +3,7 @@ import datetime
 from nose.tools import eq_
 from crontabber.app import CronTabber
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,

--- a/socorro/unittest/cron/jobs/test_clean_raw_adi_logs.py
+++ b/socorro/unittest/cron/jobs/test_clean_raw_adi_logs.py
@@ -3,7 +3,7 @@ import datetime
 from nose.tools import eq_
 from crontabber.app import CronTabber
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,

--- a/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_automatic.py
@@ -10,7 +10,7 @@ from socorro.unittest.cron.setup_configman import (
 )
 
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.external.postgresql.dbapi2_util import (
     execute_no_results,

--- a/socorro/unittest/cron/jobs/test_featured_versions_sync.py
+++ b/socorro/unittest/cron/jobs/test_featured_versions_sync.py
@@ -10,7 +10,7 @@ from socorro.unittest.cron.setup_configman import (
 )
 
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 from socorro.external.postgresql.dbapi2_util import (
     execute_no_results,

--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -12,10 +12,10 @@ from nose.tools import eq_, ok_, assert_raises
 from crontabber.app import CronTabber
 from crontabber.tests.base import TestCaseBase
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.cron.jobs import ftpscraper
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,
 )

--- a/socorro/unittest/cron/jobs/test_matviews.py
+++ b/socorro/unittest/cron/jobs/test_matviews.py
@@ -7,7 +7,7 @@ from nose.tools import ok_
 
 from crontabber.app import CronTabber
 from crontabber import base
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 from socorro.cron.jobs import matviews

--- a/socorro/unittest/cron/jobs/test_modulelist.py
+++ b/socorro/unittest/cron/jobs/test_modulelist.py
@@ -12,7 +12,7 @@ from socorro.unittest.cron.jobs.base import IntegrationTestBase
 
 import datetime
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.unittest.cron.setup_configman import (
     get_config_manager_for_crontabber,
 )

--- a/socorro/unittest/cron/jobs/test_reprocessingjobs.py
+++ b/socorro/unittest/cron/jobs/test_reprocessingjobs.py
@@ -5,7 +5,7 @@
 from mock import Mock
 from nose.tools import eq_
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 from crontabber.app import CronTabber
 

--- a/socorro/unittest/cron/setup_configman.py
+++ b/socorro/unittest/cron/setup_configman.py
@@ -7,7 +7,7 @@ from mock import Mock
 from collections import Sequence
 
 from socorro.cron.crontabber_app import CronTabber
-from socorrolib.lib.util import SilentFakeLogger
+from socorro.lib.util import SilentFakeLogger
 from socorro.webapi.servers import WebServerBase
 
 from configman import (

--- a/socorro/unittest/external/boto/test_connection_context.py
+++ b/socorro/unittest/external/boto/test_connection_context.py
@@ -8,7 +8,7 @@ import json
 import mock
 from nose.tools import eq_
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.external.boto.connection_context import (
     DatePrefixKeyBuilder,
     SimpleDatePrefixKeyBuilder,

--- a/socorro/unittest/external/boto/test_crash_data.py
+++ b/socorro/unittest/external/boto/test_crash_data.py
@@ -6,7 +6,7 @@ from boto.exception import StorageResponseError
 
 from configman import ConfigurationManager
 
-from socorrolib.lib import MissingArgumentError
+from socorro.lib import MissingArgumentError
 from socorro.external.boto.crash_data import SimplifiedCrashData
 from socorro.external.crashstorage_base import CrashIDNotFound
 from socorro.unittest.testbase import TestCase

--- a/socorro/unittest/external/boto/test_crashstorage.py
+++ b/socorro/unittest/external/boto/test_crashstorage.py
@@ -35,7 +35,7 @@ from socorro.unittest.external.es.base import ElasticsearchTestCase
 from socorro.unittest.testbase import TestCase
 
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 # Uncomment these lines to decrease verbosity of the elasticsearch library
 # while running unit tests.

--- a/socorro/unittest/external/es/test_analyzers.py
+++ b/socorro/unittest/external/es/test_analyzers.py
@@ -4,7 +4,7 @@
 
 from nose.tools import eq_, ok_
 
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 from socorro.unittest.external.es.base import (
     ElasticsearchTestCase,
     SuperSearchWithFields,

--- a/socorro/unittest/external/es/test_crashstorage.py
+++ b/socorro/unittest/external/es/test_crashstorage.py
@@ -19,7 +19,7 @@ from socorro.external.es.crashstorage import (
     ESBulkCrashStorage
 )
 from socorro.unittest.external.es.base import ElasticsearchTestCase
-from socorrolib.lib.datetimeutil import string_to_datetime
+from socorro.lib.datetimeutil import string_to_datetime
 
 
 # Uncomment these lines to decrease verbosity of the elasticsearch library

--- a/socorro/unittest/external/es/test_index_cleaner.py
+++ b/socorro/unittest/external/es/test_index_cleaner.py
@@ -7,7 +7,7 @@ import elasticsearch
 
 from nose.tools import ok_
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.external.es.index_cleaner import IndexCleaner
 from socorro.unittest.external.es.base import (
     ElasticsearchTestCase,

--- a/socorro/unittest/external/es/test_new_crash_source.py
+++ b/socorro/unittest/external/es/test_new_crash_source.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from nose.tools import eq_
 
-from socorrolib.lib.datetimeutil import utc_now
+from socorro.lib.datetimeutil import utc_now
 from socorro.external.es.new_crash_source import ESNewCrashSource
 from socorro.unittest.external.es.base import ElasticsearchTestCase
 

--- a/socorro/unittest/external/es/test_query.py
+++ b/socorro/unittest/external/es/test_query.py
@@ -8,14 +8,14 @@ import json
 import mock
 from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import (
+from socorro.lib import (
     BadArgumentError,
     DatabaseError,
     MissingArgumentError,
     ResourceNotFound,
 )
 from socorro.external.es.query import Query
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 from socorro.unittest.external.es.base import ElasticsearchTestCase
 
 # Uncomment these lines to decrease verbosity of the elasticsearch library

--- a/socorro/unittest/external/es/test_super_search_fields.py
+++ b/socorro/unittest/external/es/test_super_search_fields.py
@@ -6,13 +6,13 @@ import datetime
 import elasticsearch
 from nose.tools import assert_raises, eq_, ok_
 
-from socorrolib.lib import (
+from socorro.lib import (
     BadArgumentError,
     MissingArgumentError,
     ResourceNotFound,
 )
 from socorro.external.es.super_search_fields import SuperSearchFields
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 from socorro.unittest.external.es.base import (
     SUPERSEARCH_FIELDS,
     ElasticsearchTestCase,

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -9,7 +9,7 @@ import time
 import requests_mock
 from nose.tools import assert_raises, eq_, ok_
 
-from socorrolib.lib import BadArgumentError, datetimeutil
+from socorro.lib import BadArgumentError, datetimeutil
 from socorro.middleware import search_common
 from socorro.unittest.external.es.base import (
     ElasticsearchTestCase,

--- a/socorro/unittest/external/fs/test_crash_data.py
+++ b/socorro/unittest/external/fs/test_crash_data.py
@@ -9,7 +9,7 @@ from configman import ConfigurationManager, Namespace
 from mock import Mock
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     ResourceNotFound,
     ResourceUnavailable,

--- a/socorro/unittest/external/fs/test_fs_new_crash_source.py
+++ b/socorro/unittest/external/fs/test_fs_new_crash_source.py
@@ -7,7 +7,7 @@ from nose.tools import eq_, ok_
 from socorro.external.fs.fs_new_crash_source import (
     FSNewCrashSource
 )
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/external/http/test_correlations.py
+++ b/socorro/unittest/external/http/test_correlations.py
@@ -13,7 +13,7 @@ import mock
 from nose.tools import eq_, ok_, assert_raises
 
 from socorro.external.http import correlations
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 SAMPLE_CORE_COUNTS = open(

--- a/socorro/unittest/external/http/test_crashstorage.py
+++ b/socorro/unittest/external/http/test_crashstorage.py
@@ -7,7 +7,7 @@ import socket
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 
 from socorro.external.http.crashstorage import HTTPPOSTCrashStorage
 from socorro.database.transaction_executor import (

--- a/socorro/unittest/external/postgresql/test_adi.py
+++ b/socorro/unittest/external/postgresql/test_adi.py
@@ -6,7 +6,7 @@ import datetime
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import MissingArgumentError
+from socorro.lib import MissingArgumentError
 from socorro.external.postgresql.adi import ADI
 
 from unittestbase import PostgreSQLTestCase

--- a/socorro/unittest/external/postgresql/test_backfill.py
+++ b/socorro/unittest/external/postgresql/test_backfill.py
@@ -6,7 +6,7 @@ from .unittestbase import PostgreSQLTestCase
 from nose.tools import eq_, assert_raises
 import datetime
 
-from socorrolib.lib import MissingArgumentError, datetimeutil
+from socorro.lib import MissingArgumentError, datetimeutil
 from socorro.external.postgresql.backfill import Backfill
 from socorro.external.postgresql import staticdata, fakedata
 

--- a/socorro/unittest/external/postgresql/test_base.py
+++ b/socorro/unittest/external/postgresql/test_base.py
@@ -4,13 +4,13 @@
 
 from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import DatabaseError
+from socorro.lib import DatabaseError
 from socorro.external.postgresql.base import PostgreSQLBase
 from socorro.external.postgresql.connection_context import ConnectionContext
 from socorro.middleware import search_common
 from socorro.unittest.testbase import TestCase
 
-from socorrolib.lib import util
+from socorro.lib import util
 
 from .unittestbase import PostgreSQLTestCase
 

--- a/socorro/unittest/external/postgresql/test_bugs.py
+++ b/socorro/unittest/external/postgresql/test_bugs.py
@@ -4,7 +4,7 @@
 
 from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import MissingArgumentError
+from socorro.lib import MissingArgumentError
 from socorro.external.postgresql.bugs import Bugs
 
 from .unittestbase import PostgreSQLTestCase

--- a/socorro/unittest/external/postgresql/test_crash_adu_by_build_signature.py
+++ b/socorro/unittest/external/postgresql/test_crash_adu_by_build_signature.py
@@ -6,7 +6,7 @@ import datetime
 
 from nose.tools import eq_, ok_
 
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 
 from .unittestbase import PostgreSQLTestCase
 

--- a/socorro/unittest/external/postgresql/test_crash_data.py
+++ b/socorro/unittest/external/postgresql/test_crash_data.py
@@ -6,7 +6,7 @@ from nose.tools import eq_, ok_, assert_raises
 from configman import ConfigurationManager, Namespace
 from mock import Mock
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     ResourceNotFound,
     ResourceUnavailable

--- a/socorro/unittest/external/postgresql/test_crashes.py
+++ b/socorro/unittest/external/postgresql/test_crashes.py
@@ -6,7 +6,7 @@ import random
 import datetime
 from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     datetimeutil,

--- a/socorro/unittest/external/postgresql/test_crashes_signatures.py
+++ b/socorro/unittest/external/postgresql/test_crashes_signatures.py
@@ -5,7 +5,7 @@
 import datetime
 from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     datetimeutil,

--- a/socorro/unittest/external/postgresql/test_field.py
+++ b/socorro/unittest/external/postgresql/test_field.py
@@ -4,7 +4,7 @@
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import MissingArgumentError
+from socorro.lib import MissingArgumentError
 from socorro.external.postgresql.field import Field
 from .unittestbase import PostgreSQLTestCase
 

--- a/socorro/unittest/external/postgresql/test_gccrashes.py
+++ b/socorro/unittest/external/postgresql/test_gccrashes.py
@@ -6,7 +6,7 @@ import datetime
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import MissingArgumentError, datetimeutil, util
+from socorro.lib import MissingArgumentError, datetimeutil, util
 from socorro.external.postgresql.gccrashes import GCCrashes
 from socorro.unittest.testbase import TestCase
 from socorro.external.postgresql.connection_context import ConnectionContext

--- a/socorro/unittest/external/postgresql/test_graphics_devices.py
+++ b/socorro/unittest/external/postgresql/test_graphics_devices.py
@@ -4,7 +4,7 @@
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import MissingArgumentError
+from socorro.lib import MissingArgumentError
 from socorro.external.postgresql.graphics_devices import GraphicsDevices
 
 from .unittestbase import PostgreSQLTestCase

--- a/socorro/unittest/external/postgresql/test_new_crash_source.py
+++ b/socorro/unittest/external/postgresql/test_new_crash_source.py
@@ -16,7 +16,7 @@ from socorro.external.postgresql.new_crash_source import (
     DBCrashStorageWrapperNewCrashSource,
     PGPVNewCrashSource
 )
-from socorrolib.lib.util import DotDict as SocorroDotDict
+from socorro.lib.util import DotDict as SocorroDotDict
 from socorro.external.crashstorage_base import (
     FileDumpsMapping,
     MemoryDumpsMapping

--- a/socorro/unittest/external/postgresql/test_product_build_types.py
+++ b/socorro/unittest/external/postgresql/test_product_build_types.py
@@ -4,7 +4,7 @@
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import MissingArgumentError
+from socorro.lib import MissingArgumentError
 from socorro.external.postgresql.product_build_types import ProductBuildTypes
 
 from .unittestbase import PostgreSQLTestCase

--- a/socorro/unittest/external/postgresql/test_products.py
+++ b/socorro/unittest/external/postgresql/test_products.py
@@ -6,7 +6,7 @@ import datetime
 from nose.tools import eq_, ok_
 
 from socorro.external.postgresql.products import ProductVersions, Products
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 
 from .unittestbase import PostgreSQLTestCase
 

--- a/socorro/unittest/external/postgresql/test_releases.py
+++ b/socorro/unittest/external/postgresql/test_releases.py
@@ -5,7 +5,7 @@
 import datetime
 from nose.tools import eq_, ok_, assert_raises
 
-from socorrolib.lib import MissingArgumentError, datetimeutil
+from socorro.lib import MissingArgumentError, datetimeutil
 from socorro.external.postgresql.releases import Releases
 
 from .unittestbase import PostgreSQLTestCase

--- a/socorro/unittest/external/postgresql/test_report.py
+++ b/socorro/unittest/external/postgresql/test_report.py
@@ -5,7 +5,7 @@
 import datetime
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import BadArgumentError, datetimeutil
+from socorro.lib import BadArgumentError, datetimeutil
 from socorro.external.postgresql.report import Report
 
 from unittestbase import PostgreSQLTestCase

--- a/socorro/unittest/external/postgresql/test_signature_first_date.py
+++ b/socorro/unittest/external/postgresql/test_signature_first_date.py
@@ -6,8 +6,8 @@ import datetime
 
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import MissingArgumentError
-from socorrolib.lib.datetimeutil import UTC
+from socorro.lib import MissingArgumentError
+from socorro.lib.datetimeutil import UTC
 from socorro.external.postgresql.signature_first_date import (
     SignatureFirstDate,
 )

--- a/socorro/unittest/external/postgresql/test_signature_summary.py
+++ b/socorro/unittest/external/postgresql/test_signature_summary.py
@@ -6,7 +6,7 @@ import datetime
 from nose.tools import ok_, eq_, assert_raises
 
 from socorro.external.postgresql.signature_summary import SignatureSummary
-from socorrolib.lib import BadArgumentError, datetimeutil
+from socorro.lib import BadArgumentError, datetimeutil
 
 from .unittestbase import PostgreSQLTestCase
 

--- a/socorro/unittest/external/postgresql/test_signature_urls.py
+++ b/socorro/unittest/external/postgresql/test_signature_urls.py
@@ -5,7 +5,7 @@
 import datetime
 from nose.tools import eq_, assert_raises
 
-from socorrolib.lib import (
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     datetimeutil,

--- a/socorro/unittest/external/postgresql/test_tcbs.py
+++ b/socorro/unittest/external/postgresql/test_tcbs.py
@@ -6,7 +6,7 @@ import datetime
 import mock
 import socorro.external.postgresql.tcbs as tcbs
 from nose.tools import eq_, assert_raises
-from socorrolib.lib import BadArgumentError, datetimeutil, util
+from socorro.lib import BadArgumentError, datetimeutil, util
 from .unittestbase import PostgreSQLTestCase
 
 

--- a/socorro/unittest/external/postgresql/test_util.py
+++ b/socorro/unittest/external/postgresql/test_util.py
@@ -5,7 +5,7 @@
 from .unittestbase import PostgreSQLTestCase
 from socorro.external.postgresql.util import Util
 from nose.tools import eq_
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 
 
 class TestUtil(PostgreSQLTestCase):

--- a/socorro/unittest/external/rabbitmq/test_connection_context.py
+++ b/socorro/unittest/external/rabbitmq/test_connection_context.py
@@ -15,7 +15,7 @@ from socorro.external.rabbitmq.connection_context import (
     ConnectionContext,
     ConnectionContextPooled
 )
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/external/rabbitmq/test_crashstorage.py
+++ b/socorro/unittest/external/rabbitmq/test_crashstorage.py
@@ -7,7 +7,7 @@ from socket import timeout
 from socorro.external.rabbitmq.crashstorage import (
     RabbitMQCrashStorage,
 )
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.database.transaction_executor import (
     TransactionExecutorWithInfiniteBackoff,
     TransactionExecutor

--- a/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
+++ b/socorro/unittest/external/rabbitmq/test_rmq_new_crash_source.py
@@ -7,7 +7,7 @@ from nose.tools import eq_, ok_
 from socorro.external.rabbitmq.rmq_new_crash_source import (
     RMQNewCrashSource
 )
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/external/statsd/test_stastsd_rule_benchmark.py
+++ b/socorro/unittest/external/statsd/test_stastsd_rule_benchmark.py
@@ -17,11 +17,11 @@ from socorro.external.statsd.statsd_rule_benchmark import (
     CountStackWalkerFailures,
 )
 from socorro.external.statsd.statsd_base import StatsdCounter
-from socorrolib.unittest.lib.test_transform_rules import (
+from socorro.unittest.lib.test_transform_rules import (
     TestRuleTestLaughable,
     TestRuleTestDangerous
 )
-from socorrolib.lib import transform_rules
+from socorro.lib import transform_rules
 from socorro.external.statsd.dogstatsd import StatsClient
 
 #==============================================================================

--- a/socorro/unittest/external/test_crashstorage_base.py
+++ b/socorro/unittest/external/test_crashstorage_base.py
@@ -21,7 +21,7 @@ from socorro.external.crashstorage_base import (
     FileDumpsMapping,
     socorrodotdict_to_dict
 )
-from socorrolib.lib.util import DotDict as SocorroDotDict
+from socorro.lib.util import DotDict as SocorroDotDict
 from socorro.unittest.testbase import TestCase
 from configman import Namespace, ConfigurationManager
 from configman.dotdict import DotDict

--- a/socorro/unittest/lib/config.tst
+++ b/socorro/unittest/lib/config.tst
@@ -1,0 +1,11 @@
+# This is a test config file
+# The cannonical form: No leading or intermediate spaces
+rabbit=bunny
+# A harder case
+  badger = this badger=awful
+  # This line = a legal comment
+
+# and the line above should also be skipped, white space and all
+ =
+# as should the one above here
+

--- a/socorro/unittest/lib/optionfile.py
+++ b/socorro/unittest/lib/optionfile.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import socorro.lib.ConfigurationManager as cm
+
+testNil = cm.Option()
+
+testSingleCharacter = cm.Option()
+testSingleCharacter.singleCharacter = 'T'
+
+testDefault = cm.Option()
+testDefault.default = 'default'
+
+testDoc = cm.Option()
+testDoc.doc = 'test doc'

--- a/socorro/unittest/lib/testOoid.py
+++ b/socorro/unittest/lib/testOoid.py
@@ -1,0 +1,100 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import uuid as uu
+import  socorro.lib.ooid as oo
+import datetime as dt
+
+from socorro.lib.datetimeutil import utc_now, UTC
+from socorro.unittest.testbase import TestCase
+
+class TestOoid(TestCase):
+  def setUp(self):
+    self.baseDate = dt.datetime(2008,12,25, tzinfo=UTC)
+    self.rawuuids = []
+    self.yyyyoids = []
+    self.dyyoids = []
+    self.depths = [4,4,3,3,3,2,2,2,1,1]
+    self.badooid0 = "%s%s" %(str(uu.uuid4())[:-8],'ffeea1b2')
+    self.badooid1 = "%s%s" %(str(uu.uuid4())[:-8],'f3eea1b2')
+
+    for i in range(10):
+      self.rawuuids.append(str(uu.uuid4()))
+    assert len(self.depths) == len(self.rawuuids)
+
+    for i in self.rawuuids:
+      self.yyyyoids.append("%s%4d%02d%02d" % (i[:-8],self.baseDate.year,self.baseDate.month,self.baseDate.day))
+
+    for i in range(len(self.rawuuids)):
+      self.dyyoids.append("%s%d%02d%02d%02d" %(self.rawuuids[i][:-7],self.depths[i],self.baseDate.year%100,self.baseDate.month,self.baseDate.day))
+
+    today = utc_now()
+    self.nowstamp = dt.datetime(today.year,today.month,today.day,tzinfo=UTC)
+    self.xmas05 = dt.datetime(2005,12,25,tzinfo=UTC)
+
+
+  def testCreateNewOoid(self):
+    ooid = oo.createNewOoid()
+    ndate = oo.dateFromOoid(ooid)
+    ndepth = oo.depthFromOoid(ooid)
+    assert self.nowstamp == ndate, 'Expect date of %s, got %s' %(self.nowstamp,ndate)
+    assert oo.defaultDepth == ndepth, 'Expect default depth (%d) got %d' % (oo.defaultDepth,ndepth)
+
+    ooid = oo.createNewOoid(timestamp=self.xmas05)
+    ndate = oo.dateFromOoid(ooid)
+    ndepth = oo.depthFromOoid(ooid)
+    assert self.xmas05 == ndate, 'Expect date of %s, got %s' %(self.xmas05,ndate)
+    assert oo.defaultDepth == ndepth, 'Expect default depth (%d) got %d' % (oo.defaultDepth,ndepth)
+
+    for d in range(1,5):
+      ooid0 = oo.createNewOoid(depth=d)
+      ooid1 = oo.createNewOoid(timestamp=self.xmas05,depth=d)
+      ndate0 = oo.dateFromOoid(ooid0)
+      ndepth0 = oo.depthFromOoid(ooid0)
+      ndate1 = oo.dateFromOoid(ooid1)
+      ndepth1 = oo.depthFromOoid(ooid1)
+      assert self.nowstamp == ndate0, 'Expect date of %s, got %s' %(self.nowstamp,ndate0)
+      assert self.xmas05 == ndate1, 'Expect date of %s, got %s' %(self.xmas05,ndate1)
+      assert ndepth0 == ndepth1, 'Expect depth0(%d) == depth1(%d)' %(ndepth0,ndepth1)
+      assert d == ndepth0, 'Expect depth %d, got %d' % (d,ndepth0)
+    assert None == oo.depthFromOoid(self.badooid0)
+    assert None == oo.depthFromOoid(self.badooid1)
+
+  def testUuidToOid(self):
+    for i in range(len(self.rawuuids)):
+      u = self.rawuuids[i]
+      o0 = oo.uuidToOoid(u)
+      expected =  (self.nowstamp,oo.defaultDepth)
+      got = oo.dateAndDepthFromOoid(o0)
+      assert expected == got, 'Expected %s, got %s'%(expected,got)
+      o1 = oo.uuidToOoid(u,timestamp=self.baseDate)
+      expected =  (self.baseDate,oo.defaultDepth)
+      got = oo.dateAndDepthFromOoid(o1)
+      assert expected == got, 'Expected %s, got %s'%(expected,got)
+      o2 = oo.uuidToOoid(u,depth=self.depths[i])
+      expected = (self.nowstamp,self.depths[i])
+      got = oo.dateAndDepthFromOoid(o2)
+      assert expected == got, 'Expected %s, got %s'%(expected,got)
+      o3 = oo.uuidToOoid(u,depth=self.depths[i],timestamp=self.xmas05)
+      expected = (self.xmas05,self.depths[i])
+      got = oo.dateAndDepthFromOoid(o3)
+      assert expected == got, 'Expected %s, got %s'%(expected,got)
+
+  def testGetDate(self):
+    for ooid in self.yyyyoids:
+      assert self.baseDate == oo.dateFromOoid(ooid), 'Expected %s got %s' %(self.baseDate, oo.dateFromOoid(ooid))
+      assert 4 == oo.depthFromOoid(ooid), 'Expected %d, got %d' %(4, oo.depthFromOoid(ooid))
+    assert None == oo.dateFromOoid(self.badooid0)
+    assert None == oo.dateFromOoid(self.badooid1)
+
+  def testGetDateAndDepth(self):
+    for i in range(len(self.dyyoids)):
+      date,depth = oo.dateAndDepthFromOoid(self.dyyoids[i])
+      assert self.depths[i] == depth, 'Expect depth=%d, got %d (%s)'%(self.depth[i],depth,self.dyyoids[i])
+      assert self.baseDate == date, 'Expect %s, got %s' %(self.baseDate, date)
+    assert (None,None) == oo.dateAndDepthFromOoid(self.badooid0)
+    assert (None,None) == oo.dateAndDepthFromOoid(self.badooid1)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/socorro/unittest/lib/testPrioritize.py
+++ b/socorro/unittest/lib/testPrioritize.py
@@ -1,0 +1,232 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import  socorro.lib.prioritize as prioritize
+
+class TestNode:
+  def testConstructor(self):
+    n = prioritize.Node()
+    assert None == n.item
+    assert set() == n.parents
+    assert [] == n.children
+    n = prioritize.Node('a')
+    assert 'a' == n.item
+    assert set() == n.parents
+    assert [] == n.children
+
+  def testAddChild(self):
+    p = prioritize.Node('a')
+    n = p.addChild('c')
+    assert isinstance(n,prioritize.Node)
+    assert n in p.children
+    assert p in n.parents
+    d = prioritize.Node('d')
+    n = p.addChild(d)
+    assert d == n
+    assert d in p.children
+    assert p in d.parents
+    assert 2 == len(p.children)
+    n = p.addChild(d)
+    assert d == n
+    assert 2 == len(p.children)
+    assert 1 == len(d.parents)
+
+  def testAddParent(self):
+    c = prioritize.Node('c')
+    n = c.addParent('p')
+    assert isinstance(n,prioritize.Node)
+    assert n in c.parents
+    assert c in n.children
+    d = prioritize.Node('d')
+    n = c.addParent(d)
+    assert d == n
+    assert d in c.parents
+    assert c in d.children
+    assert 2 == len(c.parents)
+    n = c.addParent(d)
+    assert d == n
+    assert 2 == len(c.parents)
+
+  def testFindChild(self):
+    a = prioritize.Node('a')
+    b = prioritize.Node('b')
+    c = prioritize.Node('c')
+    d = prioritize.Node('d')
+    e = prioritize.Node('e')
+    f = prioritize.Node('f')
+    top = prioritize.Node('0')
+    top.addChild(a)
+    a.addChild(b)
+    a.addChild(c)
+    b.addChild(d)
+    c.addChild(d)
+    b.addChild(e)
+    d.addChild(f)
+    assert a == top.findChild('a')
+    assert a == a.findChild('a')
+    assert b == top.findChild('b')
+    assert c == top.findChild('c')
+    assert d == top.findChild('d')
+    assert e == top.findChild('e')
+    assert f == top.findChild('f')
+    assert None == top.findChild(1)
+    assert None == f.findChild('a')
+    assert None == b.findChild('a')
+
+  def testStr(self):
+    n = prioritize.Node()
+    assert "<node: set([])<- None ->[]>" == str(n)
+    n.addChild('a')
+    assert "<node: set([])<- None ->['a']>" == str(n)
+    n.addParent('a')
+    assert "<node: set(['a'])<- None ->['a']>" == str(n)
+    n.addChild('b')
+    assert "<node: set(['a'])<- None ->['a', 'b']>" == str(n)
+    for p in ('b',3,'B','c', 1,'C','d',2,'D',):
+      n.addParent(p)
+      pdisp = set((x.item for x in n.parents))
+      assert str(n).startswith("<node: %s<-"%pdisp),"Expected '%s', got '%s'"%("<node: %s<-"%pdisp,str(n))
+    n = prioritize.Node()
+    for c in (9,'A','a','b',3,'B','c', 1,'C','d',2,'D',):
+      n.addChild(p)
+      cdisp = [x.item for x in n.children]
+      assert str(n).endswith("%s>"%cdisp)
+
+def testFindChild():
+  a = prioritize.Node('a')
+  b = prioritize.Node('b')
+  c = prioritize.Node('c')
+  d = prioritize.Node('d')
+  e = prioritize.Node('e')
+  a.addChild(b)
+  a.addChild(c)
+  b.addChild(d)
+  c.addChild(d)
+  a.addChild(e)
+  assert None == a.findChild('nope')
+  assert None == b.findChild('e')
+  assert None == b.findChild('a')
+  assert a == a.findChild('a')
+  assert b == a.findChild('b')
+  assert c == a.findChild('c')
+  assert d == a.findChild('d')
+  assert e == a.findChild('e')
+  c.addChild(e)
+  e.addChild(a)
+  assert a == c.findChild('a')
+  assert None == b.findChild('a')
+
+# [ aMap for test,
+#   expected result map,
+#   map of nodeName:expected dependencyOrder result for that node (aka BottomUpVisitor)
+#   map of nodeName:expected top-down visit order for that node
+# ]
+# There is an issue here in that some of the expected orders are non-deterministic,
+# such as when a depends on b and c, should we see a,b,c or a,c,b in top down (c,b,a or b,c,a in bottom up)
+# The orders encoded here work on the original testing machine. If they fail on your machine, we'll need to
+# think about how to do some kind of regular expression test, maybe.
+dependencyTestCases = [
+  [{},
+   {},
+   {},
+   {},
+   ],
+
+  [{'a':()},
+   {'a':[]},
+   {'a':['a']},
+   {'a':['a']},
+   ],
+
+  [{'a':(),'b':()},
+   {'a':[],'b':[]},
+   {'a':['a'],'b':['b']},
+   {'a':['a'],'b':['b']},
+   ],
+
+  [{'a':('b',)},
+   {'a':['b'],'b':[]},
+   {'a':['b','a'], 'b':['b']},
+   {'a':['a','b'], 'b':['b']},
+   ],
+
+  [{'a':('b','c',)},
+   {'a':['b','c'],'b':[], 'c':[]},
+   {'a':['b','c','a'],'b':['b'],'c':['c']},
+   {'a':['a','b','c'], 'b':['b'],'c':['c']},
+   ],
+  [{'a':('b',),'b':('c',)},
+   {'a':['b'],'b':['c'],'c':[]},
+   {'a':['c','b','a'],'b':['c','b'],'c':['c']},
+   {'a':['a','b','c'],'b':['b','c',],'c':['c']},
+   ],
+
+  [{'a':('b',),'b':('a',)},
+   {'a':['b'],'b':['a']},
+   {'a':['b','a'],'b':['a','b']},
+   {'a':['a','b'],'b':['b','a']},
+   ],
+
+  [{'a':('b','c','d'),'b':('c',),'c':('d',),},
+   {'a':['b','c','d'],'b':['c',],'c':['d'],'d':[]},
+   {'a':['d','c','b','a'],'b':['d','c','b'],'c':['d','c'],'d':['d']},
+   {'a':['a','b','c','d'],'b':['b','c','d'],'c':['c','d'],'d':['d']},
+   ],
+
+  [{'a':['d'],'b':['d'],'c':['b'],'d':['e','f','g']},
+   {'a':['d'],'b':['d'],'c':['b'],'d':['e','f','g'],'e':[],'f':[],'g':[]},
+   {'a':['e','f','g','d','a'],'b':['e','f','g','d','b'],'c':['e','f','g','d','b','c'],'d':['e','f','g','d'],'e':['e'],'f':['f'],'g':['g'],},
+   {'a':['a','d','e','f','g'],'b':['b','d','e','f','g'],'c':['c','b','d','e','f','g'],'d':['d','e','f','g'],'e':['e'],'f':['f'],'g':['g'],},
+   ],
+
+  [{'a':['d'],'b':['d'],'c':['b'],'d':['e','f','g'],'e':[],'f':(),'g':[]},
+   {'a':['d'],'b':['d'],'c':['b'],'d':['e','f','g'],'e':[],'f':[],'g':[]},
+   {'a':['e','f','g','d','a'],'b':['e','f','g','d','b'],'c':['e','f','g','d','b','c'],'d':['e','f','g','d'],'e':['e'],'f':['f'],'g':['g'],},
+   {'a':['a','d','e','f','g'],'b':['b','d','e','f','g'],'c':['c','b','d','e','f','g'],'d':['d','e','f','g'],'e':['e'],'f':['f'],'g':['g'],},
+   ],
+  ]
+
+def testTopDownVisitor():
+  global dependencyTestCases
+  for aMap,ignore,ignore,expected in dependencyTestCases:
+    result = prioritize.makeDependencyMap(aMap)
+    if {} == expected:
+      assert {} == aMap
+    for k in expected.keys():
+      v = prioritize.TopDownVisitor()
+      v.visit(result[k])
+      got = [x.item for x in v.history]
+      assert expected[k]==got, "expected:%s, got:%s"%(expected[k],got)
+
+def testBottomUpVisitor():
+  global dependencyTestCases
+  for aMap,ignore,expected,ignore in dependencyTestCases:
+    result = prioritize.makeDependencyMap(aMap)
+    if {} == expected:
+      assert {} == aMap
+    for k in expected.keys():
+      v = prioritize.BottomUpVisitor()
+      v.visit(result[k])
+      got = [x.item for x in v.history]
+      assert expected[k]==got, "expected:%s, got:%s"%(expected[k],got)
+
+def testMakeDependencyMap():
+  global dependencyTestCases
+  for aMap,expected,ignore,ignore in dependencyTestCases:
+    result = prioritize.makeDependencyMap(aMap)
+    checkResult = dict([(k,[x.item for x in result[k].children]) for k in result.keys()])
+    assert expected == checkResult, "expected:%s, got:%s"%(expected,checkResult)
+
+def testDependencyOrder():
+  for aMap,ignore,ordered,ignore in dependencyTestCases:
+    if {} == aMap:
+      assert {} == ordered
+    for k in ordered.keys():
+      result = prioritize.dependencyOrder(aMap,[k])
+      assert ordered[k] == result, "expected:%s, got:%s"%(ordered[k],result)
+
+    aMap = {'a':['b']}
+    aList = ['0','a','b','c']
+  result = prioritize.dependencyOrder(aMap,aList)
+  assert ['b','a','0','c'] == result, "Expected ['b','a','0','c'], got %s"%(result)

--- a/socorro/unittest/lib/testVerTools.py
+++ b/socorro/unittest/lib/testVerTools.py
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import socorro.lib.ver_tools as vtl
+
+phs = vtl._padding_high_string
+pl  = vtl._padding_list
+
+tests = [('3',            [3, phs, 0, phs] + pl * 3, '3'),
+         ('3.',           [3, phs, 0, phs] + pl * 3, '3'),
+         ('3.0',          [3, phs, 0, phs] + pl * 3, '3'),
+         ('3.0.0',        [3, phs, 0, phs] + pl * 3, '3'),
+         ('3.5',          [3, phs, 0, phs,
+                           5, phs, 0, phs] + pl * 2, '3.5'),
+         ('3.5pre',       [3, phs, 0, phs,
+                           5, 'pre', 0, phs] + pl * 2, '3.5pre'),
+         ('3.5b3',        [3, phs, 0, phs,
+                           5, 'b', 3, phs] + pl * 2, '3.5b3'),
+
+         ('3.6.4plugin3', [3, phs, 0, phs,
+                           6, phs, 0, phs,
+                           4, 'plugin', 3, phs] + pl, '3.6.4plugin3'),
+        ]
+
+def testNormalize():
+    for ver, expected, ver2 in tests:
+        got = vtl.normalize(ver)
+        assert got == expected, "expected %s, but got %s" % (expected, got)
+
+def testDenomalize():
+    for ver, norm, expected in tests:
+        got = vtl.denormalize(norm)
+        assert got == expected, "expected %s, but got %s" % (expected, got)
+
+def testCompare():
+    got = vtl.compare('3', '3.1')
+    assert got == -1, "expected %s, but got %s" % (-1, got)
+    got = vtl.compare('3', '3.0')
+    assert got == 0, "expected %s, but got %s" % (0, got)
+    got = vtl.compare('3', '3.0pre')
+    assert got == 1, "expected %s, but got %s" % (1, got)
+    got = vtl.compare('3.5b2', '3.5b1')
+    assert got == 1, "expected %s, but got %s" % (1, got)
+    got = vtl.compare('3.5', '3.5b1')
+    assert got == 1, "expected %s, but got %s" % (1, got)
+    got = vtl.compare('3.5.1', '3.5.1b3')
+    assert got == 1, "expected %s, but got %s" % (1, got)

--- a/socorro/unittest/lib/test_converters.py
+++ b/socorro/unittest/lib/test_converters.py
@@ -1,0 +1,281 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_, ok_
+
+from configman import ConfigurationManager, RequiredConfig, Namespace
+from configman.converters import to_str
+
+from socorro.lib.converters import (
+    str_to_classes_in_namespaces_converter,
+    change_default,
+    web_services_from_str,
+)
+from socorro.unittest.testbase import TestCase
+
+#==============================================================================
+# the following two classes are used in test_classes_in_namespaces_converter1
+# and need to be declared at module level scope
+class Foo(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('x', default=17)
+    required_config.add_option('y', default=23)
+
+
+#==============================================================================
+class Bar(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('x', default=227)
+    required_config.add_option('a', default=11)
+
+
+# the following two classes are used in test_classes_in_namespaces_converter2
+# and test_classes_in_namespaces_converter_3.  They need to be declared at
+#module level scope
+#==============================================================================
+class Alpha(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('a', doc='a', default=17)
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.a = config.a
+
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        return "I am an instance of an Alpha object"
+
+
+#==============================================================================
+class AlphaBad1(Alpha):
+    def __init__(self, config):
+        super(AlphaBad1, self).__init__(config)
+        self.a_type = int
+
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise AttributeError
+
+
+#==============================================================================
+class AlphaBad2(AlphaBad1):
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise KeyError
+
+
+#==============================================================================
+class AlphaBad3(AlphaBad1):
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise TypeError
+
+
+#==============================================================================
+class Beta(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+        'b',
+        doc='b',
+        default=23
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.b = config.b
+
+
+#==============================================================================
+class TestConverters(TestCase):
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_1(self):
+        converter_fn = str_to_classes_in_namespaces_converter(
+            'class_%(name)s'
+        )
+        class_list_str = (
+            'socorro.unittest.lib.test_converters.Foo,'
+            'socorro.unittest.lib.test_converters.Bar'
+        )
+        result = converter_fn(class_list_str)
+        self.assertTrue(hasattr(result, 'required_config'))
+        req = result.required_config
+        self.assertEqual(len(req), 2)
+        self.assertTrue('class_Foo' in req)
+        self.assertEqual(len(req.class_Foo), 1)
+        self.assertTrue('class_Bar' in req)
+        self.assertEqual(len(req.class_Bar), 1)
+        self.assertEqual(
+            sorted([x.strip() for x in class_list_str.split(',')]),
+            sorted([
+                x.strip() for x in
+                to_str(result).strip("'").split(',')
+            ])
+        )
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_2(self):
+        converter_fn = str_to_classes_in_namespaces_converter(
+            'class_%(name)s'
+        )
+        class_sequence = (Foo, Bar)
+        # ought to raise TypeError because 'class_sequence' is not a string
+        self.assertRaises(TypeError, converter_fn, class_sequence)
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_3(self):
+        n = Namespace()
+        n.add_option(
+            'kls_list',
+            default=(
+                'socorro.unittest.lib.test_converters.Foo, '
+                'socorro.unittest.lib.test_converters.Foo, '
+                'socorro.unittest.lib.test_converters.Foo'
+            ),
+            from_string_converter= str_to_classes_in_namespaces_converter(
+                '%(name)s_%(index)02d'
+            )
+        )
+
+        cm = ConfigurationManager(n, argv_source=[])
+        config = cm.get_config()
+
+        self.assertEqual(len(config.kls_list.subordinate_namespace_names), 3)
+        self.assertTrue('Foo_00' in config)
+        self.assertTrue('Foo_01' in config)
+        self.assertTrue('Foo_02' in config)
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_4(self):
+        n = Namespace()
+        n.add_option(
+            'kls_list',
+            default=(
+                'socorro.unittest.lib.test_converters.Alpha, '
+                'socorro.unittest.lib.test_converters.Alpha, '
+                'socorro.unittest.lib.test_converters.Alpha'
+            ),
+            from_string_converter=str_to_classes_in_namespaces_converter(
+                '%(name)s_%(index)02d'
+            )
+        )
+
+        cm = ConfigurationManager(
+            n,
+            [{
+                'kls_list': (
+                    'socorro.unittest.lib.test_converters.Alpha, '
+                    'socorro.unittest.lib.test_converters.Beta, '
+                    'socorro.unittest.lib.test_converters.Beta, '
+                    'socorro.unittest.lib.test_converters.Alpha'
+                ),
+                'Alpha_00.a': 21,
+                'Beta_01.b': 38,
+            }]
+        )
+        config = cm.get_config()
+
+
+        self.assertEqual(len(config.kls_list.subordinate_namespace_names), 4)
+        for x in config.kls_list.subordinate_namespace_names:
+            self.assertTrue(x in config)
+        self.assertEqual(config.Alpha_00.a, 21)
+        self.assertEqual(config.Beta_01.b, 38)
+
+    #--------------------------------------------------------------------------
+    def test_classes_in_namespaces_converter_5(self):
+        n = Namespace()
+        n.add_option(
+            'kls_list',
+            default=(
+                'socorro.unittest.lib.test_converters.Alpha, '
+                'socorro.unittest.lib.test_converters.Alpha, '
+                'socorro.unittest.lib.test_converters.Alpha'
+            ),
+            from_string_converter=str_to_classes_in_namespaces_converter(
+                '%(name)s_%(index)02d'
+            )
+        )
+
+        cm = ConfigurationManager(
+            n,
+            [{
+                'kls_list': (
+                    'socorro.unittest.lib.test_converters.Alpha, '
+                    'socorro.unittest.lib.test_converters.Beta, '
+                    'socorro.unittest.lib.test_converters.Beta, '
+                    'socorro.unittest.lib.test_converters.Alpha'
+                ),
+                'Alpha_00.a': 21,
+                'Beta_01.b': 38,
+            }]
+        )
+        config = cm.get_config()
+
+        self.assertEqual(len(config.kls_list.subordinate_namespace_names), 4)
+        for i, (a_class_name, a_class, ns_name) in \
+            enumerate(config.kls_list.class_list):
+            self.assertTrue(isinstance(a_class_name, str))
+            self.assertEqual(a_class_name, a_class.__name__)
+            self.assertEqual(ns_name, "%s_%02d" % (a_class_name, i))
+
+    #--------------------------------------------------------------------------
+    def test_change_default(self):
+        class Alpha(RequiredConfig):
+            required_config = Namespace()
+            required_config.add_option(
+                'an_option',
+                default=19,
+                doc='this is an an_option',
+                from_string_converter=str,
+            )
+        a_new_option_with_a_new_default = change_default(
+            Alpha,
+            'an_option',
+            '29300'
+        )
+
+        ok_(
+            a_new_option_with_a_new_default
+            is not Alpha.required_config.an_option
+        )
+        eq_(
+            a_new_option_with_a_new_default.default,
+            '29300'
+        )
+        eq_(
+            Alpha.required_config.an_option.default,
+            19
+        )
+
+    #--------------------------------------------------------------------------
+    def test_web_services_from_str(self):
+        some_services_as_string = """[
+            {
+                "name": "collector",
+                "uri": "/submit",
+                "service_implementation_class":
+                "socorro.unittest.lib.test_converters.Alpha"
+            },
+            {
+                "name": "generic",
+                "uri": "/some/other/uri",
+                "service_implementation_class":
+                "socorro.unittest.lib.test_converters.Beta"
+            }
+        ]"""
+        services_instance = web_services_from_str()(some_services_as_string)
+        service_list = services_instance.service_list
+        eq_(len(service_list), 2)
+        eq_(len(service_list[0]), 3)
+        eq_(len(service_list[1]), 3)
+        rc = services_instance.required_config
+        ok_('collector' in rc)
+        eq_(rc.collector.service_implementation_class.default, Alpha)
+        eq_(rc.collector.uri.default, "/submit")
+        ok_('generic' in rc)
+        eq_(rc.generic.service_implementation_class.default, Beta)
+        eq_(rc.generic.uri.default, "/some/other/uri")

--- a/socorro/unittest/lib/test_datetimeutil.py
+++ b/socorro/unittest/lib/test_datetimeutil.py
@@ -1,0 +1,198 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_, ok_, raises
+import datetime
+
+from socorro.lib import datetimeutil
+
+
+UTC = datetimeutil.UTC
+
+
+def test_utc_now():
+    """
+    Test datetimeutil.utc_now()
+    """
+    res = datetimeutil.utc_now()
+    eq_(res.strftime('%Z'), 'UTC')
+    eq_(res.strftime('%z'), '+0000')
+    ok_(res.tzinfo)
+
+
+def test_string_to_datetime():
+    """
+    Test datetimeutil.string_to_datetime()
+    """
+    # Empty date
+    date = ""
+    try:
+        res = datetimeutil.string_to_datetime(date)
+        raise AssertionError("expect this to raise ValueError")
+    except ValueError:
+        pass
+
+    # already a date
+    date = datetime.datetime.utcnow()
+    res = datetimeutil.string_to_datetime(date)
+
+    eq_(res, date.replace(tzinfo=UTC))
+    eq_(res.strftime('%Z'), 'UTC')
+    eq_(res.strftime('%z'), '+0000')
+
+    # YY-mm-dd date
+    date = "2001-11-03"
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 11, 3, tzinfo=UTC))
+    eq_(res.strftime('%Z'), 'UTC')  # timezone aware
+
+    # and naughty YY-m-d date
+    date = "2001-1-3"
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 1, 3, tzinfo=UTC))
+    eq_(res.strftime('%Z'), 'UTC')  # timezone aware
+
+    # Commented out because I don't thing `YY-mm-dd+HH:ii:ss` is a
+    # valid date format.
+    ## YY-mm-dd+HH:ii:ss date
+    #date = "2001-11-30+12:34:56"
+    #try:
+    #    res = datetimeutil.string_to_datetime(date)
+    #except ValueError:
+    #    res = None
+    #expected = datetime(2001, 11, 30, 12, 34, 56)
+    #assert res == expected, "Date is %s, %s expected." % (date, expected)
+
+    # YY-mm-dd HH:ii:ss.S date
+    date = "2001-11-30 12:34:56.123456"
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 11, 30, 12, 34, 56, 123456, tzinfo=UTC))
+
+    # Separated date
+    date = ["2001-11-30", "12:34:56"]
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 11, 30, 12, 34, 56, tzinfo=UTC))
+
+    # Invalid date
+    date = "2001-11-32"
+    try:
+        res = datetimeutil.string_to_datetime(date)
+        raise AssertionError("should have raise a ValueError")
+    except ValueError:
+        pass
+
+
+def test_string_datetime_with_timezone():
+    date = "2001-11-30T12:34:56Z"
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 11, 30, 12, 34, 56, tzinfo=UTC))
+    eq_(res.strftime('%H'), '12')
+    # because it's a timezone aware datetime
+    ok_(res.tzname())
+    eq_(res.strftime('%Z'), 'UTC')
+    eq_(res.strftime('%z'), '+0000')
+
+    # plus 3 hours east of Zulu means minus 3 hours on UTC
+    date = "2001-11-30T12:10:56+03:00"
+    res = datetimeutil.string_to_datetime(date)
+    expected = datetime.datetime(2001, 11, 30, 12 - 3, 10, 56, tzinfo=UTC)
+    eq_(res, expected)
+
+    # similar example
+    date = "2001-11-30T12:10:56-01:30"
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 11, 30, 12 + 1, 10 + 30, 56, tzinfo=UTC))
+
+    # YY-mm-dd+HH:ii:ss.S date
+    date = "2001-11-30 12:34:56.123456Z"
+    res = datetimeutil.string_to_datetime(date)
+    eq_(res, datetime.datetime(2001, 11, 30, 12, 34, 56, 123456, tzinfo=UTC))
+
+    docstring = """
+        * 2012-01-10T12:13:14
+        * 2012-01-10T12:13:14.98765
+        * 2012-01-10T12:13:14.98765+03:00
+        * 2012-01-10T12:13:14.98765Z
+        * 2012-01-10 12:13:14
+        * 2012-01-10 12:13:14.98765
+        * 2012-01-10 12:13:14.98765+03:00
+        * 2012-01-10 12:13:14.98765Z
+    """.strip().splitlines()
+    examples = [x.replace('*', '').strip() for x in docstring]
+    for example in examples:
+        res = datetimeutil.string_to_datetime(example)
+        ok_(res.tzinfo)
+        ok_(isinstance(res, datetime.datetime))
+
+
+def test_date_to_string():
+    # Datetime with timezone
+    date = datetime.datetime(2012, 1, 3, 12, 23, 34, tzinfo=UTC)
+    res_exp = '2012-01-03T12:23:34+00:00'
+    res = datetimeutil.date_to_string(date)
+    eq_(res, res_exp)
+
+    # Datetime without timezone
+    date = datetime.datetime(2012, 1, 3, 12, 23, 34)
+    res_exp = '2012-01-03T12:23:34'
+    res = datetimeutil.date_to_string(date)
+    eq_(res, res_exp)
+
+    # Date (no time, no timezone)
+    date = datetime.date(2012, 1, 3)
+    res_exp = '2012-01-03'
+    res = datetimeutil.date_to_string(date)
+    eq_(res, res_exp)
+
+
+@raises(TypeError)
+def test_date_to_string_fail():
+    datetimeutil.date_to_string('2012-01-03')
+
+
+def test_uuid_to_date():
+    uuid = "e8820616-1462-49b6-9784-e99a32120201"
+    date_exp = datetime.date(year=2012, month=2, day=1)
+    date = datetimeutil.uuid_to_date(uuid)
+    eq_(date, date_exp)
+
+    uuid = "e8820616-1462-49b6-9784-e99a32181223"
+    date_exp = datetime.date(year=1118, month=12, day=23)
+    date = datetimeutil.uuid_to_date(uuid, century=11)
+    eq_(date, date_exp)
+
+
+def test_date_to_weekly_partition_with_string():
+    datestring = '2015-01-09'
+    partition_exp = '20150105'
+
+    partition = datetimeutil.datestring_to_weekly_partition(datestring)
+    eq_(partition, partition_exp)
+
+    # Is there a better way of testing that we handle 'now' as a date value?
+    datestring = 'now'
+    date_now = datetime.datetime.now().date()
+    partition_exp = (date_now + datetime.timedelta(0 - date_now.weekday())).strftime('%Y%m%d')
+    partition = datetimeutil.datestring_to_weekly_partition(datestring)
+    eq_(partition, partition_exp)
+
+
+def test_date_to_weekly_partition_with_datetime():
+    proposed_and_expected = (
+        (datetime.datetime(2014, 12, 29), '20141229'),
+        (datetime.datetime(2014, 12, 30), '20141229'),
+        (datetime.datetime(2014, 12, 31), '20141229'),
+        (datetime.datetime(2015,  1,  1), '20141229'),
+        (datetime.datetime(2015,  1,  2), '20141229'),
+        (datetime.datetime(2015,  1,  3), '20141229'),
+        (datetime.datetime(2015,  1,  4), '20141229'),
+        (datetime.datetime(2015,  1,  5), '20150105'),
+        (datetime.datetime(2015,  1,  6), '20150105'),
+        (datetime.datetime(2015,  1,  7), '20150105'),
+        (datetime.datetime(2015,  1,  8), '20150105'),
+        (datetime.datetime(2015,  1,  9), '20150105'),
+    )
+    for to_be_tested, expected in proposed_and_expected:
+        result = datetimeutil.datestring_to_weekly_partition(to_be_tested)
+        eq_(result, expected)

--- a/socorro/unittest/lib/test_external_common.py
+++ b/socorro/unittest/lib/test_external_common.py
@@ -1,0 +1,224 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import datetime
+
+import isodate
+from nose.tools import eq_, ok_, assert_raises
+
+from socorro.lib import BadArgumentError, external_common, util
+from socorro.unittest.testbase import TestCase
+
+
+#==============================================================================
+class TestExternalCommon(TestCase):
+    """Test functions of the external_common module. """
+
+    #--------------------------------------------------------------------------
+    def test_check_type(self):
+        # Test 1: null
+        param = None
+        datatype = "datetime"
+        res = external_common.check_type(param, datatype)
+        eq_(res, None)
+
+        # .....................................................................
+        # Test 2: integer
+        param = 12
+        datatype = "int"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, int))
+        eq_(res, param)
+
+        # .....................................................................
+        # Test 3: integer
+        param = "12"
+        datatype = "int"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, int))
+        eq_(res, 12)
+
+        # .....................................................................
+        # Test 4: string
+        param = datetime.datetime(2012, 01, 01)
+        datatype = "str"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, str))
+        eq_(res, "2012-01-01 00:00:00")
+
+        # .....................................................................
+        # Test 5: boolean
+        param = 1
+        datatype = "bool"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, bool))
+        eq_(res, True)
+
+        # .....................................................................
+        # Test 6: boolean
+        param = "T"
+        datatype = "bool"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, bool))
+        eq_(res, True)
+
+        # .....................................................................
+        # Test 7: boolean
+        param = 14
+        datatype = "bool"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, bool))
+        eq_(res, False)
+
+        # .....................................................................
+        # Test 8: datetime
+        param = "2012-01-01T00:00:00"
+        datatype = "datetime"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, datetime.datetime))
+        eq_(res.year, 2012)
+        eq_(res.month, 1)
+        eq_(res.hour, 0)
+
+        # .....................................................................
+        # Test 9: timedelta
+        param = "72"
+        datatype = "timedelta"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, datetime.timedelta))
+        eq_(res.days, 3)
+
+        # Test: date
+        param = "2012-01-01"
+        datatype = "date"
+        res = external_common.check_type(param, datatype)
+
+        ok_(isinstance(res, datetime.date))
+        eq_(res.year, 2012)
+        eq_(res.month, 1)
+        eq_(res.day, 1)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments_old_way(self):
+        """Test external_common.parse_arguments(). """
+        filters = [
+            ("param1", "default", ["list", "str"]),
+            ("param2", None, "int"),
+            ("param3", ["list", "of", 4, "values"], ["list", "str"])
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = ["value1"]
+        params_exp.param2 = None
+        params_exp.param3 = ["list", "of", "4", "values"]
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=False,
+        )
+
+        eq_(params, params_exp)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments(self):
+        """Test external_common.parse_arguments(). """
+        filters = [
+            ("param1", "default", [str]),
+            ("param2", None, int),
+            ("param3", ["some", "default", "list"], [str]),
+            ("param4", ["list", "of", 4, "values"], [str]),
+            ("param5", None, bool),
+            ("param6", None, datetime.date),
+            ("param7", None, datetime.date),
+            ("param8", None, datetime.datetime),
+            ("param9", None, [str]),
+        ]
+        arguments = {
+            "param1": "value1",
+            "unknown": 12345,
+            "param5": "true",
+            "param7": datetime.date(2016, 2, 9).isoformat(),
+            "param8": datetime.datetime(2016, 2, 9).isoformat(),
+            # note the 'param9' is deliberately not specified.
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = ["value1"]
+        params_exp.param2 = None
+        params_exp.param3 = ['some', 'default', 'list']
+        params_exp.param4 = ["list", "of", "4", "values"]
+        params_exp.param5 = True
+        params_exp.param6 = None
+        params_exp.param7 = datetime.date(2016, 2, 9)
+        params_exp.param8 = datetime.datetime(2016, 2, 9).replace(
+            tzinfo=isodate.UTC
+        )
+        params_exp.param9 = None
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=True
+        )
+        for key in params:
+            eq_(params[key], params_exp[key], '{}: {!r} != {!r}'.format(
+                key,
+                params[key],
+                params_exp[key]
+            ))
+        eq_(params, params_exp)
+
+    #--------------------------------------------------------------------------
+    def test_parse_arguments_with_class_validators(self):
+
+        class NumberConverter(object):
+
+            def clean(self, value):
+                conv = {'one': 1, 'two': 2, 'three': 3}
+                try:
+                    return conv[value]
+                except KeyError:
+                    raise ValueError('No idea?!')
+
+        # Define a set of filters with some types being non-trivial types
+        # but instead a custom validator.
+
+        filters = [
+            ("param1", 0, NumberConverter()),
+        ]
+        arguments = {
+            "param1": "one",
+        }
+        params_exp = util.DotDict()
+        params_exp.param1 = 1
+
+        params = external_common.parse_arguments(
+            filters,
+            arguments,
+            modern=True
+        )
+        eq_(params, params_exp)
+
+        # note that a ValueError becomes a BadArgumentError
+        arguments = {
+            "param1": "will cause a ValueError in NumberConverter.clean",
+        }
+        assert_raises(
+            BadArgumentError,
+            external_common.parse_arguments,
+            filters,
+            arguments,
+            modern=True
+        )

--- a/socorro/unittest/lib/test_sqlutils.py
+++ b/socorro/unittest/lib/test_sqlutils.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_
+
+from socorro.lib import sqlutils
+
+
+def test_quote_value():
+    eq_(sqlutils.quote_value('name'), "'name'")
+    eq_(sqlutils.quote_value("'name'"), "'''name'''")
+    eq_(sqlutils.quote_value("o'clock"), "'o''clock'")

--- a/socorro/unittest/lib/test_statistics.py
+++ b/socorro/unittest/lib/test_statistics.py
@@ -1,0 +1,172 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from mock import patch, call
+
+from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.statistics import StatisticsForStatsd
+from socorro.unittest.testbase import TestCase
+
+
+class TestStatsd(TestCase):
+
+    def setUp(self):
+        super(TestStatsd, self).setUp()
+        self.logger = SilentFakeLogger()
+
+    def test_statistics_all_good(self):
+        d = DotDict()
+        d.statsd_host = 'localhost'
+        d.statsd_port = 666
+        d.prefix = 'a.b'
+        d.active_counters_list = ['x', 'y', 'z']
+
+        with patch('socorro.lib.statistics.StatsClient') as StatsClientMocked:
+            s = StatisticsForStatsd(d, 'processor')
+            StatsClientMocked.assert_called_with(
+                'localhost', 666, 'a.b.processor')
+
+            s.incr('x')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('a.b.processor.x')]
+            )
+
+            s.incr('y')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('a.b.processor.y')]
+            )
+
+            s.incr('z')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('a.b.processor.z')]
+            )
+
+            s.incr('w')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('a.b.processor.y'),
+                    call.incr('a.b.processor.x'),
+                    call.incr('a.b.processor.y')
+                ]
+            )
+
+            s.incr(None)
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('a.b.processor.y'),
+                    call.incr('a.b.processor.x'),
+                    call.incr('a.b.processor.y'),
+                    call.incr('a.b.processor.unknown')
+                ]
+            )
+
+
+
+    def test_statistics_all_missing_prefix(self):
+        d = DotDict()
+        d.statsd_host = 'localhost'
+        d.statsd_port = 666
+        d.prefix = None
+        d.active_counters_list = ['x', 'y', 'z']
+
+        with patch('socorro.lib.statistics.StatsClient') as StatsClientMocked:
+            s = StatisticsForStatsd(d, 'processor')
+            StatsClientMocked.assert_called_with(
+                'localhost', 666, 'processor')
+
+            s.incr('x')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('processor.x')]
+            )
+
+            s.incr('y')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('processor.y')]
+            )
+
+            s.incr('z')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('processor.z')]
+            )
+
+            s.incr('w')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('processor.y'),
+                    call.incr('processor.x'),
+                    call.incr('processor.y')
+                ]
+            )
+
+            s.incr(None)
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('processor.y'),
+                    call.incr('processor.x'),
+                    call.incr('processor.y'),
+                    call.incr('processor.unknown')
+                ]
+            )
+
+
+    def test_statistics_all_missing_prefix_and_missing_name(self):
+        d = DotDict()
+        d.statsd_host = 'localhost'
+        d.statsd_port = 666
+        d.prefix = None
+        d.active_counters_list = ['x', 'y', 'z']
+
+        with patch('socorro.lib.statistics.StatsClient') as StatsClientMocked:
+            s = StatisticsForStatsd(d, None)
+            StatsClientMocked.assert_called_with(
+                'localhost', 666, '')
+
+            s.incr('x')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('x')]
+            )
+
+            s.incr('y')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('y')]
+            )
+
+            s.incr('z')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [call.incr('z')]
+            )
+
+            s.incr('w')
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('y'),
+                    call.incr('x'),
+                    call.incr('y')
+                ]
+            )
+
+            s.incr(None)
+            StatsClientMocked.assert_has_calls(
+                StatsClientMocked.mock_calls,
+                [
+                    call.incr('y'),
+                    call.incr('x'),
+                    call.incr('y'),
+                    call.incr('unknown')
+                ]
+            )

--- a/socorro/unittest/lib/test_task_manager.py
+++ b/socorro/unittest/lib/test_task_manager.py
@@ -1,0 +1,137 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from mock import Mock
+from nose.tools import eq_, ok_
+
+from socorro.lib.task_manager import TaskManager, default_task_func
+from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.unittest.testbase import TestCase
+
+
+class TestTaskManager(TestCase):
+
+    def setUp(self):
+        super(TestTaskManager, self).setUp()
+        self.logger = SilentFakeLogger()
+
+    def test_constuctor1(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.quit_on_empty_queue =  False
+
+        tm = TaskManager(config)
+        ok_(tm.config == config)
+        ok_(tm.logger == self.logger)
+        ok_(tm.task_func == default_task_func)
+        ok_(tm.quit == False)
+
+    def test_executor_identity(self):
+        config = DotDict()
+        config.logger = self.logger
+        tm = TaskManager(
+            config,
+            job_source_iterator=range(1),
+
+        )
+        tm._pid = 666
+        eq_(tm.executor_identity(), '666-MainThread')
+
+    def test_get_iterator(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.quit_on_empty_queue =  False
+
+        tm = TaskManager(
+            config,
+            job_source_iterator=range(1),
+        )
+        eq_(tm._get_iterator(), [0])
+
+        def an_iter(self):
+            for i in range(5):
+                yield i
+
+        tm = TaskManager(
+            config,
+            job_source_iterator=an_iter,
+        )
+        eq_(
+            [x for x in tm._get_iterator()],
+            [0, 1, 2, 3, 4]
+        )
+
+        class X(object):
+            def __init__(self, config):
+                self.config = config
+
+            def __iter__(self):
+                for key in self.config:
+                    yield key
+
+        tm = TaskManager(
+            config,
+            job_source_iterator=X(config)
+        )
+        eq_(
+            [x for x in tm._get_iterator()],
+            [y for y in config.keys()]
+        )
+
+    def test_blocking_start(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.idle_delay = 1
+        config.quit_on_empty_queue =  False
+
+        class MyTaskManager(TaskManager):
+            def _responsive_sleep(
+                self,
+                seconds,
+                wait_log_interval=0,
+                wait_reason=''
+            ):
+                try:
+                    if self.count >= 2:
+                        self.quit = True
+                    self.count += 1
+                except AttributeError:
+                    self.count = 0
+
+        tm = MyTaskManager(
+            config,
+            task_func=Mock()
+        )
+
+        waiting_func = Mock()
+
+        tm.blocking_start(waiting_func=waiting_func)
+
+        eq_(
+            tm.task_func.call_count,
+            10
+        )
+        eq_(waiting_func.call_count, 0)
+
+
+    def test_blocking_start_with_quit_on_empty(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.idle_delay = 1
+        config.quit_on_empty_queue =  True
+
+        tm = TaskManager(
+            config,
+            task_func=Mock()
+        )
+
+        waiting_func = Mock()
+
+        tm.blocking_start(waiting_func=waiting_func)
+
+        eq_(
+            tm.task_func.call_count,
+            10
+        )
+        eq_(waiting_func.call_count, 0)

--- a/socorro/unittest/lib/test_threaded_task_manager.py
+++ b/socorro/unittest/lib/test_threaded_task_manager.py
@@ -1,0 +1,217 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import time
+
+from nose.tools import ok_, eq_
+from mock import Mock
+
+from socorro.lib.threaded_task_manager import ThreadedTaskManager, \
+      ThreadedTaskManagerWithConfigSetup, \
+      default_task_func
+from socorro.lib.util import DotDict, SilentFakeLogger
+from socorro.unittest.testbase import TestCase
+
+
+class TestThreadedTaskManager(TestCase):
+
+    def setUp(self):
+        super(TestThreadedTaskManager, self).setUp()
+        self.logger = SilentFakeLogger()
+
+    def test_constuctor1(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 1
+        config.maximum_queue_size = 1
+        ttm = ThreadedTaskManager(config)
+        try:
+            ok_(ttm.config == config)
+            ok_(ttm.logger == self.logger)
+            ok_(ttm.task_func == default_task_func)
+            ok_(ttm.quit == False)
+        finally:
+            # we got threads to join
+            ttm._kill_worker_threads()
+
+    def test_start1(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 1
+        config.maximum_queue_size = 1
+        ttm = ThreadedTaskManager(config)
+        try:
+            ttm.start()
+            time.sleep(0.2)
+            ok_(ttm.queuing_thread.isAlive(),
+                            "the queing thread is not running")
+            ok_(len(ttm.thread_list) == 1,
+                            "where's the worker thread?")
+            ok_(ttm.thread_list[0].isAlive(),
+                            "the worker thread is stillborn")
+            ttm.stop()
+            ok_(ttm.queuing_thread.isAlive() == False,
+                            "the queuing thread did not stop")
+        except Exception:
+            # we got threads to join
+            ttm.wait_for_completion()
+
+    def test_doing_work_with_one_worker(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 1
+        config.maximum_queue_size = 1
+        my_list = []
+
+        def insert_into_list(anItem):
+            my_list.append(anItem)
+
+        ttm = ThreadedTaskManager(config,
+                                  task_func=insert_into_list
+                                 )
+        try:
+            ttm.start()
+            time.sleep(0.2)
+            ok_(len(my_list) == 10,
+                            'expected to do 10 inserts, '
+                               'but %d were done instead' % len(my_list))
+            ok_(my_list == range(10),
+                            'expected %s, but got %s' % (range(10), my_list))
+            ttm.stop()
+        except Exception:
+            # we got threads to join
+            ttm.wait_for_completion()
+            raise
+
+    def test_doing_work_with_two_workers_and_generator(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 2
+        config.maximum_queue_size = 2
+        my_list = []
+
+        def insert_into_list(anItem):
+            my_list.append(anItem)
+
+        ttm = ThreadedTaskManager(config,
+                                  task_func=insert_into_list,
+                                  job_source_iterator=(((x,), {}) for x in
+                                                       xrange(10))
+                                 )
+        try:
+            ttm.start()
+            time.sleep(0.2)
+            ok_(len(ttm.thread_list) == 2,
+                            "expected 2 threads, but found %d"
+                              % len(ttm.thread_list))
+            ok_(len(my_list) == 10,
+                            'expected to do 10 inserts, '
+                              'but %d were done instead' % len(my_list))
+            ok_(sorted(my_list) == range(10),
+                            'expected %s, but got %s' % (range(10),
+                                                         sorted(my_list)))
+        except Exception:
+            # we got threads to join
+            ttm.wait_for_completion()
+            raise
+
+    def test_doing_work_with_two_workers_and_config_setup(self):
+        def new_iter():
+            for x in xrange(5):
+                yield ((x,), {})
+
+        my_list = []
+
+        def insert_into_list(anItem):
+            my_list.append(anItem)
+
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 2
+        config.maximum_queue_size = 2
+        config.job_source_iterator = new_iter
+        config.task_func = insert_into_list
+        ttm = ThreadedTaskManagerWithConfigSetup(config)
+        try:
+            ttm.start()
+            time.sleep(0.2)
+            ok_(len(ttm.thread_list) == 2,
+                            "expected 2 threads, but found %d"
+                              % len(ttm.thread_list))
+            ok_(len(my_list) == 5,
+                            'expected to do 5 inserts, '
+                              'but %d were done instead' % len(my_list))
+            ok_(sorted(my_list) == range(5),
+                            'expected %s, but got %s' % (range(5),
+                                                         sorted(my_list)))
+        except Exception:
+            # we got threads to join
+            ttm.wait_for_completion()
+            raise
+
+    # failure tests
+
+    count = 0
+
+    def test_task_raises_unexpected_exception(self):
+        global count
+        count = 0
+
+        def new_iter():
+            for x in xrange(10):
+                yield (x,)
+
+        my_list = []
+
+        def insert_into_list(anItem):
+            global count
+            count += 1
+            if count == 4:
+                raise Exception('Unexpected')
+            my_list.append(anItem)
+
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 1
+        config.maximum_queue_size = 1
+        config.job_source_iterator = new_iter
+        config.task_func = insert_into_list
+        ttm = ThreadedTaskManagerWithConfigSetup(config)
+        try:
+            ttm.start()
+            time.sleep(0.2)
+            ok_(len(ttm.thread_list) == 1,
+                            "expected 1 threads, but found %d"
+                              % len(ttm.thread_list))
+            ok_(sorted(my_list) == [0, 1, 2, 4, 5, 6, 7, 8, 9],
+                            'expected %s, but got %s'
+                              % ([0, 1, 2, 5, 6, 7, 8, 9], sorted(my_list)))
+            ok_(len(my_list) == 9,
+                            'expected to do 9 inserts, '
+                              'but %d were done instead' % len(my_list))
+        except Exception:
+            # we got threads to join
+            ttm.wait_for_completion()
+            raise
+
+    def test_blocking_start_with_quit_on_empty(self):
+        config = DotDict()
+        config.logger = self.logger
+        config.number_of_threads = 2
+        config.maximum_queue_size = 2
+        config.quit_on_empty_queue =  True
+
+        tm = ThreadedTaskManager(
+            config,
+            task_func=Mock()
+        )
+
+        waiting_func = Mock()
+
+        tm.blocking_start(waiting_func=waiting_func)
+
+        eq_(
+            tm.task_func.call_count,
+            10
+        )

--- a/socorro/unittest/lib/test_transform_rules.py
+++ b/socorro/unittest/lib/test_transform_rules.py
@@ -1,0 +1,711 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from nose.tools import eq_, ok_, assert_raises
+from mock import Mock
+
+from configman.dotdict import DotDict
+from configman import Namespace
+
+from socorro.lib import transform_rules
+from socorro.unittest.testbase import TestCase
+
+
+def assert_expected(actual, expected):
+    assert actual == expected, "expected:\n%s\nbut got:\n%s" % (str(expected),
+                                                                str(actual))
+
+def assert_expected_same(actual, expected):
+    assert actual == expected, "expected:\n%s\nbut got:\n%s" % (expected,
+                                                                actual)
+
+def foo(s, d):
+    pass
+
+def bar(s, d):
+    pass
+
+
+#==============================================================================
+class TestRuleTestLaughable(transform_rules.Rule):
+    required_config = Namespace()
+    required_config.add_option('laughable', default='fred')
+
+    def _predicate(self, *args, **kwargs):
+        return self.config.laughable != 'fred'
+
+    def close(self):
+        try:
+            self.close_counter += 1
+        except AttributeError:
+            self.close_counter = 1
+
+
+
+#==============================================================================
+class TestRuleTestDangerous(transform_rules.Rule):
+    required_config = Namespace()
+    required_config.add_option('dangerous', default='sally')
+
+    def _action(self, *args, **kwargs):
+        return self.config.dangerous != 'sally'
+
+    def close(self):
+        try:
+            self.close_counter += 1
+        except AttributeError:
+            self.close_counter = 1
+
+
+#==============================================================================
+class TestRuleTestNoCloseMethod(transform_rules.Rule):
+
+    def _action(self, *args, **kwargs):
+        return True
+
+
+#==============================================================================
+class TestRuleTestBrokenCloseMethod(transform_rules.Rule):
+
+    def _action(self, *args, **kwargs):
+        return true
+
+    def close(self):
+        # this is deliberately breaking
+        raise AttributeError("We're human")
+
+
+#==============================================================================
+class TestTransformRules(TestCase):
+
+    def test_kw_str_parse(self):
+        a = 'a=1, b=2'
+        actual = transform_rules.kw_str_parse(a)
+        expected = {'a':1, 'b':2}
+        assert_expected(expected, actual)
+
+        a = 'a="fred", b=3.1415'
+        actual = transform_rules.kw_str_parse(a)
+        expected = {'a':'fred', 'b':3.1415}
+        assert_expected(expected, actual)
+
+    def test_TransfromRule_init(self):
+        r = transform_rules.TransformRule(True, (), {}, True, (), {})
+        assert_expected(r.predicate, True)
+        assert_expected(r.predicate_args, ())
+        assert_expected(r.predicate_kwargs, {})
+        assert_expected(r.action, True)
+        assert_expected(r.action_args, ())
+        assert_expected(r.action_kwargs, {})
+
+        r = transform_rules.TransformRule(True, '', '', True, '', '')
+        assert_expected(r.predicate, True)
+        assert_expected(r.predicate_args, ())
+        assert_expected(r.predicate_kwargs, {})
+        assert_expected(r.action, True)
+        assert_expected(r.action_args, ())
+        assert_expected(r.action_kwargs, {})
+
+        r = transform_rules.TransformRule(foo, '', '', bar, '', '')
+        assert_expected(r.predicate, foo)
+        assert_expected(r.predicate_args, ())
+        assert_expected(r.predicate_kwargs, {})
+        assert_expected(r.action, bar)
+        assert_expected(r.action_args, ())
+        assert_expected(r.action_kwargs, {})
+
+        r = transform_rules.TransformRule(
+            'socorro.unittest.lib.test_transform_rules.foo', '', '',
+            'socorro.unittest.lib.test_transform_rules.bar', '', '')
+        repr_pred = repr(r.predicate)
+        assert 'foo' in repr_pred, 'expected "foo" in %s' % repr_pred
+        assert_expected(r.predicate_args, ())
+        assert_expected(r.predicate_kwargs, {})
+        repr_act = repr(r.action)
+        assert 'bar' in repr_act, 'expected "bar" in %s' % repr_act
+        assert_expected(r.action_args, ())
+        assert_expected(r.action_kwargs, {})
+
+        r = transform_rules.TransformRule(
+            'socorro.unittest.lib.test_transform_rules.foo',
+            (1,),
+            {'a':13},
+            'socorro.unittest.lib.test_transform_rules.bar',
+            '',
+            ''
+        )
+        repr_pred = repr(r.predicate)
+        assert 'foo' in repr_pred, 'expected "foo" in %s' % repr_pred
+        assert_expected(r.predicate_args, (1,))
+        assert_expected(r.predicate_kwargs, {'a':13})
+        repr_act = repr(r.action)
+        assert 'bar' in repr_act, 'expected "bar" in %s' % repr_act
+        assert_expected(r.action_args, ())
+        assert_expected(r.action_kwargs, {})
+
+        r = transform_rules.TransformRule(
+            'socorro.unittest.lib.test_transform_rules.foo',
+            '1, 2',
+            'a=13',
+            'socorro.unittest.lib.test_transform_rules.bar',
+            '',
+            ''
+        )
+        repr_pred = repr(r.predicate)
+        assert 'foo' in repr_pred, 'expected "foo" in %s' % repr_pred
+        assert_expected(r.predicate_args, (1,2))
+        assert_expected(r.predicate_kwargs, {'a':13})
+        repr_act = repr(r.action)
+        assert 'bar' in repr_act, 'expected "bar" in %s' % repr_act
+        assert_expected(r.action_args, ())
+        assert_expected(r.action_kwargs, {})
+
+    def test_TransformRule_with_class(self):
+        """test to make sure that classes can be used as predicates and
+        actions"""
+        class MyRule(object):
+            def __init__(self, config=None):
+                self.predicate_called = False
+                self.action_called = False
+            def predicate(self):
+                self.predicate_called = True
+                return True
+            def action(self):
+                self.action_called = True
+                return True
+        r = transform_rules.TransformRule(
+            MyRule, (), {},
+            MyRule, (), {}
+        )
+        eq_(r.predicate, r._predicate_implementation.predicate)
+        eq_(r.action, r._action_implementation.action)
+        eq_(r._action_implementation, r._predicate_implementation)
+        r.act()
+        ok_(r._predicate_implementation.predicate_called)
+        ok_(r._action_implementation.action_called)
+
+    def test_TransformRule_with_class_function_mix(self):
+        """test to make sure that classes can be mixed with functions as
+        predicates and actions"""
+        class MyRule(object):
+            def __init__(self, config=None):
+                self.predicate_called = False
+                self.action_called = False
+            def predicate(self):
+                self.predicate_called = True
+                return True
+            def action(self):
+                self.action_called = True
+                return True
+
+        def my_predicate():
+            return True
+
+        r = transform_rules.TransformRule(
+            my_predicate, (), {},
+            MyRule, (), {}
+        )
+        eq_(r.predicate, my_predicate)
+        eq_(r.action, r._action_implementation.action)
+        self.assertNotEqual(r._action_implementation, r._predicate_implementation)
+        r.act()
+        # make sure that the class predicate function was not called
+        ok_(not r._action_implementation.predicate_called)
+        ok_(r._action_implementation.action_called)
+
+
+    def test_TransfromRule_function_or_constant(self):
+        r = transform_rules.TransformRule.function_invocation_proxy(True,
+                                                                    (),
+                                                                    {})
+        assert_expected(r, True)
+        r = transform_rules.TransformRule.function_invocation_proxy(False,
+                                                                    (),
+                                                                    {})
+        assert_expected(r, False)
+
+        r = transform_rules.TransformRule.function_invocation_proxy(True,
+                                                                    (1, 2, 3),
+                                                                    {})
+        assert_expected(r, True)
+        r = transform_rules.TransformRule.function_invocation_proxy(False,
+                                                                    (),
+                                                                    {'a':13})
+        assert_expected(r, False)
+
+        r = transform_rules.TransformRule.function_invocation_proxy('True',
+                                                                    (1, 2, 3),
+                                                                    {})
+        assert_expected(r, True)
+        r = transform_rules.TransformRule.function_invocation_proxy(None,
+                                                                    (),
+                                                                    {'a':13})
+        assert_expected(r, False)
+
+        def fn1(*args, **kwargs):
+            return (args, kwargs)
+
+        r = transform_rules.TransformRule.function_invocation_proxy(fn1,
+                                                                    (1, 2, 3),
+                                                                    {})
+        assert_expected(r, ((1, 2, 3), {}))
+        r = transform_rules.TransformRule.function_invocation_proxy(fn1,
+                                                                    (1, 2, 3),
+                                                                    {'a':13})
+        assert_expected(r, ((1, 2, 3), {'a':13}))
+
+
+    def test_TransfromRule_act(self):
+        rule = transform_rules.TransformRule(True, (), {}, True, (), {})
+        r = rule.act()
+        assert_expected(r, (True, True))
+
+        rule = transform_rules.TransformRule(True, (), {}, False, (), {})
+        r = rule.act()
+        assert_expected(r, (True, False))
+
+        def pred1(s, d, fred):
+            return bool(fred)
+        s = {'dwight': 96}
+        d = {}
+
+        rule = transform_rules.TransformRule(pred1, (True), {}, False, (), {})
+        r = rule.act(s, d)
+        assert_expected(r, (True, False))
+
+        rule = transform_rules.TransformRule(pred1, (), {'fred':True},
+                                             False, (), {})
+        r = rule.act(s, d)
+        assert_expected(r, (True, False))
+
+        rule = transform_rules.TransformRule(pred1, (), {'fred':False},
+                                             False, (), {})
+        r = rule.act(s, d)
+        assert_expected(r, (False, None))
+
+        def copy1(s, d, s_key, d_key):
+            d[d_key] = s[s_key]
+            return True
+
+        rule = transform_rules.TransformRule(pred1, (), {'fred':True},
+                                             copy1, (),
+                                               's_key="dwight", d_key="wilma"')
+        r = rule.act(s, d)
+        assert_expected(r, (True, True))
+        assert_expected(s['dwight'], 96)
+        assert_expected(d['wilma'], 96)
+
+
+    def test_TransformRuleSystem_init(self):
+        rules = transform_rules.TransformRuleSystem()
+        assert_expected(rules.rules, [])
+
+    def test_TransformRuleSystem_load_rules(self):
+        rules = transform_rules.TransformRuleSystem()
+        some_rules = [(True, '', '', True, '', ''),
+                      (False, '', '', False, '', '')]
+        rules.load_rules(some_rules)
+        expected = [transform_rules.TransformRule(*(True, (), {},
+                                                    True, (), {})),
+                    transform_rules.TransformRule(*(False, (), {},
+                                                    False, (), {}))]
+        assert_expected_same(rules.rules, expected)
+
+    def test_TransformRuleSystem_append_rules(self):
+        rules = transform_rules.TransformRuleSystem()
+        some_rules = [(True, '', '', True, '', ''),
+                      (False, '', '', False, '', '')]
+        rules.append_rules(some_rules)
+        expected = [transform_rules.TransformRule(*(True, (), {},
+                                                    True, (), {})),
+                    transform_rules.TransformRule(*(False, (), {},
+                                                    False, (), {}))]
+        assert_expected_same(rules.rules, expected)
+
+    def test_TransformRuleSystem_apply_all_rules(self):
+
+        quit_check_mock = Mock()
+
+        def assign_1(s, d):
+            d['one'] = 1
+            return True
+
+        def increment_1(s, d):
+            try:
+                d['one'] += 1
+                return True
+            except KeyError:
+                return False
+
+        some_rules = [(True, '', '', increment_1, '', ''),
+                      (True, '', '', assign_1, '', ''),
+                      (False, '', '', increment_1, '', ''),
+                      (True, '', '', increment_1, '', ''),
+                     ]
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
+        rules.load_rules(some_rules)
+        s = {}
+        d = {}
+        rules.apply_all_rules(s, d)
+        assert_expected(d, {'one': 2})
+        assert_expected(quit_check_mock.call_count, 4)
+
+    def test_TransformRuleSystem_apply_all_until_action_succeeds(self):
+
+        quit_check_mock = Mock()
+
+        def assign_1(s, d):
+            d['one'] = 1
+            return True
+
+        def increment_1(s, d):
+            try:
+                d['one'] += 1
+                return True
+            except KeyError:
+                return False
+
+        some_rules = [(True, '', '', increment_1, '', ''),
+                      (True, '', '', assign_1, '', ''),
+                      (False, '', '', increment_1, '', ''),
+                      (True, '', '', increment_1, '', ''),
+                     ]
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
+        rules.load_rules(some_rules)
+        s = {}
+        d = {}
+        rules.apply_until_action_succeeds(s, d)
+        assert_expected(d, {'one': 1})
+        assert_expected(quit_check_mock.call_count, 2)
+
+
+    def test_TransformRuleSystem_apply_all_until_action_fails(self):
+
+        quit_check_mock = Mock()
+
+        def assign_1(s, d):
+            d['one'] = 1
+            return True
+
+        def increment_1(s, d):
+            try:
+                d['one'] += 1
+                return True
+            except KeyError:
+                return False
+
+        some_rules = [(True, '', '', increment_1, '', ''),
+                      (True, '', '', assign_1, '', ''),
+                      (False, '', '', increment_1, '', ''),
+                      (True, '', '', increment_1, '', ''),
+                     ]
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
+        rules.load_rules(some_rules)
+        s = {}
+        d = {}
+        rules.apply_until_action_fails(s, d)
+        assert_expected(d, {})
+        assert_expected(quit_check_mock.call_count, 1)
+
+
+    def test_TransformRuleSystem_apply_all_until_predicate_succeeds(self):
+
+        quit_check_mock = Mock()
+
+        def assign_1(s, d):
+            d['one'] = 1
+            return True
+
+        def increment_1(s, d):
+            try:
+                d['one'] += 1
+                return True
+            except KeyError:
+                return False
+
+        some_rules = [(True, '', '', increment_1, '', ''),
+                      (True, '', '', assign_1, '', ''),
+                      (False, '', '', increment_1, '', ''),
+                      (True, '', '', increment_1, '', ''),
+                     ]
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
+        rules.load_rules(some_rules)
+        s = {}
+        d = {}
+        rules.apply_until_predicate_succeeds(s, d)
+        assert_expected(d, {})
+        assert_expected(quit_check_mock.call_count, 1)
+
+    def test_TransformRuleSystem_apply_all_until_predicate_fails(self):
+
+        quit_check_mock = Mock()
+
+        def assign_1(s, d):
+            d['one'] = 1
+            return True
+
+        def increment_1(s, d):
+            try:
+                d['one'] += 1
+                return True
+            except KeyError:
+                return False
+
+        some_rules = [(True, '', '', increment_1, '', ''),
+                      (True, '', '', assign_1, '', ''),
+                      (False, '', '', increment_1, '', ''),
+                      (True, '', '', increment_1, '', ''),
+                     ]
+        rules = transform_rules.TransformRuleSystem(quit_check=quit_check_mock)
+        rules.load_rules(some_rules)
+        s = {}
+        d = {}
+        rules.apply_until_predicate_fails(s, d)
+        assert_expected(d, {'one': 1})
+
+        some_rules = [
+            (True, '', '', True, '', ''),
+            (True, '', '', False, '', ''),
+        ]
+        rules.load_rules(some_rules)
+        res = rules.apply_until_predicate_fails()
+        assert_expected(res, None)
+
+        some_rules = [
+            (True, '', '', True, '', ''),
+            (False, '', '', False, '', ''),
+        ]
+        rules.load_rules(some_rules)
+        res = rules.apply_until_predicate_fails()
+        assert_expected(res, False)
+
+        some_rules = [
+            (True, '', '', True, '', ''),
+            (False, '', '', True, '', ''),
+        ]
+        rules.load_rules(some_rules)
+        res = rules.apply_until_predicate_fails()
+        assert_expected(res, False)
+
+        assert_expected(quit_check_mock.call_count, 9)
+
+    def test_is_not_null_predicate(self):
+        ok_(
+            transform_rules.is_not_null_predicate(
+                {'alpha': 'hello'}, None, None, None, 'alpha'
+            )
+        )
+        ok_(not
+            transform_rules.is_not_null_predicate(
+                {'alpha': 'hello'}, None, None, None, 'beta'
+            )
+        )
+        ok_(not
+            transform_rules.is_not_null_predicate(
+                {'alpha': ''}, None, None, None, 'alpha'
+            )
+        )
+        ok_(not
+            transform_rules.is_not_null_predicate(
+                {'alpha': None}, None, None, None, 'alpha'
+            )
+        )
+
+    def test_rule_simple(self):
+        fake_config = DotDict()
+        fake_config.logger = Mock()
+        fake_config.chatty_rules = False
+        fake_config.chatty = False
+
+        r1 = transform_rules.Rule(fake_config)
+        eq_(r1.predicate(None, None, None, None), True)
+        eq_(r1.action(None, None, None, None), True)
+        eq_(r1.act(), (True, True))
+
+        class BadPredicate(transform_rules.Rule):
+            def _predicate(self, *args, **kwargs):
+                return False
+
+        r2 = BadPredicate(fake_config)
+        eq_(r2.predicate(None, None, None, None), False)
+        eq_(r2.action(None, None, None, None), True)
+        eq_(r2.act(), (False, None))
+
+        class BadAction(transform_rules.Rule):
+            def _action(self, *args, **kwargs):
+                return False
+
+        r3 = BadAction(fake_config)
+        eq_(r3.predicate(None, None, None, None), True)
+        eq_(r3.action(None, None, None, None), False)
+        eq_(r3.act(), (True, False))
+
+    def test_rule_exceptions(self):
+        fake_config = DotDict()
+        fake_config.logger = Mock()
+        fake_config.chatty_rules = False
+        fake_config.chatty = False
+
+        class BadPredicate(transform_rules.Rule):
+            def _predicate(self, *args, **kwargs):
+                raise Exception("highwater")
+
+        r2 = BadPredicate(fake_config)
+        ok_(not fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        eq_(r2.predicate(None, None, None, None), False)
+        ok_(fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        eq_(r2.action(None, None, None, None), True)
+        ok_(not fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        eq_(r2.act(), (False, None))
+        ok_(fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        class BadAction(transform_rules.Rule):
+            def _action(self, *args, **kwargs):
+                raise Exception("highwater")
+
+        r3 = BadAction(fake_config)
+        ok_(not fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        eq_(r3.predicate(None, None, None, None), True)
+        ok_(not fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        eq_(r3.action(None, None, None, None), False)
+        ok_(fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+        eq_(r3.act(), (True, False))
+        ok_(fake_config.logger.debug.called)
+        fake_config.logger.debug.reset_mock()
+
+    def test_rules_in_config(self):
+        config = DotDict()
+        config.chatty_rules = False
+        config.chatty = False
+        config.tag = 'test.rule'
+        config.action = 'apply_all_rules'
+        config['TestRuleTestLaughable.laughable'] = 'wilma'
+        config['TestRuleTestDangerous.dangerous'] = 'dwight'
+        config.rules_list = DotDict()
+        config.rules_list.class_list = [
+            (
+                'TestRuleTestLaughable',
+                TestRuleTestLaughable,
+                'TestRuleTestLaughable'
+            ),
+            (
+                'TestRuleTestDangerous',
+                TestRuleTestDangerous,
+                'TestRuleTestDangerous'
+            )
+        ]
+        trs = transform_rules.TransformRuleSystem(config)
+
+        ok_(isinstance(trs.rules[0], TestRuleTestLaughable))
+        ok_(isinstance(trs.rules[1], TestRuleTestDangerous))
+        ok_(trs.rules[0].predicate(None))
+        ok_(trs.rules[1].action(None))
+
+    def test_rules_close(self):
+        config = DotDict()
+        config.logger = Mock().s
+        config.chatty_rules = False
+        config.chatty = False
+        config.tag = 'test.rule'
+        config.action = 'apply_all_rules'
+        config['TestRuleTestLaughable.laughable'] = 'wilma'
+        config['TestRuleTestDangerous.dangerous'] = 'dwight'
+        config.rules_list = DotDict()
+        config.rules_list.class_list = [
+            (
+                'TestRuleTestLaughable',
+                TestRuleTestLaughable,
+                'TestRuleTestLaughable'
+            ),
+            (
+                'TestRuleTestDangerous',
+                TestRuleTestDangerous,
+                'TestRuleTestDangerous'
+            )
+        ]
+        trs = transform_rules.TransformRuleSystem(config)
+
+        trs.close()
+
+        eq_(trs.rules[0].close_counter, 1)
+        eq_(trs.rules[1].close_counter, 1)
+
+    def test_rules_close_if_close_method_available(self):
+        config = DotDict()
+        config.logger = Mock()
+        config.chatty_rules = False
+        config.chatty = False
+        config.tag = 'test.rule'
+        config.action = 'apply_all_rules'
+        config.rules_list = DotDict()
+        config.rules_list.class_list = [
+            (
+                'TestRuleTestNoCloseMethod',
+                TestRuleTestNoCloseMethod,
+                'TestRuleTestNoCloseMethod'
+            ),
+            (
+                'TestRuleTestDangerous',
+                TestRuleTestDangerous,
+                'TestRuleTestDangerous'
+            )
+        ]
+        trs = transform_rules.TransformRuleSystem(config)
+        trs.close()
+
+        assert len(config.logger.debug.mock_calls) == 3
+        config.logger.debug.assert_any_call(
+            'trying to close %s',
+            'socorro.unittest.lib.test_transform_rules.'
+            'TestRuleTestNoCloseMethod'
+        )
+        config.logger.debug.assert_any_call(
+            'trying to close %s',
+            'socorro.unittest.lib.test_transform_rules.'
+            'TestRuleTestDangerous'
+        )
+        config.logger.debug.assert_any_call(
+            '%s has no close',
+            'socorro.unittest.lib.test_transform_rules.'
+            'TestRuleTestNoCloseMethod'
+        )
+
+    def test_rules_close_bubble_close_errors(self):
+        config = DotDict()
+        config.logger = Mock()
+        config.tag = 'test.rule'
+        config.action = 'apply_all_rules'
+        config.rules_list = DotDict()
+        config.rules_list.class_list = [
+            (
+                'TestRuleTestBrokenCloseMethod',
+                TestRuleTestBrokenCloseMethod,
+                'TestRuleTestBrokenCloseMethod'
+            ),
+        ]
+        trs = transform_rules.TransformRuleSystem(config)
+        assert_raises(
+            AttributeError,
+            trs.close
+        )
+
+        assert len(config.logger.debug.mock_calls) == 1
+        config.logger.debug.assert_any_call(
+            'trying to close %s',
+            'socorro.unittest.lib.test_transform_rules.'
+            'TestRuleTestBrokenCloseMethod'
+        )

--- a/socorro/unittest/middleware/test_middleware_app.py
+++ b/socorro/unittest/middleware/test_middleware_app.py
@@ -17,14 +17,14 @@ from configman import (
     environment
 )
 
-from socorrolib.lib.util import DotDict
-from socorrolib.lib import (
+from socorro.lib.util import DotDict
+from socorro.lib import (
     MissingArgumentError,
     BadArgumentError,
     ResourceNotFound,
     ResourceUnavailable
 )
-from socorrolib.lib import datetimeutil
+from socorro.lib import datetimeutil
 from socorro.middleware import middleware_app
 from socorro.unittest.testbase import TestCase
 from socorro.webapi.servers import CherryPy

--- a/socorro/unittest/middleware/test_search_common.py
+++ b/socorro/unittest/middleware/test_search_common.py
@@ -7,11 +7,11 @@ import datetime
 from nose.tools import eq_, ok_, assert_raises
 from configman import ConfigurationManager, Namespace
 
-from socorrolib.lib import BadArgumentError, datetimeutil
+from socorro.lib import BadArgumentError, datetimeutil
 from socorro.middleware.search_common import (
     SearchBase, SearchParam, convert_to_type, get_parameters, restrict_fields
 )
-from socorrolib.unittest.testbase import TestCase
+from socorro.unittest.testbase import TestCase
 
 
 SUPERSEARCH_FIELDS_MOCKED_RESULTS = {

--- a/socorro/unittest/processor/test_breakpad_pipe_to_json.py
+++ b/socorro/unittest/processor/test_breakpad_pipe_to_json.py
@@ -6,7 +6,7 @@ from nose.tools import eq_, ok_
 
 import socorro.processor.breakpad_pipe_to_json as bpj
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.unittest.testbase import TestCase
 
 cannonical_json_dump = {

--- a/socorro/unittest/processor/test_breakpad_transform_rules.py
+++ b/socorro/unittest/processor/test_breakpad_transform_rules.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from configman.dotdict import DotDict as CDotDict
 
 from socorro.unittest.testbase import TestCase
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.processor.breakpad_transform_rules import (
     BreakpadStackwalkerRule,
     BreakpadStackwalkerRule2015,

--- a/socorro/unittest/processor/test_general_transform_rules.py
+++ b/socorro/unittest/processor/test_general_transform_rules.py
@@ -10,7 +10,7 @@ from mock import Mock
 from configman.dotdict import DotDict as CDotDict
 
 from socorro.unittest.testbase import TestCase
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.processor.general_transform_rules import (
     IdentifierRule,
     CPUInfoRule,

--- a/socorro/unittest/processor/test_hybrid_processor.py
+++ b/socorro/unittest/processor/test_hybrid_processor.py
@@ -15,8 +15,8 @@ from socorro.processor.hybrid_processor import (
   HybridCrashProcessor,
   create_symbol_path_str
 )
-from socorrolib.lib.datetimeutil import datetimeFromISOdateString, UTC
-from socorrolib.lib.util import CachingIterator
+from socorro.lib.datetimeutil import datetimeFromISOdateString, UTC
+from socorro.lib.util import CachingIterator
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/processor/test_legacy_processor.py
+++ b/socorro/unittest/processor/test_legacy_processor.py
@@ -14,7 +14,7 @@ from socorro.processor.legacy_processor import (
   LegacyCrashProcessor,
   create_symbol_path_str
 )
-from socorrolib.lib.datetimeutil import datetimeFromISOdateString, UTC
+from socorro.lib.datetimeutil import datetimeFromISOdateString, UTC
 from socorro.unittest.testbase import TestCase
 
 

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -13,8 +13,8 @@ from nose.tools import eq_, ok_
 from configman.dotdict import DotDict as CDotDict
 
 from socorro.unittest.testbase import TestCase
-from socorrolib.lib.util import DotDict
-from socorrolib.lib.datetimeutil import datetimeFromISOdateString
+from socorro.lib.util import DotDict
+from socorro.lib.datetimeutil import datetimeFromISOdateString
 from socorro.processor.mozilla_transform_rules import (
     ProductRule,
     UserDataRule,

--- a/socorro/unittest/processor/test_processor_2015.py
+++ b/socorro/unittest/processor/test_processor_2015.py
@@ -11,8 +11,8 @@ from socorro.processor.processor_2015 import (
     Processor2015,
     rule_sets_from_string
 )
-from socorrolib.lib.util import DotDict as SDotDict
-from socorrolib.lib.transform_rules import TransformRuleSystem
+from socorro.lib.util import DotDict as SDotDict
+from socorro.lib.transform_rules import TransformRuleSystem
 from socorro.processor.support_classifiers import (
     BitguardClassifier,
     OutOfDateClassifier
@@ -26,7 +26,7 @@ rule_set_01 = [
     [
         'ruleset01',
         'tag0.tag1',
-        'socorrolib.lib.transform_rules.TransformRuleSystem',
+        'socorro.lib.transform_rules.TransformRuleSystem',
         'apply_all_rules',
         'socorro.processor.support_classifiers.BitguardClassifier, '
         'socorro.processor.support_classifiers.OutOfDateClassifier'
@@ -38,7 +38,7 @@ rule_set_02 = [
     [
         'ruleset01',
         'tag0.tag1',
-        'socorrolib.lib.transform_rules.TransformRuleSystem',
+        'socorro.lib.transform_rules.TransformRuleSystem',
         'apply_all_rules',
         'socorro.processor.support_classifiers.BitguardClassifier, '
         'socorro.processor.support_classifiers.OutOfDateClassifier'
@@ -46,7 +46,7 @@ rule_set_02 = [
     [
         'ruleset02',
         'tag2.tag3',
-        'socorrolib.lib.transform_rules.TransformRuleSystem',
+        'socorro.lib.transform_rules.TransformRuleSystem',
         'apply_until_action_succeeds',
         'socorro.processor.skunk_classifiers.SetWindowPos, '
         'socorro.processor.skunk_classifiers.UpdateWindowAttributes'
@@ -62,7 +62,7 @@ class TestProcessor2015(TestCase):
         ok_('ruleset01' in rc)
         eq_('tag0.tag1', rc.ruleset01.tag.default)
         eq_(
-            'socorrolib.lib.transform_rules.TransformRuleSystem',
+            'socorro.lib.transform_rules.TransformRuleSystem',
             rc.ruleset01.rule_system_class.default
         )
         eq_('apply_all_rules', rc.ruleset01.action.default)
@@ -79,7 +79,7 @@ class TestProcessor2015(TestCase):
         ok_('ruleset01' in rc)
         eq_('tag0.tag1', rc.ruleset01.tag.default)
         eq_(
-            'socorrolib.lib.transform_rules.TransformRuleSystem',
+            'socorro.lib.transform_rules.TransformRuleSystem',
             rc.ruleset01.rule_system_class.default
         )
         eq_('apply_all_rules', rc.ruleset01.action.default)
@@ -92,7 +92,7 @@ class TestProcessor2015(TestCase):
         ok_('ruleset02' in rc)
         eq_('tag2.tag3', rc.ruleset02.tag.default)
         eq_(
-            'socorrolib.lib.transform_rules.TransformRuleSystem',
+            'socorro.lib.transform_rules.TransformRuleSystem',
             rc.ruleset02.rule_system_class.default
         )
         eq_('apply_until_action_succeeds', rc.ruleset02.action.default)

--- a/socorro/unittest/processor/test_signature_utilities.py
+++ b/socorro/unittest/processor/test_signature_utilities.py
@@ -9,9 +9,9 @@ from nose.tools import eq_, ok_
 
 from configman.dotdict import DotDict as CDotDict
 
-import socorrolib.lib.util as sutil
+import socorro.lib.util as sutil
 
-from socorrolib.lib.util import DotDict
+from socorro.lib.util import DotDict
 from socorro.processor.signature_utilities import (
     AbortSignature,
     CSignatureTool,

--- a/socorro/unittest/processor/test_skunk_classifiers.py
+++ b/socorro/unittest/processor/test_skunk_classifiers.py
@@ -6,7 +6,7 @@ import copy
 
 from nose.tools import eq_, ok_
 
-from socorrolib.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.util import DotDict, SilentFakeLogger
 from socorro.processor.skunk_classifiers import (
     SkunkClassificationRule,
     DontConsiderTheseFilter,

--- a/socorro/unittest/processor/test_support_classifiers.py
+++ b/socorro/unittest/processor/test_support_classifiers.py
@@ -8,7 +8,7 @@ from nose.tools import eq_, ok_
 
 from sys import maxint
 
-from socorrolib.lib.util import DotDict, SilentFakeLogger
+from socorro.lib.util import DotDict, SilentFakeLogger
 from socorro.processor.support_classifiers import (
     SupportClassificationRule,
     BitguardClassifier,

--- a/socorro/webapi/webapiService.py
+++ b/socorro/webapi/webapiService.py
@@ -7,8 +7,8 @@ import web
 import cgi
 import re
 
-import socorrolib.lib.util as util
-from socorrolib.lib import (
+import socorro.lib.util as util
+from socorro.lib import (
     DatabaseError,
     InsertionError,
     MissingArgumentError,

--- a/tools/submit_crash_to_rabbitmq.py
+++ b/tools/submit_crash_to_rabbitmq.py
@@ -15,8 +15,8 @@ To run it, pass one more more crash IDs like this::
 import logging
 
 from configman import configuration, Namespace
-from socorrolib.lib.util import DotDict
-from socorrolib.lib.converters import change_default
+from socorro.lib.util import DotDict
+from socorro.lib.converters import change_default
 from socorro.external.rabbitmq.connection_context import ConnectionContext
 from socorro.external.rabbitmq.crashstorage import RabbitMQCrashStorage
 from socorro.database.transaction_executor import TransactionExecutor

--- a/webapp-django/crashstats/api/tests/test_views.py
+++ b/webapp-django/crashstats/api/tests/test_views.py
@@ -10,7 +10,7 @@ import mock
 import pyquery
 from nose.tools import eq_, ok_
 
-from socorrolib.lib import BadArgumentError, MissingArgumentError
+from socorro.lib import BadArgumentError, MissingArgumentError
 from crashstats.base.tests.testbase import TestCase
 from crashstats.crashstats.tests.test_views import (
     BaseTestViews,

--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -16,7 +16,7 @@ from django.forms.forms import DeclarativeFieldsMetaclass
 from ratelimit.decorators import ratelimit
 from waffle.decorators import waffle_switch
 
-from socorrolib.lib import BadArgumentError, MissingArgumentError
+from socorro.lib import BadArgumentError, MissingArgumentError
 from socorro.external.crashstorage_base import CrashIDNotFound
 
 import crashstats

--- a/webapp-django/crashstats/base/tests/test_ga.py
+++ b/webapp-django/crashstats/base/tests/test_ga.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
 from django.core.urlresolvers import reverse
 
-from socorrolib.lib import BadArgumentError
+from socorro.lib import BadArgumentError
 
 from crashstats.crashstats.models import ProductBuildTypes
 from crashstats.base.tests.testbase import DjangoTestCase

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -12,7 +12,7 @@ import time
 import ujson
 from configman import configuration, Namespace
 
-from socorrolib.lib import BadArgumentError
+from socorro.lib import BadArgumentError
 from socorro.external.es.base import ElasticsearchConfig
 from socorro.external.postgresql.crashstorage import PostgreSQLCrashStorage
 from socorro.external.rabbitmq.crashstorage import (
@@ -33,7 +33,7 @@ import socorro.external.postgresql.signature_first_date
 import socorro.external.postgresql.server_status
 import socorro.external.boto.crash_data
 
-from socorrolib.app import socorro_app
+from socorro.app import socorro_app
 
 from django.conf import settings
 from django.core.cache import cache

--- a/webapp-django/crashstats/signature/views.py
+++ b/webapp-django/crashstats/signature/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.shortcuts import render
 
-from socorrolib.lib import BadArgumentError
+from socorro.lib import BadArgumentError
 
 from crashstats.base.utils import render_exception, urlencode_obj
 from crashstats.api.views import has_permissions

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -11,7 +11,7 @@ from django.core.urlresolvers import reverse
 
 from waffle.models import Switch
 
-from socorrolib.lib import BadArgumentError
+from socorro.lib import BadArgumentError
 
 from crashstats.crashstats.tests.test_views import BaseTestViews, Response
 from crashstats.supersearch.models import SuperSearchUnredacted

--- a/webapp-django/crashstats/supersearch/views.py
+++ b/webapp-django/crashstats/supersearch/views.py
@@ -15,7 +15,7 @@ from ratelimit.decorators import ratelimit
 
 from waffle.decorators import waffle_switch
 
-from socorrolib.lib import BadArgumentError
+from socorro.lib import BadArgumentError
 
 from crashstats.base.utils import render_exception, urlencode_obj
 from crashstats.api.views import has_permissions

--- a/wsgi/collector.py
+++ b/wsgi/collector.py
@@ -1,5 +1,5 @@
 import os
-from socorrolib.app.socorro_app import (
+from socorro.app.socorro_app import (
     SocorroWelcomeApp,
     main
 )

--- a/wsgi/collector.wsgi
+++ b/wsgi/collector.wsgi
@@ -1,5 +1,5 @@
 import os
-from socorrolib.app.generic_app import main
+from socorro.app.generic_app import main
 from socorro.collector.collector_app import CollectorApp
 from socorro.webapi.servers import ApacheModWSGI
 import socorro.collector.collector_app

--- a/wsgi/middleware.py
+++ b/wsgi/middleware.py
@@ -1,5 +1,5 @@
 import os
-from socorrolib.app.generic_app import main
+from socorro.app.generic_app import main
 from socorro.middleware.middleware_app import MiddlewareApp
 from socorro.webapi.servers import WSGIServer
 import socorro.middleware.middleware_app

--- a/wsgi/middleware.wsgi
+++ b/wsgi/middleware.wsgi
@@ -1,5 +1,5 @@
 import os
-from socorrolib.app.generic_app import main
+from socorro.app.generic_app import main
 from socorro.middleware.middleware_app import MiddlewareApp
 from socorro.webapi.servers import ApacheModWSGI
 import socorro.middleware.middleware_app


### PR DESCRIPTION
At the beginning of the year, we extracted socorrolib from socorro with
the thinking that we'd use socorrolib as a requirement for future
projects. Later, we decided to do those projects in other ways, so
then the value proposition of maintaining socorrolib as a separate
repository wasn't enthusing.

This merges that code back in. It was done in the following steps:

1. copy the relevant directories from socorrolib/ to socorro/
2. do a global search-and-replace of "socorrolib" to "socorro"

It's pretty straight-forward--nothing fancy.