### PR TITLE
Pin the revision of Breakpad to build in build-breakpad.sh to the revision used in the snapshot.

### DIFF
--- a/scripts/breakpad-taskcluster.sh
+++ b/scripts/breakpad-taskcluster.sh
@@ -16,6 +16,9 @@
 #
 # You must be a member of the `socorro` project in Taskcluster for this
 # task to work properly.
+#
+# NOTE: If you build a snapshot against a newer revision of Breakpad,
+#  update BREAKPAD_REV in build-breakpad.sh to match!
 : <<'EOF'
 {
 	"created": "2016-04-09T00:49:49.410Z",

--- a/scripts/build-breakpad.sh
+++ b/scripts/build-breakpad.sh
@@ -12,6 +12,10 @@
 # any failures in this script should cause the build to fail
 set -v -e -x
 
+# Build the revision used in the snapshot unless otherwise specified.
+# Update this if you update the snapshot!
+: BREAKPAD_REV         "${BREAKPAD_REV:=e0f2c17988dadcc7fb760b118b1741883435bbfd}"
+
 export MAKEFLAGS
 MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)
 
@@ -38,11 +42,13 @@ if [ ! -d "breakpad" ]; then
   fetch breakpad
 else
   cd breakpad
-  gclient sync
 fi
 
 cd src
-echo "using breakpad version: $(git rev parse HEAD)"
+git checkout "$BREAKPAD_REV"
+gclient sync
+
+echo "using breakpad version: $(git rev-parse HEAD)"
 
 mkdir -p "${PREFIX}"
 rsync -a --exclude="*.git" ./src "${PREFIX}"/
@@ -53,7 +59,7 @@ if test -z "${SKIP_CHECK}"; then
   #make check
   true
 fi
-git rev-parse master > "${PREFIX}"/revision.txt
+git rev-parse HEAD > "${PREFIX}"/revision.txt
 cd ../..
 
 cp breakpad/src/src/third_party/libdisasm/libdisasm.a "${PREFIX}"/lib/


### PR DESCRIPTION
This fixes local builds that don't use the Breakpad snapshot because
upstream Breakpad made a breaking API change.