### PR TITLE
[DO NOT MERGE] Bug 1311647 - Add more fields to telemetry crash reports

### DIFF
--- a/socorro/schemas/crash_report.json
+++ b/socorro/schemas/crash_report.json
@@ -43,6 +43,30 @@
         }
     },
     "properties": {
+        "abort_message": {
+            "type": ["string", "null"],
+            "description": "The abort message."
+        },
+        "accessibility": {
+            "type": ["boolean", "null"],
+            "description": "The presence of this field indicates that accessibility services were accessed."
+        },
+        "adapter_device_id": {
+            "type": ["string", "null"],
+            "description": "The graphics adapter device identifier."
+        },
+        "adapter_driver_version": {
+            "type": ["string", "null"],
+            "description": "The graphics adapter driver version."
+        },
+        "adapter_subsys_id": {
+            "type": ["string", "null"],
+            "description": "The graphics adapter subsystem identifier."
+        },
+        "adapter_vendor_id": {
+            "type": ["string", "null"],
+            "description": "The graphics adapter vendor. This value is sometimes a name, and sometimes a hexidecimal identifier. Common identifiers include: 0x8086 (Intel), 0x1002 (AMD), 0x10de (NVIDIA)."
+        },
         "additional_minidumps": {
             "type": "array",
             "description": "List the prefixes of the additionnal minidumps, when there are dumps from multiple processes."
@@ -53,19 +77,35 @@
         },
         "addons_checked": {
             "type": ["boolean", "null"],
-            "description": "Value of the 'extensions. checkCompatibility' preference."
+            "description": "Value of the 'extensions.checkCompatibility' preference."
         },
         "address": {
             "type": ["string", "null"],
             "description": "The crashing address. This value is only meaningful for crashes involving bad memory accesses. "
         },
+        "app_init_dlls": {
+            "type": ["string", "null"],
+            "description": "DLLs injected through the AppInit_DLLs registry key."
+        },
         "app_notes": {
             "type": ["string", "null"],
             "description": "Notes from the application that crashed. Mostly contains graphics-related annotations."
         },
+        "available_virtual_memory": {
+            "type": ["integer", "null"],
+            "description": "The amount of unreserved and uncommited (i.e. available) memory in the process's address space. Note that this memory may be fragmented into many separate segments, so an allocation attempt may fail even when this value is substantially greater than zero."
+        },
+        "available_physical_memory": {
+            "type": ["integer", "null"],
+            "description": "The amount of physical memory currently available. This is the amount of physical memory that can be immediately reused without having to write its contents to disk first."
+        },
+        "bios_manufacturer": {
+            "type": ["string", "null"],
+            "description": "The BIOS manufacturer."
+        },
         "build_id": {
             "type": ["string", "null"],
-            "description": "The unique build identifier of this version, which is a timestamp of the form YYYYMMDDHHMMSS. "
+            "description": "The unique build identifier of this version, which is a timestamp of the form YYYYMMDDHHMMSS."
         },
         "classifications": {
             "type": "object",
@@ -119,13 +159,21 @@
                 }
             }
         },
-        "cpu_info": {
-            "type": ["string", "null"],
-            "description": "Detailed processor info. Usually contains information such as the family, model, and stepping number. "
+        "contains_memory_report": {
+            "type": ["boolean", "null"],
+            "description": "Has content for processed_crash.memory_report or not."
         },
         "cpu_arch": {
             "type": ["string", "null"],
             "description": "The build architecture. Usually one of: 'x86', 'amd64' (a.k.a. x86-64), 'arm', 'arm64'."
+        },
+        "cpu_info": {
+            "type": ["string", "null"],
+            "description": "Detailed processor info. Usually contains information such as the family, model, and stepping number. "
+        },
+        "cpu_microcode_version": {
+            "type": ["string", "null"],
+            "description": "Microcode version of the CPU."
         },
         "crash_id": {
             "type": ["string", "null"],
@@ -135,9 +183,30 @@
             "type": ["string", "null"],
             "description": "Date at which the crash report was received by Socorro."
         },
+        "dom_ipc_enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "The value of the 'dom.ipc.enabled' preference (in other terms, whether e10s is enabled)."
+        },
+        "e10s_cohort": {
+            "type": ["string", "null"],
+            "description": "The e10s cohort."
+        },
         "flash_version": {
             "type": ["string", "null"],
             "description": "Version of the Flash Player plugin."
+        },
+        "gmp_plugin": {
+            "type": ["boolean", "null"],
+            "description": "Whether it is a GMP plugin crash."
+        },
+        "graphics_critical_error": {
+            "type": ["string", "null"],
+            "description": "Log of graphics-related errors."
+        },
+        "graphics_startup_test": {
+            "type": ["boolean", "null"],
+            "description": "Whether the crash occured in the DriverCrashGuard."
         },
         "hang_type": {
             "type": ["integer", "null"],
@@ -147,9 +216,37 @@
             "type": ["integer", "null"],
             "description": "Length of time since this version was installed. "
         },
+        "ipc_channel_error": {
+            "type": ["string", "null"],
+            "description": "The IPC channel error."
+        },
+        "ipc_fatal_error_msg": {
+            "type": ["string", "null"],
+            "description": "The message linked to an IPC fatal error."
+        },
+        "ipc_fatal_error_protocol": {
+            "type": ["string", "null"],
+            "description": "The protocol linked to an IPC fatal error."
+        },
+        "ipc_message_name": {
+            "type": ["string", "null"],
+            "description": "The name of the IPC message."
+        },
+        "ipc_system_error": {
+            "type": ["integer", "null"],
+            "description": "A replacement of `system_error`. https://bugzilla.mozilla.org/show_bug.cgi?id=1267222"
+        },
+        "is_garbage_collecting": {
+            "type": ["boolean", "null"],
+            "description": "Whether there was a garbage collection in progress."
+        },
         "java_stack_trace": {
             "type": ["string", "null"],
-            "description": "When Java code crashes due to an unhandled exception, this is the Java Stack Trace. It is usually more useful than the system stack trace given for the crashing thread. "
+            "description": "When Java code crashes due to an unhandled exception, this is the Java Stack Trace. It is usually more useful than the system stack trace given for the crashing thread."
+        },
+        "jit_category": {
+            "type": ["string", "null"],
+            "description": "JIT classification."
         },
         "json_dump": {
             "type": "object",
@@ -371,6 +468,14 @@
                 }
             }
         },
+        "moz_crash_reason": {
+            "type": ["string", "null"],
+            "description": "For aborts caused by MOZ_CRASH, MOZ_RELEASE_ASSERT and related macros, this is the accompanying description."
+        },
+        "oom_allocation_size": {
+            "type": ["integer", "null"],
+            "description": "The size of the allocation that caused the OOM crash."
+        },
         "platform": {
             "type": ["string", "null"],
             "description": "Basic name of the operating system. Can be \"Windows NT\", \"Mac OS X\" or \"Linux\". Use `platform_pretty_version` for a more precise OS name including version."
@@ -423,17 +528,49 @@
             "type": ["string", "null"],
             "description": "The update channel that the user is on. Typically \"nightly\", \"aurora\", \"beta\", or \"release\", but this may also be other values like \"release-cck-partner\"."
         },
+        "safe_mode": {
+            "type": ["boolean", "null"],
+            "description": "Whether Firefox was running in Safe Mode."
+        },
         "signature": {
             "type": ["string", "null"],
             "description": "This is the field most commonly used for aggregating individual crash reports into a group. It usually contains one or more stack frames from the crashing thread. The stack frames may also be augmented or replaced with other tokens such as 'OOM | small' or 'shutdownhang' that further identify the crash kind. "
+        },
+        "shutdown_progress": {
+            "type": ["string", "null"],
+            "description": "See https://bugzilla.mozilla.org/show_bug.cgi?id=1038342"
+        },
+        "startup_crash": {
+            "type": ["boolean", "null"],
+            "description": "Annotation that tells whether the crash happened before the startup phase was finished or not."
+        },
+        "submitted_from_infobar": {
+            "type": ["boolean", "null"],
+            "description": "Whether the crash report was submitted through the infobar."
+        },
+        "theme": {
+            "type": ["string", "null"],
+            "description": "The current theme."
         },
         "topmost_filenames": {
             "type": ["string", "null"],
             "description": "Paths of the files at the top of the stack."
         },
+        "total_physical_memory": {
+            "type": ["integer", "null"],
+            "description": "The total amount of physical memory."
+        },
+        "total_virtual_memory": {
+            "type": ["integer", "null"],
+            "description": "The size of the user-mode portion of the virtual address space of the calling process. This value depends on the type of process, the type of processor, and the configuration of the operating system. 32-bit processes usually have values in the range 2--4 GiB. 64-bit processes usually have *much* larger values."
+        },
         "uptime": {
             "type": ["integer", "null"],
             "description": "Length of time the process was running before it crashed. Small values (from 0 to 5 or so) usually indicate start-up crashes."
+        },
+        "useragent_locale": {
+            "type": ["string", "null"],
+            "description": "The locale of the Firefox installation."
         },
         "user_comments": {
             "type": ["string", "null"],

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -22,6 +22,7 @@ def main():
         params={
             'product': 'Firefox',
             '_columns': ['uuid'],
+            '_facets_size': 0
         }
     )
     search = r.json()


### PR DESCRIPTION
I've tested the schema with the `validate_and_test.py` script (also with 1000 reports instead of 100, just to be sure).