### PR TITLE
fixes bug 1343623 - validate_and_test.py should test more realistically

### DIFF
--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import json
 import os
@@ -6,15 +7,37 @@ import os
 import jsonschema
 import requests
 
+from socorro.external.boto.crashstorage import TelemetryBotoS3CrashStorage
 
 API_BASE = 'https://crash-stats.mozilla.com/api/{}/'
 HERE = os.path.dirname(__file__)
 
 
+class MockedTelemetryBotoS3CrashStorage(TelemetryBotoS3CrashStorage):
+
+    def __init__(self):
+        # Deliberately not doing anything fancy with config. So no super call.
+        # Prep the self._all_fields so it's available when
+        # self.save_raw_and_processed() is called.
+        r = requests.get(
+            API_BASE.format('SuperSearchFields'),
+        )
+        print(r.url)
+        self._all_fields = r.json()
+
+    def _get_all_fields(self):
+        return self._all_fields
+
+    def save_processed(self, crash):
+        self.combined = crash
+
+
 def main():
-    schema = json.load(open(os.path.join(HERE, 'crash_report.json')))
+    file_path = os.path.join(HERE, 'crash_report.json')
+    with open(file_path) as f:
+        schema = json.load(f)
     jsonschema.Draft4Validator.check_schema(schema)
-    print('Processed Crash schema is valid')
+    print('{} is a valid JSON schema'.format(file_path))
 
     print('Fetching data...')
     r = requests.get(
@@ -27,15 +50,29 @@ def main():
     )
     search = r.json()
 
+    processor = MockedTelemetryBotoS3CrashStorage()
+
     print('Testing {} random recent crash reports'.format(len(search['hits'])))
     for hit in search['hits']:
+        r = requests.get(
+            API_BASE.format('RawCrash'),
+            params={'crash_id': hit['uuid']}
+        )
+        print(r.url)
+        raw_crash = r.json()
         r = requests.get(
             API_BASE.format('ProcessedCrash'),
             params={'crash_id': hit['uuid']}
         )
         print(r.url)
-        crash = r.json()
-        jsonschema.validate(crash, schema)
+        processed_crash = r.json()
+        processor.save_raw_and_processed(
+            raw_crash,
+            (),  # dumps
+            processed_crash,
+            hit['uuid'],
+        )
+        jsonschema.validate(processor.combined, schema)
 
     print('Done testing, all crash reports passed.')
 


### PR DESCRIPTION
It works!
```
▶ python socorro/schemas/validate_and_test.py
socorro/schemas/crash_report.json is a valid JSON schema
Fetching data...
https://crash-stats.mozilla.com/api/SuperSearchFields/
Testing 100 random recent crash reports
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=60935f48-8d17-485c-a8e7-232ae2170222
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=60935f48-8d17-485c-a8e7-232ae2170222
Traceback (most recent call last):
  File "socorro/schemas/validate_and_test.py", line 79, in <module>
    main()
  File "socorro/schemas/validate_and_test.py", line 73, in main
    jsonschema.validate(processor.combined, schema)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/jsonschema/validators.py", line 478, in validate
    cls(schema, *args, **kwargs).validate(instance)
  File "/Users/peterbe/virtualenvs/socorro/lib/python2.7/site-packages/jsonschema/validators.py", line 123, in validate
    raise error
jsonschema.exceptions.ValidationError: u'1163071488' is not of type u'integer', u'null'

Failed validating u'type' in schema[u'properties'][u'available_physical_memory']:
    {u'description': u'The amount of physical memory currently available. This is the amount of physical memory that can be immediately reused without having to write its contents to disk first.',
     u'type': [u'integer', u'null']}

On instance[u'available_physical_memory']:
    u'1163071488'
```

What I have here is the old new crash_report.json that had a bunch of new fields with the wrong type. 

cc @marco-c 