### PR TITLE
fixes bug 1323235 - Validate input on _histogram_interval.date

### DIFF
--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1486,6 +1486,19 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
         )
 
     @minimum_es_version('1.0')
+    def test_get_with_date_histogram_with_bad_interval(self):
+        kwargs = {
+            '_histogram.date': ['product', 'platform'],
+            'signature': '!=crash_me_I_m_famous',
+            '_histogram_interval.date': 'xdays',  # Note! It's just wrong
+        }
+        assert_raises(
+            BadArgumentError,
+            self.api.get,
+            **kwargs
+        )
+
+    @minimum_es_version('1.0')
     def test_get_with_number_histogram(self):
         yesterday = self.now - datetime.timedelta(days=1)
         the_day_before = self.now - datetime.timedelta(days=2)

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -1492,11 +1492,14 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
             'signature': '!=crash_me_I_m_famous',
             '_histogram_interval.date': 'xdays',  # Note! It's just wrong
         }
-        assert_raises(
-            BadArgumentError,
-            self.api.get,
-            **kwargs
-        )
+
+        # Not using assert_raises here so we can do a check on the exception
+        # object when it does raise.
+        try:
+            self.api.get(**kwargs)
+            raise AssertionError('The line above is supposed to error out')
+        except BadArgumentError as exception:
+            eq_(exception.param, '_histogram_interval.date')
 
     @minimum_es_version('1.0')
     def test_get_with_number_histogram(self):


### PR DESCRIPTION
I first thought I could validate the input early in the webapp but when I saw [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units) and decided it's too risky to get it right. Better to ask for forgiveness than "seek permission". 

Here's what you get now:
<img width="899" alt="screen shot 2016-12-13 at 2 03 28 pm" src="https://cloud.githubusercontent.com/assets/26739/21155113/cf1bfa3c-c13e-11e6-8e9b-cdf3930890c0.png">
