### PR TITLE
fixes bug 1323123 - unable to switch result size in top crasher

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -266,10 +266,10 @@ SIMPLE_SEARCH_FIELDS = (
 
 # the number of result filter on tcbs
 TCBS_RESULT_COUNTS = (
-    '50',
-    '100',
-    '200',
-    '300'
+    50,
+    100,
+    200,
+    300,
 )
 
 # channels allowed in middleware calls,

--- a/webapp-django/crashstats/topcrashers/forms.py
+++ b/webapp-django/crashstats/topcrashers/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+
+from crashstats.supersearch.form_fields import MultipleValueField
+from crashstats.crashstats.forms import BaseForm
+
+
+class TopCrashersForm(BaseForm):
+    product = forms.CharField()
+    version = MultipleValueField(required=False)
+    process_type = forms.CharField(required=False)
+    platform = forms.CharField(required=False)
+    _facets_size = forms.IntegerField(required=False)
+    _tcbs_mode = forms.CharField(required=False)
+    _range_type = forms.CharField(required=False)

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -230,13 +230,22 @@ class TestViews(BaseTestViews):
         ok_('not a number' in response.content)
         eq_(response['Content-Type'], 'text/html; charset=utf-8')
 
+    def test_topcrashers_400_by_bad_facets_size(self):
+        response = self.client.get(self.base_url, {
+            'product': 'WaterWolf',
+            '_facets_size': 'notanumber',
+        })
+        eq_(response.status_code, 400)
+        ok_('Enter a whole number' in response.content)
+        eq_(response['Content-Type'], 'text/html; charset=utf-8')
+
     def test_topcrasher_with_product_sans_release(self):
         # SnowLion is not a product at all
         response = self.client.get(self.base_url, {
             'product': 'SnowLion',
             'version': '0.1',
         })
-        eq_(response.status_code, 404)
+        eq_(response.status_code, 400)
 
     @mock.patch('crashstats.crashstats.models.Bugs.get')
     def test_topcrasher_without_any_signatures(self, rpost):

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -139,7 +139,6 @@ def get_topcrashers_results(**kwargs):
         params['_aggs.signature'] = [
             'platform',
         ]
-        assert isinstance(params['_facets_size'], int)
         params['_facets_size'] *= 2
 
         if range_type == 'build':

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -16,6 +16,7 @@ from crashstats.crashstats.decorators import (
 )
 from crashstats.supersearch.models import SuperSearchUnredacted
 from crashstats.supersearch.utils import get_date_boundaries
+from crashstats.topcrashers.forms import TopCrashersForm
 
 
 def datetime_to_build_id(date):
@@ -138,6 +139,7 @@ def get_topcrashers_results(**kwargs):
         params['_aggs.signature'] = [
             'platform',
         ]
+        assert isinstance(params['_facets_size'], int)
         params['_facets_size'] *= 2
 
         if range_type == 'build':
@@ -180,13 +182,17 @@ def get_topcrashers_results(**kwargs):
 def topcrashers(request, days=None, possible_days=None, default_context=None):
     context = default_context or {}
 
-    product = request.GET.get('product')
-    versions = request.GET.getlist('version')
-    crash_type = request.GET.get('process_type')
-    os_name = request.GET.get('platform')
-    result_count = request.GET.get('_facets_size')
-    tcbs_mode = request.GET.get('_tcbs_mode')
-    range_type = request.GET.get('_range_type')
+    form = TopCrashersForm(request.GET)
+    if not form.is_valid():
+        return http.HttpResponseBadRequest(unicode(form.errors))
+
+    product = form.cleaned_data['product']
+    versions = form.cleaned_data['version']
+    crash_type = form.cleaned_data['process_type']
+    os_name = form.cleaned_data['platform']
+    result_count = form.cleaned_data['_facets_size']
+    tcbs_mode = form.cleaned_data['_tcbs_mode']
+    range_type = form.cleaned_data['_range_type']
 
     range_type = 'build' if range_type == 'build' else 'report'
 
@@ -194,7 +200,7 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
         tcbs_mode = 'realtime'
 
     if product not in context['active_versions']:
-        raise http.Http404('Unrecognized product')
+        return http.HttpResponseBadRequest('Unrecognized product')
 
     context['product'] = product
 


### PR DESCRIPTION
Now this happens instead:

<img width="731" alt="screen shot 2016-12-13 at 1 05 04 pm" src="https://cloud.githubusercontent.com/assets/26739/21153263/b63305f8-c137-11e6-95ff-dbe053298fac.png">
