### PR TITLE
bug 1308218 - track cache hits percentage

### DIFF
--- a/webapp-django/crashstats/manage/jinja2/manage/analyze-model-fetches.html
+++ b/webapp-django/crashstats/manage/jinja2/manage/analyze-model-fetches.html
@@ -31,11 +31,12 @@
             <thead>
                 <tr>
                     <th rowspan="2">API / URL</th>
-                    <th colspan="3" class="{sorter: false}"># Uses</th>
+                    <th colspan="4" class="{sorter: false}"># Uses</th>
                     <th colspan="3" class="{sorter: false}">Times (sec)</th>
                 </tr>
                 <tr class="sort-keys">
                     <th>Hits</th>
+                    <th>Hits%</th>
                     <th>Misses</th>
                     <th>Both</th>
                     <th>Hits</th>
@@ -46,9 +47,10 @@
             <tbody>
                 {% for label, value_type, records in measurements %}
                 {% for item, info in records %}
-                <tr class="type-{{ value_type}}">
+                <tr class="type-{{ value_type}} {{ loop.cycle('odd', 'even') }}">
                     <td>{{ truncatechars(item, 150) }}</td>
                     <td>{{ info['uses']['hits'] }}</td>
+                    <td>{{ info['uses']['hits_percentage'] }}</td>
                     <td>{{ info['uses']['misses'] }}</td>
                     <td>{{ info['uses']['both'] }}</td>
                     <td>{{ info['times']['hits'] | msec2sec }}</td>
@@ -63,9 +65,9 @@
 
         <p><b>How This Works</b></p>
         <p>
-            Every time our Django views need data from the middleware, a
+            Every time our Django views need data from the implementation classes, a
             bean counter is incremented on it being used, how long it took
-            and whether or not it was able to draw from the cache.
+            and whether or not it was able to benefit from the cache.
         </p>
     </div>
 </div>

--- a/webapp-django/crashstats/manage/views.py
+++ b/webapp-django/crashstats/manage/views.py
@@ -315,6 +315,14 @@ def analyze_model_fetches(request):
             data['uses']['both'] = (
                 data['uses']['hits'] + data['uses']['misses']
             )
+            data['uses']['hits_percentage'] = (
+                data['uses']['both'] and
+                round(
+                    100.0 * data['uses']['hits'] / data['uses']['both'],
+                    1
+                ) or
+                'n/a'
+            )
             records.append((item, data))
         measurements.append([label, value_type, records])
     context['measurements'] = measurements


### PR DESCRIPTION
This makes it easier to see what % we get. 
Looks like this:
<img width="1888" alt="screen shot 2016-11-29 at 2 27 04 pm" src="https://cloud.githubusercontent.com/assets/26739/20725624/7ad9e4e2-b640-11e6-9104-877ee56ebf91.png">
