### PR TITLE
fixes bug 1321324 - UnicodeEncodeError on handling 400 errors

### DIFF
--- a/webapp-django/crashstats/api/views.py
+++ b/webapp-django/crashstats/api/views.py
@@ -342,12 +342,12 @@ def model_wrapper(request, model_name):
             raise
         except NOT_FOUND_EXCEPTIONS as exception:
             return http.HttpResponseNotFound(
-                json.dumps({'error': str(exception)}),
+                json.dumps({'error': unicode(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
         except BAD_REQUEST_EXCEPTIONS as exception:
             return http.HttpResponseBadRequest(
-                json.dumps({'error': str(exception)}),
+                json.dumps({'error': unicode(exception)}),
                 content_type='application/json; charset=UTF-8'
             )
 


### PR DESCRIPTION
Before:
<img width="1302" alt="screen shot 2016-11-30 at 12 16 27 pm" src="https://cloud.githubusercontent.com/assets/26739/20763156/e53090fa-b6f6-11e6-8b53-470cb8bb9ba5.png">

After:
<img width="1172" alt="screen shot 2016-11-30 at 12 17 12 pm" src="https://cloud.githubusercontent.com/assets/26739/20763174/f3f2be6a-b6f6-11e6-9c32-3af2132f4f60.png">
