### PR TITLE
Fixes bug 1330819 - Extract more measurements from memory reports.

### DIFF
--- a/socorro/processor/rules/memory_report_extraction.py
+++ b/socorro/processor/rules/memory_report_extraction.py
@@ -67,8 +67,10 @@ class MemoryReportExtraction(Rule):
 
         # These ones are in the memory report.
         metrics_measured = {
+            'gfx-textures': 0,
             'ghost-windows': 0,
             'heap-allocated': 0,
+            'host-object-urls': 0,
             'private': 0,
             'resident': 0,
             'resident-unique': 0,
@@ -79,8 +81,11 @@ class MemoryReportExtraction(Rule):
 
         # These ones are derived from the memory report.
         metrics_derived = {
-            'heap-unclassified': 0,
             'explicit': 0,
+            'heap-overhead': 0,
+            'heap-unclassified': 0,
+            'images': 0,
+            'js-main-runtime': 0,
             'top-non-detached': 0,
         }
 
@@ -121,8 +126,15 @@ class MemoryReportExtraction(Rule):
                         )
                     )
 
-                if 'top(none)/detached' in path:
+                if path.startswith('explicit/images/'):
+                    all_metrics['images'] += amount
+                elif 'top(none)/detached' in path:
                     all_metrics['top-non-detached'] += amount
+                elif path.startswith('explicit/heap-overhead/'):
+                    all_metrics['heap-overhead'] += amount
+
+            elif path.startswith('js-main-runtime/'):
+                all_metrics['js-main-runtime'] += amount
 
             elif path in metrics_measured:
                 all_metrics[path] += amount

--- a/socorro/unittest/processor/rules/memory_reports/good.json
+++ b/socorro/unittest/processor/rules/memory_reports/good.json
@@ -67,6 +67,22 @@
    "description": "Memory mapped by the process that is present in physical memory, also known as the resident set size (RSS).  This is the best single figure to use when considering the memory resources used by the process, but it depends both on other processes being run and details of the OS kernel and so is best used for comparing the memory usage of a single process at different points in time."
   },
   {
+    "kind": 2,
+    "description": "Memory used for storing GL textures.",
+    "process": "Web Content (pid 11717)",
+    "amount": 123456,
+    "units": 0,
+    "path": "gfx-textures"
+  },
+  {
+    "kind": 2,
+    "description": "The number of host objects stored for access via URLs (e.g. blobs passed to URL.createObjectURL).",
+    "process": "Web Content (pid 11717)",
+    "amount": 5,
+    "units": 1,
+    "path": "host-object-urls"
+  },
+  {
    "process": "Main Process (pid 11620)",
    "path": "explicit/heap-overhead/bin-unused",
    "kind": 0,
@@ -153,6 +169,86 @@
    "units": 0,
    "amount": 905883648,
    "description": "Memory mapped by the process, including code and data segments, the heap, thread stacks, memory explicitly mapped by the process via mmap and similar operations, and memory shared with other processes. This is the vsize figure as reported by 'top' and 'ps'.  This figure is of limited use on Mac, where processes share huge amounts of memory with one another.  But even on other operating systems, 'resident' is a much better measure of the memory resources used by the process."
+  },
+  {
+    "kind": 0,
+    "description": "Objects, including fixed slots.",
+    "process": "Web Content (pid 11717)",
+    "amount": 100000,
+    "units": 0,
+    "path": "js-main-runtime/compartments/classes/objects/gc-heap"
+  },
+  {
+    "kind": 1,
+    "description": "Non-fixed object slots.",
+    "process": "Web Content (pid 11717)",
+    "amount": 100000,
+    "units": 0,
+    "path": "js-main-runtime/compartments/classes/objects/malloc-heap/slots"
+  },
+  {
+    "kind": 1,
+    "description": "Normal (non-asm.js) indexed elements.",
+    "process": "Web Content (pid 11717)",
+    "amount": 100000,
+    "units": 0,
+    "path": "js-main-runtime/compartments/classes/objects/malloc-heap/elements/normal"
+  },
+  {
+    "kind": 1,
+    "description": "Miscellaneous object data.",
+    "process": "Web Content (pid 11717)",
+    "amount": 100000,
+    "units": 0,
+    "path": "js-main-runtime/compartments/classes/objects/malloc-heap/misc"
+  },
+  {
+    "kind": 0,
+    "description": "Shapes in a property tree.",
+    "process": "Web Content (pid 11717)",
+    "amount": 100000,
+    "units": 0,
+    "path": "js-main-runtime/compartments/classes/shapes/gc-heap/tree"
+  },
+  {
+    "kind": 0,
+    "description": "Shapes in dictionary mode.",
+    "process": "Web Content (pid 11717)",
+    "amount": 100000,
+    "units": 0,
+    "path": "js-main-runtime/compartments/classes/shapes/gc-heap/dict"
+  },
+  {
+    "kind": 1,
+    "description": "Decoded image data which is stored on the heap.",
+    "process": "Web Content (pid 11717)",
+    "amount": 48,
+    "units": 0,
+    "path": "explicit/images/chrome/vector/used/image(24x24, chrome:\\\\browser\\skin\\search-indicator-magnifying-glass.svg)/locked/surface(24x24@0)/decoded-heap"
+  },
+  {
+    "kind": 1,
+    "description": "Raster image source data and vector image documents.",
+    "process": "Web Content (pid 11717)",
+    "amount": 22088,
+    "units": 0,
+    "path": "explicit/images/chrome/vector/used/image(24x24, chrome:\\\\browser\\skin\\search-indicator-magnifying-glass.svg)/source"
+  },
+  {
+    "kind": 1,
+    "description": "Decoded image data which is stored on the heap.",
+    "process": "Web Content (pid 11717)",
+    "amount": 48,
+    "units": 0,
+    "path": "explicit/images/chrome/vector/used/image(30x31, chrome:\\\\browser\\skin\\tabbrowser\\tab-selected-end.svg)/locked/surface(30x31@0)/decoded-heap"
+  },
+  {
+    "kind": 1,
+    "description": "Raster image source data and vector image documents.",
+    "process": "Web Content (pid 11717)",
+    "amount": 40392,
+    "units": 0,
+    "path": "explicit/images/chrome/vector/used/image(30x31, chrome:\\\\browser\\skin\\tabbrowser\\tab-selected-end.svg)/source"
   },
   {
    "process": "Main Process (pid 11620)",

--- a/socorro/unittest/processor/rules/test_memory_report_extraction.py
+++ b/socorro/unittest/processor/rules/test_memory_report_extraction.py
@@ -92,9 +92,14 @@ class TestMemoryReportExtraction(TestCase):
 
         expected_res = {
             'explicit': 232227872,
+            'gfx-textures': 0,
             'ghost-windows': 7,
             'heap-allocated': 216793184,
+            'heap-overhead': 14483360,
             'heap-unclassified': 171114283,
+            'host-object-urls': 0,
+            'images': 0,
+            'js-main-runtime': 0,
             'private': 182346923,
             'resident': 330346496,
             'resident-unique': 253452288,
@@ -114,9 +119,14 @@ class TestMemoryReportExtraction(TestCase):
 
         expected_res = {
             'explicit': 20655576,
+            'gfx-textures': 123456,
             'ghost-windows': 0,
             'heap-allocated': 20655576,
-            'heap-unclassified': 20655576,
+            'heap-overhead': 0,
+            'heap-unclassified': 20593000,
+            'host-object-urls': 5,
+            'images': 62576,
+            'js-main-runtime': 600000,
             'private': 0,
             'resident': 123518976,
             'resident-unique': 56209408,


### PR DESCRIPTION
The new measurements are: gfx-textures, host-object-urls, heap-overhead,
images, js-main-runtime.

@adngdb, @EricRahm: please review!