### PR TITLE
Remove unused bidpom dep

### DIFF
--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,4 +1,3 @@
-bidpom==2.0.1
 PyPOM==1.1.1
 pytest==3.0.4
 pytest-base-url==1.2.0


### PR DESCRIPTION
@m8ttyB r?

(venv) sdonner-17447:e2e-tests sdonner$ py.test --driver=Firefox --base-url https://crash-stats.allizom.org tests/
==================================================== test session starts =====================================================
platform darwin -- Python 2.7.10, pytest-3.0.4, py-1.4.32, pluggy-0.4.0
driver: Firefox
sensitiveurl: mozilla\.org
baseurl: https://crash-stats.allizom.org
rootdir: /Users/sdonner/socorro/e2e-tests, inifile: setup.cfg
plugins: xdist-1.15.0, variables-1.4, selenium-1.6.0, html-1.11.0, base-url-1.2.0
collected 32 items 

tests/test_crash_reports.py ....................
tests/test_layout.py x...
tests/test_search.py s....
tests/test_smoke_tests.py ..s

===================================== 29 passed, 2 skipped, 1 xfailed in 208.71 seconds ======================================
(venv) sdonner-17447:e2e-tests sdonner$ git branch
  master
* remove-bidpom
