### PR TITLE
Bump pytest-metadata

### DIFF
--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest==3.0.5
     pytest-base-url==1.2.0
     pytest-html==1.13.0
-    pytest-metadata==1.1.0
+    pytest-metadata==1.2.0
     pytest-selenium==1.7.0
     pytest-variables==1.4
     pytest-xdist==1.15.0


### PR DESCRIPTION
pytest-metadata has a 1.2.0 release, today: https://pyup.io/changelogs/pytest-metadata/

@willkg r?  and a merge when/if you r+?  Thanks!