### PR TITLE
Auth-Token and raven

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -559,6 +559,11 @@ if raven_dsn:
     RAVEN_CONFIG = {
         'dsn': raven_dsn,
         'release': SOCORRO_REVISION,
+        'processors': (
+            # Note! This processor extends the default
+            # SanitizePasswordsProcessor to also scrub 'Auth-Token'.
+            'crashstats.tokens.utils.RavenSanitizeAuthTokenProcessor',
+        )
     }
 
 # The Mozilla Google Analytics ID is used here as a default.

--- a/webapp-django/crashstats/tokens/utils.py
+++ b/webapp-django/crashstats/tokens/utils.py
@@ -4,4 +4,7 @@ from raven.processors import SanitizePasswordsProcessor
 class RavenSanitizeAuthTokenProcessor(SanitizePasswordsProcessor):
     """Extend the standard SanitizePasswordsProcessor with one more key
     which is 'Auth-Token' which is what we use in our API."""
-    FIELDS = tuple(SanitizePasswordsProcessor.FIELDS) + ('auth-token',)
+    # Make it a frozenset because that's what the base class has.
+    FIELDS = frozenset(
+        tuple(SanitizePasswordsProcessor.FIELDS) + ('auth-token',)
+    )

--- a/webapp-django/crashstats/tokens/utils.py
+++ b/webapp-django/crashstats/tokens/utils.py
@@ -1,0 +1,7 @@
+from raven.processors import SanitizePasswordsProcessor
+
+
+class RavenSanitizeAuthTokenProcessor(SanitizePasswordsProcessor):
+    """Extend the standard SanitizePasswordsProcessor with one more key
+    which is 'Auth-Token' which is what we use in our API."""
+    FIELDS = tuple(SanitizePasswordsProcessor.FIELDS) + ('auth-token',)


### PR DESCRIPTION
@willkg I don't know how environmentally equipped you are to review and test this. 
Testing is actually kinda messy. Enabled the raven DSN we use for socorro-stage. Then I put in a temporary `raise` and tested it with:
```
curl -H "Auth-token: e85659f64c734013a39df04a74a716b4" http://socorro.dev/api/UploadedSymbols/\?end_date\=2016-11-29\&start_date\=2016-11-01
```
(note token, it just for my laptop)
Here's what it looks like:
https://sentry.prod.mozaws.net/operations/socorro-stage/issues/370785/

The most important change is that now the `Auth-Token` is scrubbed. 
<img width="926" alt="screen shot 2016-11-30 at 1 18 08 pm" src="https://cloud.githubusercontent.com/assets/26739/20765473/76082878-b700-11e6-8419-1ae9a98ffd07.png">
