### PR TITLE
Submit e2e test results to ActiveData

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@1.1') _
+@Library('fxtest@1.3') _
 
 /** Desired capabilities */
 def capabilities = [
@@ -36,8 +36,9 @@ pipeline {
       }
       post {
         always {
-          junit 'e2e-tests/results/*.xml'
           archiveArtifacts 'e2e-tests/results/*'
+          junit 'e2e-tests/results/*.xml'
+          submitToActiveData('e2e-tests/results/py27.log')
           publishHTML(target: [
             allowMissing: false,
             alwaysLinkToLastBuild: true,

--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
     PYTEST_ADDOPTS =
       "-n=10 " +
       "--color=yes " +
+      "--tb=short " +
       "--driver=SauceLabs " +
       "--variables=capabilities.json"
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')

--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
     stage('Test') {
       steps {
         writeCapabilities(capabilities, 'e2e-tests/capabilities.json')
-        sh "tox -c e2e-tests/tox.ini -e tests"
+        sh "tox -c e2e-tests/tox.ini -e py27"
       }
       post {
         always {
@@ -43,7 +43,7 @@ pipeline {
             alwaysLinkToLastBuild: true,
             keepAll: true,
             reportDir: 'e2e-tests/results',
-            reportFiles: "tests.html",
+            reportFiles: "py27.html",
             reportName: 'HTML Report'])
         }
       }

--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = tests, flake8
+envlist = py27, flake8
 
 [testenv]
 passenv = PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY SAUCELABS_USERNAME

--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -3,13 +3,16 @@ skipsdist = true
 envlist = py27, flake8
 
 [testenv]
-passenv = PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY SAUCELABS_USERNAME
+passenv = PYTEST_ADDOPTS PYTEST_BASE_URL SAUCELABS_API_KEY SAUCELABS_USERNAME \
+    JENKINS_URL JOB_NAME BUILD_NUMBER
 deps =
     bidpom==2.0.1
+    mozlog==3.4
     PyPOM==1.1.1
     pytest==3.0.5
     pytest-base-url==1.2.0
     pytest-html==1.13.0
+    pytest-metadata==1.1.0
     pytest-selenium==1.7.0
     pytest-variables==1.4
     pytest-xdist==1.15.0
@@ -18,6 +21,7 @@ deps =
 commands = pytest \
     --junit-xml=results/{envname}.xml \
     --html=results/{envname}.html \
+    --log-raw=results/{envname}.log \
     {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
This patch enables publishing of structured logs from the e2e tests to ActiveData, which will allow us to track results over time and help us to identify tests that need attention.