### PR TITLE
Fixes bug 1319298 - Handle some rust functions in signature generation.

### DIFF
--- a/socorro/siglists/irrelevant_signature_re.txt
+++ b/socorro/siglists/irrelevant_signature_re.txt
@@ -9,6 +9,7 @@ __aeabi_fcmpgt.*
 ashmem
 app_process@0x.*
 core\.odex@0x.*
+core::panicking::.*
 CrashStatsLogForwarder::CrashAction
 _CxxThrowException
 dalvik-heap
@@ -46,6 +47,7 @@ PR_WaitCondVar
 RaiseException
 RtlpAdjustHeapLookasideDepth
 std::_Atomic_fetch_add_4
+std::panicking::.*
 system@framework@.*\.jar@classes\.dex@0x.*
 ___TERMINATING_DUE_TO_UNCAUGHT_EXCEPTION___
 WaitForSingleObjectExImplementation

--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -143,6 +143,7 @@ _RTC_Terminate
 Rtl.*
 _Rtl.*
 __Rtl.*
+__rust_start_panic
 SEC_.*Item
 seckey_.*
 SECKEY_.*


### PR DESCRIPTION
For a crash stack trace like this:

> mozalloc_abort
> abort
> __rust_start_panic
> std::panicking::rust_panic_with_hook::hc303199e04562edf
> std::panicking::begin_panic::h6ed03353807cf54d
> std::panicking::begin_panic_fmt::hc321cece241bb2f5
> core::panicking::panic_fmt::h27224b181f9f037f
> core::panicking::panic_bounds_check::h19e9bbc59320a57e
> rust_url_capi::rusturl_get_path
> mozilla::net::nsStandardURL::GetPath

this commit will change the crash signature from this:

> [@ mozalloc_abort | abort | __rust_start_panic ]

to this:

> [@ mozalloc_abort | abort | __rust_start_panic | rust_url_capi::rusturl_get_path ]]