### PR TITLE
IAM roles

### DIFF
--- a/socorro/external/boto/connection_context.py
+++ b/socorro/external/boto/connection_context.py
@@ -124,13 +124,13 @@ class ConnectionContextBase(RequiredConfig):
     required_config.add_option(
         'access_key',
         doc="access key",
-        default="",
+        default=None,
         reference_value_from='resource.boto',
     )
     required_config.add_option(
         'secret_access_key',
         doc="secret access key",
-        default="",
+        default=None,
         secret=True,
         reference_value_from='secrets.boto',
         likely_to_be_changed=True,

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -577,8 +577,8 @@ ANALYZE_MODEL_FETCHES = config('ANALYZE_MODEL_FETCHES', False, cast=bool)
 
 
 # Credentials for being able to make an S3 connection
-AWS_ACCESS_KEY = config('AWS_ACCESS_KEY', '')
-AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', '')
+AWS_ACCESS_KEY = config('AWS_ACCESS_KEY', None)
+AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', None)
 
 # Information for uploading symbols to S3
 SYMBOLS_BUCKET_DEFAULT_NAME = config('SYMBOLS_BUCKET_DEFAULT_NAME', '')

--- a/webapp-django/crashstats/symbols/tests/test_views.py
+++ b/webapp-django/crashstats/symbols/tests/test_views.py
@@ -117,7 +117,7 @@ class TestViews(BaseTestViews):
         settings.SYMBOLS_COMPRESS_EXTENSIONS = self.symbols_compress_extensions
 
     def test_unpack_and_upload_misconfigured(self):
-        with self.settings(AWS_ACCESS_KEY=''):
+        with self.settings(SYMBOLS_BUCKET_DEFAULT_LOCATION=None):
             assert_raises(
                 ImproperlyConfigured,
                 unpack_and_upload,

--- a/webapp-django/crashstats/symbols/views.py
+++ b/webapp-django/crashstats/symbols/views.py
@@ -57,8 +57,6 @@ def check_symbols_archive_content(content):
 
 def unpack_and_upload(iterator, symbols_upload, bucket_name, bucket_location):
     necessary_setting_keys = (
-        'AWS_ACCESS_KEY',
-        'AWS_SECRET_ACCESS_KEY',
         'SYMBOLS_BUCKET_DEFAULT_LOCATION',
         'SYMBOLS_BUCKET_DEFAULT_NAME',
         'SYMBOLS_FILE_PREFIX',


### PR DESCRIPTION
boto supports IAM roles as long as no keys are passed when creating connections. This works in my v254 deployment for S3 crash storage and symbol uploads from EC2 instances with IAM role that has S3 access. I patched rpm install instead of building from source though, but I think this covers everything.