### PR TITLE
Add MOZ_CrashOOL and MOZ_CrashPrintf to the prefix signature list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -89,6 +89,8 @@ mozilla::layers::CompositorD3D11::HandleError
 mozilla.*FatalError
 moz_xmalloc
 moz_xrealloc
+MOZ_CrashOOL
+MOZ_CrashPrintf
 msvcr120\.dll@0x.*
 \<name omitted\>
 NP_Shutdown


### PR DESCRIPTION
In [bug 1338574](https://bugzilla.mozilla.org/show_bug.cgi?id=1338574) I'm adding two new variants of MOZ_CRASH, each with its own function. IIUC, these need to be added to the prefix signature list so we don't group all crashes utilizing these functions together. See also [bug 1341035](https://bugzilla.mozilla.org/show_bug.cgi?id=1341035).