### PR TITLE
Update to latest e2e dependency versions

### DIFF
--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -9,15 +9,15 @@ deps =
     bidpom==2.0.1
     mozlog==3.4
     PyPOM==1.1.1
-    pytest==3.0.5
-    pytest-base-url==1.2.0
-    pytest-html==1.13.0
-    pytest-metadata==1.2.0
-    pytest-selenium==1.7.0
-    pytest-variables==1.4
+    pytest==3.0.6
+    pytest-base-url==1.3.0
+    pytest-html==1.14.1
+    pytest-metadata==1.3.0
+    pytest-selenium==1.9.0
+    pytest-variables==1.5.1
     pytest-xdist==1.15.0
     selenium==3.0.2
-    requests==2.12.5
+    requests==2.13.0
 commands = pytest \
     --junit-xml=results/{envname}.xml \
     --html=results/{envname}.html \


### PR DESCRIPTION
@willkg r?

Build-passing output, below:

```
Started by user Stephen Donner
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/socorro.git
 > /usr/local/git/bin/git init /var/lib/jenkins/jobs/socorro.adhoc/workspace@script # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
 > /usr/local/git/bin/git --version # timeout=10
Setting http proxy: proxy.dmz.scl3.mozilla.com:3128
 > /usr/local/git/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/local/git/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
 > /usr/local/git/bin/git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > /usr/local/git/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
Setting http proxy: proxy.dmz.scl3.mozilla.com:3128
 > /usr/local/git/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/local/git/bin/git rev-parse origin/update-deps^{commit} # timeout=10
Checking out Revision 11d6d66bd79dd2efb5019d8b802d6d925257c908 (origin/update-deps)
 > /usr/local/git/bin/git config core.sparsecheckout # timeout=10
 > /usr/local/git/bin/git checkout -f 11d6d66bd79dd2efb5019d8b802d6d925257c908
First time build. Skipping changelog.
Loading library fxtest@1.3
 > /usr/local/git/bin/git rev-parse --is-inside-work-tree # timeout=10
Setting origin to https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/local/git/bin/git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
Fetching origin...
Fetching upstream changes from origin
 > /usr/local/git/bin/git --version # timeout=10
 > /usr/local/git/bin/git fetch --tags --progress origin +refs/heads/*:refs/remotes/origin/*
 > /usr/local/git/bin/git rev-parse 1.3^{commit} # timeout=10
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/local/git/bin/git init /var/lib/jenkins/jobs/socorro.adhoc/workspace@libs/fxtest # timeout=10
Fetching upstream changes from https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/local/git/bin/git --version # timeout=10
Setting http proxy: proxy.dmz.scl3.mozilla.com:3128
 > /usr/local/git/bin/git fetch --tags --progress https://github.com/mozilla/fxtest-jenkins-pipeline.git +refs/heads/*:refs/remotes/origin/*
 > /usr/local/git/bin/git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
 > /usr/local/git/bin/git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > /usr/local/git/bin/git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
Fetching upstream changes from https://github.com/mozilla/fxtest-jenkins-pipeline.git
Setting http proxy: proxy.dmz.scl3.mozilla.com:3128
 > /usr/local/git/bin/git fetch --tags --progress https://github.com/mozilla/fxtest-jenkins-pipeline.git +refs/heads/*:refs/remotes/origin/*
Checking out Revision 337da3aab01ebfeb206d9ad8c7ac2d5fd7a7b333 (1.3)
 > /usr/local/git/bin/git config core.sparsecheckout # timeout=10
 > /usr/local/git/bin/git checkout -f 337da3aab01ebfeb206d9ad8c7ac2d5fd7a7b333
 > /usr/local/git/bin/git rev-list 337da3aab01ebfeb206d9ad8c7ac2d5fd7a7b333 # timeout=10
[Pipeline] withEnv
[Pipeline] {
[Pipeline] ansiColor
[Pipeline] {
[Pipeline] timestamps
[Pipeline] {
[Pipeline] timeout
Timeout set to expire in 1 hr 0 min
[Pipeline] {
[Pipeline] node
Running on master in /var/lib/jenkins/jobs/socorro.adhoc/workspace
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Declarative: Checkout SCM)
[Pipeline] checkout
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/socorro.git
 > /usr/local/git/bin/git init /var/lib/jenkins/jobs/socorro.adhoc/workspace # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
 > /usr/local/git/bin/git --version # timeout=10
Setting http proxy: proxy.dmz.scl3.mozilla.com:3128
 > /usr/local/git/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/local/git/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
 > /usr/local/git/bin/git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > /usr/local/git/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
Setting http proxy: proxy.dmz.scl3.mozilla.com:3128
 > /usr/local/git/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/local/git/bin/git rev-parse origin/update-deps^{commit} # timeout=10
Checking out Revision 11d6d66bd79dd2efb5019d8b802d6d925257c908 (origin/update-deps)
 > /usr/local/git/bin/git config core.sparsecheckout # timeout=10
 > /usr/local/git/bin/git checkout -f 11d6d66bd79dd2efb5019d8b802d6d925257c908
[Pipeline] }
[Pipeline] // stage
[Pipeline] withCredentials
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Lint)
[Pipeline] sh
[workspace] Running shell script
+ tox -c e2e-tests/tox.ini -e flake8
flake8 create: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests/.tox/flake8
flake8 installdeps: flake8
flake8 installed: appdirs==1.4.2,configparser==3.5.0,enum34==1.1.6,flake8==3.3.0,mccabe==0.6.1,packaging==16.8,pycodestyle==2.3.1,pyflakes==1.5.0,pyparsing==2.1.10,six==1.10.0
flake8 runtests: PYTHONHASHSEED='2861189898'
flake8 runtests: commands[0] | flake8 .
___________________________________ summary ____________________________________
  flake8: commands succeeded
  congratulations :)
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Test)
[Pipeline] writeFile
[Pipeline] sh
[workspace] Running shell script
+ tox -c e2e-tests/tox.ini -e py27
py27 create: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests/.tox/py27
py27 installdeps: bidpom==2.0.1, mozlog==3.4, PyPOM==1.1.1, pytest==3.0.6, pytest-base-url==1.3.0, pytest-html==1.14.1, pytest-metadata==1.3.0, pytest-selenium==1.9.0, pytest-variables==1.5.1, pytest-xdist==1.15.0, selenium==3.0.2, requests==2.13.0
py27 installed: apipkg==1.4,appdirs==1.4.2,bidpom==2.0.1,blessings==1.6,execnet==1.4.1,mozlog==3.4,packaging==16.8,py==1.4.32,pyparsing==2.1.10,PyPOM==1.1.1,pytest==3.0.6,pytest-base-url==1.3.0,pytest-html==1.14.1,pytest-metadata==1.3.0,pytest-selenium==1.9.0,pytest-variables==1.5.1,pytest-xdist==1.15.0,requests==2.13.0,selenium==3.0.2,six==1.10.0,zope.component==4.3.0,zope.event==4.2.0,zope.interface==4.3.3
py27 runtests: PYTHONHASHSEED='2337817182'
py27 runtests: commands[0] | pytest --junit-xml=results/py27.xml --html=results/py27.html --log-raw=results/py27.log
============================= test session starts ==============================
platform linux2 -- Python 2.7.9, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests/.tox/py27/bin/python2.7
cachedir: .cache
sensitiveurl: mozilla\.org
driver: SauceLabs
metadata: {'Platform': 'Linux-2.6.32-642.1.1.el6.x86_64-x86_64-with-redhat-6.8-Santiago', 'Base URL': 'https://crash-stats.allizom.org', 'JENKINS_URL': 'http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/', 'BUILD_NUMBER': '29', 'Plugins': {'html': '1.14.1', 'mozlog': '3.4', 'xdist': '1.15.0', 'selenium': '1.9.0', 'metadata': '1.3.0', 'base-url': '1.3.0', 'variables': '1.5.1'}, 'Python': '2.7.9', 'Packages': {'pytest': '3.0.6', 'py': '1.4.32', 'pluggy': '0.4.0'}, 'JOB_NAME': 'socorro.adhoc', 'Driver': 'SauceLabs', 'Capabilities': {}}
baseurl: https://crash-stats.allizom.org
rootdir: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests, inifile: tox.ini
plugins: xdist-1.15.0, variables-1.5.1, selenium-1.9.0, metadata-1.3.0, html-1.14.1, base-url-1.3.0, mozlog-3.4
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I

[gw0] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw1] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw2] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw3] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw4] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw5] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw6] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw7] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw8] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw9] linux2 Python 2.7.9 cwd: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests

[gw0] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw3] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw1] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw6] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw4] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw2] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw7] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw5] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw8] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]

[gw9] Python 2.7.9 (default, Apr  7 2015, 17:34:09)  -- [GCC 4.4.7 20120313 (Red Hat 4.4.7-11)]
gw0 [36] / gw1 [36] / gw2 [36] / gw3 [36] / gw4 [36] / gw5 [36] / gw6 [36] / gw7 [36] / gw8 [36] / gw9 [36]

scheduling tests via LoadScheduling

tests/test_api.py::TestAPI::test_public_api_navigation 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Firefox] 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[SeaMonkey] 
tests/test_api.py::TestAPI::test_platforms 
tests/test_api.py::TestAPI::test_supersearch_fields 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Thunderbird] 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[FennecAndroid] 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Thunderbird] 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Firefox] 
tests/test_api.py::TestAPI::test_crontabber 
[gw3] PASSED tests/test_api.py::TestAPI::test_supersearch_fields 
[gw8] PASSED tests/test_api.py::TestAPI::test_crontabber 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[FennecAndroid] 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_browser_return_results 
[gw2] PASSED tests/test_api.py::TestAPI::test_platforms 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_all_return_results 
[gw4] PASSED tests/test_api.py::TestAPI::test_public_api_navigation 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[SeaMonkey] 
[gw1] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[FennecAndroid] 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[SeaMonkey] 
[gw0] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Firefox] 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_plugin_return_results 
[gw6] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[SeaMonkey] 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Thunderbird] 
[gw9] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Thunderbird] 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Firefox] 
[gw2] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_all_return_results 
tests/test_crash_reports.py::TestCrashReports::test_that_only_plugin_reports_have_plugin_icon 
[gw5] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Thunderbird] 
tests/test_crash_reports.py::TestCrashReports::test_top_crasher_reports_tab_has_uuid_report 
[gw8] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_browser_return_results 
[gw3] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[FennecAndroid] 
tests/test_crash_reports.py::TestCrashReports::test_that_only_browser_reports_have_browser_icon 
tests/test_crash_reports.py::TestCrashReports::test_that_7_days_is_selected_default_for_nightlies 
[gw7] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Firefox] 
[gw4] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[SeaMonkey] 
tests/test_crash_reports.py::TestCrashReports::test_that_lowest_version_topcrashers_do_not_return_errors 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[FennecAndroid] 
[gw1] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[SeaMonkey] 
[gw0] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_plugin_return_results 
tests/test_layout.py::TestLayout::test_that_products_are_sorted_correctly 
tests/test_layout.py::TestSuperSearchLayout::test_super_search_page_is_loaded 
[gw3] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_7_days_is_selected_default_for_nightlies 
[gw9] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Firefox] 
[gw5] PASSED tests/test_crash_reports.py::TestCrashReports::test_top_crasher_reports_tab_has_uuid_report 
[gw2] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_only_plugin_reports_have_plugin_icon 
[gw8] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_only_browser_reports_have_browser_icon 
[gw6] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Thunderbird] 
[gw4] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_lowest_version_topcrashers_do_not_return_errors 
[gw0] PASSED tests/test_layout.py::TestSuperSearchLayout::test_super_search_page_is_loaded 
[gw1] xfail tests/test_layout.py::TestLayout::test_that_products_are_sorted_correctly 
[gw7] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[FennecAndroid] 
tests/test_smoke_tests.py::TestSmokeTests::test_that_bugzilla_link_contain_current_site 
tests/test_layout.py::TestSuperSearchLayout::test_search_change_column 
tests/test_smoke_tests.py::TestSmokeTests::test_non_privileged_accounts_cannot_view_exploitable_crash_reports 
tests/test_search.py::TestSuperSearch::test_search_with_multiple_lines 
tests/test_search.py::TestSuperSearch::test_search_for_unrealistic_data 
[gw0] SKIPPED tests/test_smoke_tests.py::TestSmokeTests::test_non_privileged_accounts_cannot_view_exploitable_crash_reports 
tests/test_layout.py::TestSuperSearchLayout::test_search_change_facet 
tests/test_smoke_tests.py::TestSmokeTests::test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users 
[gw2] SKIPPED tests/test_search.py::TestSuperSearch::test_search_for_unrealistic_data 
tests/test_search.py::TestSearchForSpecificResults::test_search_for_valid_signature 
tests/test_search.py::TestSuperSearch::test_search_with_one_line 
tests/test_search.py::TestSearchForSpecificResults::test_selecting_one_version_doesnt_show_other_versions 
[gw4] PASSED tests/test_smoke_tests.py::TestSmokeTests::test_that_bugzilla_link_contain_current_site 
[gw1] PASSED tests/test_smoke_tests.py::TestSmokeTests::test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users 
[gw5] PASSED tests/test_search.py::TestSuperSearch::test_search_with_one_line 
[gw3] PASSED tests/test_search.py::TestSearchForSpecificResults::test_search_for_valid_signature 
[gw9] PASSED tests/test_layout.py::TestSuperSearchLayout::test_search_change_facet 
[gw8] PASSED tests/test_search.py::TestSuperSearch::test_search_with_multiple_lines 
Post stage
[gw7] PASSED tests/test_search.py::TestSearchForSpecificResults::test_selecting_one_version_doesnt_show_other_versions 
[gw6] PASSED tests/test_layout.py::TestSuperSearchLayout::test_search_change_column 

 generated xml file: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests/results/py27.xml 
 generated html file: /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests/results/py27.html 
=========================== short test summary info ============================
SKIP [1] tests/test_search.py:11: TODO: Update to work with the new date picker
SKIP [1] tests/test_smoke_tests.py:33: TODO: Persona is being deprecated - move test to Google Accounts
XFAIL tests/test_layout.py::TestLayout::()::test_that_products_are_sorted_correctly
  Fennec shouldn't be an option - bug 1292594
============== 33 passed, 2 skipped, 1 xfailed in 117.44 seconds ===============
___________________________________ summary ____________________________________
  py27: commands succeeded
  congratulations :)
[Pipeline] step
Archiving artifacts
[Pipeline] step
Recording test results
[Pipeline] publishHTML
[htmlpublisher] Archiving HTML reports...
[htmlpublisher] Archiving at BUILD level /var/lib/jenkins/jobs/socorro.adhoc/workspace/e2e-tests/results to /var/lib/jenkins/jobs/socorro.adhoc/builds/29/htmlreports/HTML_Report
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withCredentials
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // timeout
[Pipeline] }
[Pipeline] // timestamps
[Pipeline] }
[Pipeline] // ansiColor
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] End of Pipeline
Finished: SUCCESS
```