### PR TITLE
Fixes bug 1313283 - Strip signatures from leading or trailing white s…

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -63,6 +63,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.signature_utilities.SignatureRunWatchDog, "
         "socorro.processor.signature_utilities.SignatureIPCChannelError, "
         "socorro.processor.signature_utilities.SignatureIPCMessageName, "
+        "socorro.processor.signature_utilities.SigTrim, "
         "socorro.processor.signature_utilities.SigTrunc, "
     ],
     [   # a set of classifiers for support

--- a/socorro/processor/signature_utilities.py
+++ b/socorro/processor/signature_utilities.py
@@ -631,6 +631,25 @@ class AbortSignature(Rule):
 
 
 #==============================================================================
+class SigTrim(Rule):
+    """ensure that the signature never has any leading or trailing white
+    spaces"""
+
+    #--------------------------------------------------------------------------
+    def version(self):
+        return '1.0'
+
+    #--------------------------------------------------------------------------
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        return isinstance(processed_crash.signature, basestring)
+
+    #--------------------------------------------------------------------------
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        processed_crash.signature = processed_crash.signature.strip()
+        return True
+
+
+#==============================================================================
 class SigTrunc(Rule):
     """ensure that the signature is never longer than 255 characters"""
 


### PR DESCRIPTION
…paces.

@willkg What do you think about this?

Fun fact: we can easily use SuperSearch to find all signatures starting or ending with a white space, e.g. https://crash-stats.mozilla.com/api/SuperSearch/?signature=%24%20&_results_number=0