### PR TITLE
A large uint64_t can take more than 17 chars

### DIFF
--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -114,13 +114,13 @@ const unsigned kMaxThreadFrames = 100;
 const unsigned kTailFramesWhenTruncating = 10;
 
 static string ToHex(uint64_t value) {
-  char buffer[17];
+  char buffer[32];
   sprintf(buffer, "0x%lx", value);
   return buffer;
 }
 
 static string ToInt(uint64_t value) {
-  char buffer[17];
+  char buffer[32];
   sprintf(buffer, "%ld", value);
   return buffer;
 }


### PR DESCRIPTION
To be serialized ...
This was crashing for us in sprintf on Linux (not on Mac weirdly).

```
#include <limits>
#include <iostream>

int main()
{
   std::cout << std::numeric_limits<uint64_t>::max() << std::endl;
   return 0;
}

./a.out | wc -c
     21
```