### PR TITLE
fixes bug 1319483 - ignore platform if not selective

### DIFF
--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -724,6 +724,11 @@ def crashes_per_day(request, default_context=None):
     for version in context['active_versions'][params['product']]:
         context['available_versions'].append(version['version'])
 
+    if not params.get('platforms'):
+        params['platforms'] = [
+            x['name'] for x in platforms if x.get('display')
+        ]
+
     context['platforms'] = params.get('platforms')
 
     end_date = params.get('date_end') or datetime.datetime.utcnow()
@@ -779,12 +784,17 @@ def crashes_per_day(request, default_context=None):
     # to be called `version`
     supersearch_params = copy.deepcopy(params)
     supersearch_params['version'] = supersearch_params.pop('versions')
-    if 'platforms' in supersearch_params:
-        supersearch_params['platform'] = supersearch_params.pop('platforms')
-        # in SuperSearch it's called 'Mac' not 'Mac OS X'
-        if 'Mac OS X' in supersearch_params['platform']:
-            supersearch_params['platform'].append('Mac')
-            supersearch_params['platform'].remove('Mac OS X')
+    supersearch_params['platform'] = supersearch_params.pop('platforms')
+    # in SuperSearch it's called 'Mac' not 'Mac OS X'
+    if 'Mac OS X' in supersearch_params['platform']:
+        supersearch_params['platform'].append('Mac')
+        supersearch_params['platform'].remove('Mac OS X')
+
+    if params['product'] == 'FennecAndroid':
+        # FennecAndroid only has one platform and it's "Android"
+        # so none of the options presented in the crashes_per_day.html
+        # template are applicable.
+        del supersearch_params['platform']
 
     try:
         graph_data, results, adi_by_version = _get_crashes_per_day_with_adu(

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -724,10 +724,6 @@ def crashes_per_day(request, default_context=None):
     for version in context['active_versions'][params['product']]:
         context['available_versions'].append(version['version'])
 
-    if not params.get('platforms'):
-        params['platforms'] = [
-            x['name'] for x in platforms if x.get('display')
-        ]
     context['platforms'] = params.get('platforms')
 
     end_date = params.get('date_end') or datetime.datetime.utcnow()
@@ -783,11 +779,12 @@ def crashes_per_day(request, default_context=None):
     # to be called `version`
     supersearch_params = copy.deepcopy(params)
     supersearch_params['version'] = supersearch_params.pop('versions')
-    supersearch_params['platform'] = supersearch_params.pop('platforms')
-    # in SuperSearch it's called 'Mac' not 'Mac OS X'
-    if 'Mac OS X' in supersearch_params['platform']:
-        supersearch_params['platform'].append('Mac')
-        supersearch_params['platform'].remove('Mac OS X')
+    if 'platforms' in supersearch_params:
+        supersearch_params['platform'] = supersearch_params.pop('platforms')
+        # in SuperSearch it's called 'Mac' not 'Mac OS X'
+        if 'Mac OS X' in supersearch_params['platform']:
+            supersearch_params['platform'].append('Mac')
+            supersearch_params['platform'].remove('Mac OS X')
 
     try:
         graph_data, results, adi_by_version = _get_crashes_per_day_with_adu(


### PR DESCRIPTION
The change is small but important. What it does now is that instead, by default, it selects NO platforms. I.e. the 3 checkboxes are not checked. Only if you select one, does the platform parameter go to supersearch. 

This solves the problem for platforms like FennecAndroid that has no crashes under either Windows, Mac OS X or Linux. 

