### PR TITLE
fixes bug 1321367 - BadArgumentError in Crashes per Day on bad date

### DIFF
--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -21,6 +21,7 @@ from django.utils.http import urlquote
 
 from session_csrf import anonymous_csrf
 
+from socorro.lib import BadArgumentError
 from socorro.external.crashstorage_base import CrashIDNotFound
 from . import forms, models, utils
 from .decorators import pass_default_context
@@ -788,13 +789,16 @@ def crashes_per_day(request, default_context=None):
         supersearch_params['platform'].append('Mac')
         supersearch_params['platform'].remove('Mac OS X')
 
-    graph_data, results, adi_by_version = _get_crashes_per_day_with_adu(
-        supersearch_params,
-        start_date,
-        end_date,
-        platforms,
-        _date_range_type
-    )
+    try:
+        graph_data, results, adi_by_version = _get_crashes_per_day_with_adu(
+            supersearch_params,
+            start_date,
+            end_date,
+            platforms,
+            _date_range_type
+        )
+    except BadArgumentError as exception:
+        return http.HttpResponseBadRequest(unicode(exception))
 
     render_csv = request.GET.get('format') == 'csv'
     data_table = {


### PR DESCRIPTION
Now it looks like this:
<img width="1306" alt="screen shot 2016-11-30 at 2 20 02 pm" src="https://cloud.githubusercontent.com/assets/26739/20767398/1ea2e5de-b708-11e6-840e-d55c2c821587.png">

At first I thought this a bit ugly and we should instead re-render with error messages in the form. 
However, that's [not what we do with any other form validation errors](https://github.com/mozilla/socorro/blob/7a0329ba25ee2c306f783cf4484fbaa7d2a3387f/webapp-django/crashstats/crashstats/views.py#L700).

