### PR TITLE
Bug 1330275 - Fix alignment issue with some correlation results

### DIFF
--- a/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/correlation.js
+++ b/webapp-django/crashstats/crashstats/static/crashstats/js/socorro/correlation.js
@@ -98,7 +98,7 @@ window.correlations = (function () {
             return '100.0';
         }
 
-        if (num < 0.1) {
+        if (result.length < 4) {
             return '0' + result;
         }
 


### PR DESCRIPTION
The problem is due to rounding, when you have a value smaller than 0.1 but really close to it.