### PR TITLE
Fixes bug 1318448: reduces deepcopies we do in the processor

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -232,6 +232,14 @@ class CrashStorageBase(RequiredConfig):
         """some implementations may need explicit closing."""
         pass
 
+    def is_mutator(self):
+        """Whether this storage class mutates the crash or not
+
+        By default, crash storage classes don't mutate the crash.
+
+        """
+        return False
+
     #--------------------------------------------------------------------------
     def save_raw_crash(self, raw_crash, dumps, crash_id):
         """this method that saves  both the raw_crash and the dump, must be
@@ -621,15 +629,20 @@ class PolyCrashStorage(CrashStorageBase):
         for a_store in self.stores.itervalues():
             self.quit_check()
             try:
-                a_store.save_raw_and_processed(
-                    raw_crash,
-                    dump,
+                if a_store.is_mutator():
                     # We do this because `a_store.save_raw_and_processed`
                     # expects the processed crash to be a DotDict but
                     # you can't deepcopy those, so we deepcopy the
                     # pure dict version and then dress it back up as a
                     # DotDict.
-                    SocorroDotDict(copy.deepcopy(processed_crash_as_dict)),
+                    crash = SocorroDotDict(copy.deepcopy(processed_crash_as_dict))
+                else:
+                    crash = processed_crash
+
+                a_store.save_raw_and_processed(
+                    raw_crash,
+                    dump,
+                    crash,
                     crash_id
                 )
             except Exception:

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -629,7 +629,11 @@ class PolyCrashStorage(CrashStorageBase):
         for a_store in self.stores.itervalues():
             self.quit_check()
             try:
-                if a_store.is_mutator():
+                store_class = getattr(
+                    a_store, 'wrapped_object', a_store.__class__
+                )
+
+                if store_class.is_mutator():
                     # We do this because `a_store.save_raw_and_processed`
                     # expects the processed crash to be a DotDict but
                     # you can't deepcopy those, so we deepcopy the
@@ -646,10 +650,6 @@ class PolyCrashStorage(CrashStorageBase):
                     crash_id
                 )
             except Exception:
-                store_class = getattr(
-                    a_store, 'wrapped_object', a_store.__class__
-                )
-
                 self.logger.error(
                     '%r failed (crash id: %s)',
                     store_class,

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -629,11 +629,11 @@ class PolyCrashStorage(CrashStorageBase):
         for a_store in self.stores.itervalues():
             self.quit_check()
             try:
-                store_class = getattr(
-                    a_store, 'wrapped_object', a_store.__class__
+                store_instance = getattr(
+                    a_store, 'wrapped_object', a_store
                 )
 
-                if store_class.is_mutator():
+                if store_instance.is_mutator():
                     # We do this because `a_store.save_raw_and_processed`
                     # expects the processed crash to be a DotDict but
                     # you can't deepcopy those, so we deepcopy the
@@ -650,6 +650,9 @@ class PolyCrashStorage(CrashStorageBase):
                     crash_id
                 )
             except Exception:
+                store_class = getattr(
+                    a_store, 'wrapped_object', a_store.__class__
+                )
                 self.logger.error(
                     '%r failed (crash id: %s)',
                     store_class,

--- a/socorro/external/es/crashstorage.py
+++ b/socorro/external/es/crashstorage.py
@@ -303,6 +303,10 @@ class ESCrashStorageRedactedJsonDump(ESCrashStorageRedactedSave):
         )
     )
 
+    def is_mutator(self):
+        # This crash storage mutates the crash, so we mark it as such.
+        return True
+
     #--------------------------------------------------------------------------
     def save_raw_and_processed(self, raw_crash, dumps, processed_crash,
                                crash_id):


### PR DESCRIPTION
This changes the PolyCrashStorage code such that it only does a deep
copy of the processed crash if the crash storage says it mutates the
crash data.

Currently, we have 5 crash storage classes configured in production.
This change will reduce the number of deepcopies we're doing from 5 to
1.

r?