### PR TITLE
stackwalker: Fix compilation with upstream breakpad

### DIFF
--- a/minidump-stackwalk/get-minidump-instructions.cc
+++ b/minidump-stackwalk/get-minidump-instructions.cc
@@ -415,6 +415,7 @@ int main(int argc, char** argv)
       if (p && (p - line == 8 || p - line == 16) && !strstr(line, "<.data>:")) {
         frame.instruction = strtoull(line, nullptr, 16);
         symbolizer.FillSourceLineInfo(module_list,
+              /* unloaded_modules= */ NULL,
                                       &system_info,
                                       &frame);
         print_frame(frame, last_frame);

--- a/minidump-stackwalk/stackwalker.cc
+++ b/minidump-stackwalk/stackwalker.cc
@@ -138,6 +138,7 @@ public:
                                               StackFrame* stack_frame) {
     SymbolizerResult res =
       StackFrameSymbolizer::FillSourceLineInfo(modules,
+                       /* unloaded_modules= */ NULL,
                                                system_info,
                                                stack_frame);
     RecordResult(stack_frame->module, res);


### PR DESCRIPTION
Recently on breakpad upstream there was a parameter added to the
StackFrameSymbolizer::FillSourceLineInfo method, therefore compilation
would fail.

https://chromium.googlesource.com/breakpad/breakpad/+/0924d424e444d57dd95c647652a11f2d655c11a0

This commit passes NULL for the unloaded_modules parameter to fix the
compilation failure. It might be useful to actually use that parameter
in the future though.