### PR TITLE
Fixes bug 1345504 - Made better use of space in Signature report.

### DIFF
--- a/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
+++ b/webapp-django/crashstats/signature/jinja2/signature/signature_summary.html
@@ -25,33 +25,6 @@
     </div>
 </div>
 
-<div class="panel tab-inner-panel" id="panel-uptime">
-    <header class="title" title="Toggle visibility">
-        <h2>Uptime Range</h2>
-        <div class="options show">show</div>
-    </header>
-    <div class="content">
-        <table class="tablesorter data-table">
-            <thead>
-                <tr>
-                    <th class="header">Uptime Range</th>
-                    <th class="header">Count</th>
-                    <th class="header">Percentage</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for uptime in query.facets.histogram_uptime %}
-                <tr>
-                    <td>{{ uptime.term }}</td>
-                    <td>{{ uptime.count }}</td>
-                    <td>{{ (100.0 * uptime.count / query.total) | round(1) }}%</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-</div>
-
 <div class="panel tab-inner-panel" id="panel-product">
     <header class="title" title="Toggle visibility">
         <h2>Product <sup>*</sup></h2>
@@ -89,33 +62,6 @@
     </div>
 </div>
 
-<div class="panel tab-inner-panel" id="panel-cpu-name">
-    <header class="title" title="Toggle visibility">
-        <h2>Architecture</h2>
-        <div class="options show">show</div>
-    </header>
-    <div class="content">
-        <table class="tablesorter data-table">
-            <thead>
-                <tr>
-                    <th class="header">Architecture</th>
-                    <th class="header">Count</th>
-                    <th class="header">Percentage</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for cpu_name in query.facets.cpu_name %}
-                <tr>
-                    <td>{{ cpu_name.term }}</td>
-                    <td>{{ cpu_name.count }}</td>
-                    <td>{{ (100.0 * cpu_name.count / query.total) | round(1) }}%</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-</div>
-
 <div class="panel tab-inner-panel" id="panel-process-type">
     <header class="title" title="Toggle visibility">
         <h2>Process Type</h2>
@@ -136,33 +82,6 @@
                     <td>{{ process_type.term }}</td>
                     <td>{{ process_type.count }}</td>
                     <td>{{ (100.0 * process_type.count / query.total) | round(1) }}%</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-</div>
-
-<div class="panel tab-inner-panel" id="panel-flash-version">
-    <header class="title" title="Toggle visibility">
-        <h2>Flash&trade; Version</h2>
-        <div class="options show">show</div>
-    </header>
-    <div class="content">
-        <table class="tablesorter data-table">
-            <thead>
-                <tr>
-                    <th class="header">Flash&trade; Version</th>
-                    <th class="header">Count</th>
-                    <th class="header">Percentage</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for flash_version in query.facets.flash_version %}
-                <tr>
-                    <td>{{ flash_version.term }}</td>
-                    <td>{{ flash_version.count }}</td>
-                    <td>{{ (100.0 * flash_version.count / query.total) | round(1) }}%</td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -200,6 +119,87 @@
                     <td>{{ device.cpu_abi }}</td>
                     <td>{{ device.count }}</td>
                     <td>{{ (100.0 * device.count / query.total) | round(1) }}%</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="panel tab-inner-panel" id="panel-uptime">
+    <header class="title" title="Toggle visibility">
+        <h2>Uptime Range</h2>
+        <div class="options show">show</div>
+    </header>
+    <div class="content">
+        <table class="tablesorter data-table">
+            <thead>
+                <tr>
+                    <th class="header">Uptime Range</th>
+                    <th class="header">Count</th>
+                    <th class="header">Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for uptime in query.facets.histogram_uptime %}
+                <tr>
+                    <td>{{ uptime.term }}</td>
+                    <td>{{ uptime.count }}</td>
+                    <td>{{ (100.0 * uptime.count / query.total) | round(1) }}%</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="panel tab-inner-panel" id="panel-cpu-name">
+    <header class="title" title="Toggle visibility">
+        <h2>Architecture</h2>
+        <div class="options show">show</div>
+    </header>
+    <div class="content">
+        <table class="tablesorter data-table">
+            <thead>
+                <tr>
+                    <th class="header">Architecture</th>
+                    <th class="header">Count</th>
+                    <th class="header">Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for cpu_name in query.facets.cpu_name %}
+                <tr>
+                    <td>{{ cpu_name.term }}</td>
+                    <td>{{ cpu_name.count }}</td>
+                    <td>{{ (100.0 * cpu_name.count / query.total) | round(1) }}%</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="panel tab-inner-panel" id="panel-flash-version">
+    <header class="title" title="Toggle visibility">
+        <h2>Flash&trade; Version</h2>
+        <div class="options show">show</div>
+    </header>
+    <div class="content">
+        <table class="tablesorter data-table">
+            <thead>
+                <tr>
+                    <th class="header">Flash&trade; Version</th>
+                    <th class="header">Count</th>
+                    <th class="header">Percentage</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for flash_version in query.facets.flash_version %}
+                <tr>
+                    <td>{{ flash_version.term }}</td>
+                    <td>{{ flash_version.count }}</td>
+                    <td>{{ (100.0 * flash_version.count / query.total) | round(1) }}%</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/webapp-django/crashstats/signature/static/signature/css/signature_report.less
+++ b/webapp-django/crashstats/signature/static/signature/css/signature_report.less
@@ -114,10 +114,13 @@ a.crash-id {
 
 section.aggregations-panel,
 section.summary-panel {
+    > .body > .content.loaded {
+        column-count: 2;
+    }
     .panel {
         display: inline-block;
         vertical-align: top;
-        width: 45%;
+        width: 95%;
         margin-left: 2.4%;
         margin-right: 2.4%;
     }

--- a/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
+++ b/webapp-django/crashstats/signature/static/signature/js/signature_tab.js
@@ -1,3 +1,5 @@
+/* global SignatureReport Qs */
+
 /**
  * Abstract class for a tab to show information on the signature report page.
  *
@@ -123,6 +125,7 @@ SignatureReport.Tab.prototype.buildUrl = function (params, option) {
 // Extend this if anything different should be done with the returned data.
 SignatureReport.Tab.prototype.onAjaxSuccess = function (contentElement, data) {
     contentElement.empty().append($(data));
+    contentElement.addClass('loaded');
     if (this.dataDisplayType === 'table') {
         $('.tablesorter').tablesorter();
     }
@@ -145,6 +148,7 @@ SignatureReport.Tab.prototype.loadPanel = function (option) {
 
     // Append the new panel.
     this.$contentElement.append(panel.$panelElement);
+    this.$contentElement.addClass('loaded');
 
     // Disable the currently selected option.
     $('option[value=' + option + ']', this.$selectElement).prop('disabled', true);
@@ -169,7 +173,7 @@ SignatureReport.Tab.prototype.loadContent = function (contentElement, option) {
         // table or a graph.
         var dataTypes = {
             'table': 'html',
-            'graph': 'json'
+            'graph': 'json',
         };
 
         // Empty the content element and append a loader.
@@ -182,7 +186,7 @@ SignatureReport.Tab.prototype.loadContent = function (contentElement, option) {
             error: function(jqXHR, textStatus, errorThrown) {
                 SignatureReport.handleError(contentElement, jqXHR, textStatus, errorThrown);
             },
-            dataType: dataTypes[this.dataDisplayType]
+            dataType: dataTypes[this.dataDisplayType],
         });
 
     }


### PR DESCRIPTION
This uses the column-count CSS property to display inner panels in columns, thus leading to a better use of white space when there are long results. It also reorders summary panels to keep the same display order than now.

Assigned to @lonnen for he is the Grand Master of UI. 