### PR TITLE
fixes bug 1322615 - Don't look for status messages in JSON endpoints

### DIFF
--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -132,10 +132,10 @@
         </div>
     </div>
 
-    {% for status in status_messages() %}
+    {% for status in status_messages %}
     <div class="status-message severity-{{ status.severity }}">
-        {{ status.text | replace_bugzilla_links }}
-        <small>({{ status.date | time_tag }})</small>
+        {{ status.message | replace_bugzilla_links }}
+        <small>({{ status.created_at | time_tag }})</small>
     </div>
     {% endfor %}
 

--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -132,7 +132,7 @@
         </div>
     </div>
 
-    {% for status in status_messages %}
+    {% for status in status_messages() %}
     <div class="status-message severity-{{ status.severity }}">
         {{ status.text | replace_bugzilla_links }}
         <small>({{ status.date | time_tag }})</small>

--- a/webapp-django/crashstats/status/context_processors.py
+++ b/webapp-django/crashstats/status/context_processors.py
@@ -2,19 +2,22 @@ from crashstats.status.models import StatusMessage
 
 
 def status_message(request):
-    statuses = StatusMessage.objects.filter(enabled=True)
 
-    if not statuses.exists():
-        return {}
+    def inner():
+        statuses = StatusMessage.objects.filter(enabled=True)
 
-    messages = []
-    for status in statuses.order_by('-created_at'):
-        messages.append({
-            'text': status.message,
-            'severity': status.severity,
-            'date': status.created_at,
-        })
+        if not statuses.exists():
+            return {}
+
+        messages = []
+        for status in statuses.order_by('-created_at'):
+            messages.append({
+                'text': status.message,
+                'severity': status.severity,
+                'date': status.created_at,
+            })
+        return messages
 
     return {
-        'status_messages': messages,
+        'status_messages': inner,
     }

--- a/webapp-django/crashstats/status/context_processors.py
+++ b/webapp-django/crashstats/status/context_processors.py
@@ -2,22 +2,8 @@ from crashstats.status.models import StatusMessage
 
 
 def status_message(request):
-
-    def inner():
-        statuses = StatusMessage.objects.filter(enabled=True)
-
-        if not statuses.exists():
-            return {}
-
-        messages = []
-        for status in statuses.order_by('-created_at'):
-            messages.append({
-                'text': status.message,
-                'severity': status.severity,
-                'date': status.created_at,
-            })
-        return messages
-
     return {
-        'status_messages': inner,
+        'status_messages': (
+            StatusMessage.objects.filter(enabled=True).order_by('-created_at')
+        ),
     }


### PR DESCRIPTION
Now, when I do `curl http://socorro.dev/monitoring/healthcheck/?elb=true` it doesn't need to do any SQL queries. 