### PR TITLE
fixes bug 1323314 - Excessive whitespace from pagination.html

### DIFF
--- a/webapp-django/crashstats/base/jinja2/macros/pagination.html
+++ b/webapp-django/crashstats/base/jinja2/macros/pagination.html
@@ -10,10 +10,10 @@
     {% endif %}
 
     {% for page in range(1, report.total_pages + 1) %}
-        {% if page == current_page %}
+        {%- if page == current_page %}
         <strong>{{ page }}</strong>
         {% elif page > 2 and page < (report.total_pages - 2) %}
-            {% if current_page < 3 and page==7 %}
+            {%- if current_page < 3 and page==7 %}
             &hellip;
             {% elif current_page> 6 and page == 3 %}
             &hellip;
@@ -21,11 +21,11 @@
             <a href="{{ current_url }}{{ separator }}page={{ page }}{{ tab }}" data-page="{{ page }}">{{ page }}</a>
             {% elif page == (report.total_pages - 3) %}
             &hellip;
-            {% endif %}
+            {% endif -%}
         {% else %}
             <a href="{{ current_url }}{{ separator }}page={{ page }}{{ tab }}" data-page="{{ page }}">{{ page }}</a>
         {% endif %}
-    {% endfor %}
+    {%- endfor %}
     {% if report.total_pages > current_page %}
         <a href="{{ current_url }}{{ separator }}page={{ current_page + 1 }}{{ tab }}" data-page="{{ current_page + 1 }}">Next &rarr;</a>
     {% endif %}


### PR DESCRIPTION
Now the search result page is only ~300KB instead of ~700KB each time. 
(Only applicable when there's a LOT of pages possible)