### PR TITLE
fixes bug 1347229 - Make validate_and_test.py report on keys never se…

### DIFF
--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -82,8 +82,6 @@ def run(no_crashes, *urls):
         search = r.json()
         uuids = [x['uuid'] for x in search['hits']]
 
-    assert len(uuids) == len(set(uuids))
-
     processor = MockedTelemetryBotoS3CrashStorage()
 
     all_keys = set()

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -138,9 +138,9 @@ def run(no_crashes, *urls):
             len(keys_not_in_crashes),
             'keys in JSON Schema, but never in any of the tested crashes:'
         )
-        print('  ', 'KEY'.ljust(70), 'TYPE(S)')
+        print('  ', 'KEY'.ljust(60), 'TYPE(S)')
         for k in sorted(keys_not_in_crashes):
-            print('  ', k.ljust(70), all_schema_types[k])
+            print('  ', k.ljust(60), all_schema_types[k])
 
 
 def main():

--- a/socorro/schemas/validate_and_test.py
+++ b/socorro/schemas/validate_and_test.py
@@ -33,7 +33,7 @@ class MockedTelemetryBotoS3CrashStorage(TelemetryBotoS3CrashStorage):
         self.combined = crash
 
 
-def main(*urls):
+def run(no_crashes, *urls):
     file_path = os.path.join(HERE, 'crash_report.json')
     with open(file_path) as f:
         schema = json.load(f)
@@ -57,7 +57,8 @@ def main(*urls):
             url,
             params={
                 '_columns': ['uuid'],
-                '_facets_size': 0
+                '_facets_size': 0,
+                '_results_number': no_crashes,
             }
         )
         search = r.json()
@@ -74,7 +75,8 @@ def main(*urls):
             params={
                 'product': 'Firefox',
                 '_columns': ['uuid'],
-                '_facets_size': 0
+                '_facets_size': 0,
+                '_results_number': no_crashes,
             }
         )
         search = r.json()
@@ -83,6 +85,25 @@ def main(*urls):
     assert len(uuids) == len(set(uuids))
 
     processor = MockedTelemetryBotoS3CrashStorage()
+
+    all_keys = set()
+
+    def log_all_keys(crash, prefix=''):
+        for key, value in crash.items():
+            if isinstance(value, dict):
+                log_all_keys(value, prefix=prefix + '{}.'.format(key))
+            else:
+                all_keys.add(prefix + key)
+
+    all_schema_types = {}
+
+    def log_all_schema_keys(schema, prefix=''):
+        for key, value in schema['properties'].items():
+            if isinstance(value, dict) and 'properties' in value:
+                log_all_schema_keys(value, prefix=prefix + '{}.'.format(key))
+            else:
+                all_schema_types[prefix + key] = value['type']
+    log_all_schema_keys(schema)
 
     print('Testing {} random recent crash reports'.format(len(uuids)))
     for uuid in uuids:
@@ -98,17 +119,47 @@ def main(*urls):
         )
         print(r.url)
         processed_crash = r.json()
+
         processor.save_raw_and_processed(
             raw_crash,
             (),  # dumps
             processed_crash,
             uuid,
         )
+        log_all_keys(processor.combined)
+
         jsonschema.validate(processor.combined, schema)
 
-    print('Done testing, all crash reports passed.')
+    print('\nDone testing, all crash reports passed.\n')
+
+    keys_not_in_crashes = set(all_schema_types.keys()) - all_keys
+    if keys_not_in_crashes:
+        print(
+            len(keys_not_in_crashes),
+            'keys in JSON Schema, but never in any of the tested crashes:'
+        )
+        print('  ', 'KEY'.ljust(70), 'TYPE(S)')
+        for k in sorted(keys_not_in_crashes):
+            print('  ', k.ljust(70), all_schema_types[k])
+
+
+def main():
+    import argparse
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        '--crashes-per-url', '-n',
+        help='Number of crashes to download per SuperSearch URL',
+        default=20,
+    )
+    argparser.add_argument(
+        'urls',
+        help='SuperSearch API URL(s) to use instead of the default',
+        nargs='*',
+    )
+    args = argparser.parse_args()
+    run(args.crashes_per_url, *args.urls)
 
 
 if __name__ == '__main__':
     import sys
-    sys.exit(main(*sys.argv[1:]))
+    sys.exit(main())


### PR DESCRIPTION
…en in crashes


Looks like this:
```
▶ python socorro/schemas/validate_and_test.py -n 2 https://crash-stats.mozilla.com/api/SuperSearch/\?product\=Firefox\&date\=%3E%3D2017-03-07T17%3A54%3A00.000Z\&date\=%3C2017-03-14T17%3A54%3A00.000Z https://crash-stats.mozilla.com/api/SuperSearch/\?memory_images\=%3E%3D0\&product\=Firefox\&date\=%3E%3D2017-03-07T17%3A54%3A00.000Z\&date\=%3C2017-03-14T17%3A54%3A00.000Z https://crash-stats.mozilla.com/api/SuperSearch/\?plugin_name\=flash\&product\=Firefox\&date\=%3E%3D2017-03-07T17%3A55%3A00.000Z\&date\=%3C2017-03-14T17%3A55%3A00.000Z
socorro/schemas/crash_report.json is a valid JSON schema
Fetching data...
https://crash-stats.mozilla.com/api/SuperSearchFields/
Testing 6 random recent crash reports
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=8626e445-0681-4ae0-ac00-7f2122170307
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=8626e445-0681-4ae0-ac00-7f2122170307
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=e0684c29-44ae-4db2-a4c6-6c4b72170307
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=e0684c29-44ae-4db2-a4c6-6c4b72170307
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=cb0b3150-0355-4caf-a5cd-3d9e12170308
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=cb0b3150-0355-4caf-a5cd-3d9e12170308
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=9f1d2cce-f096-4073-ad31-709fa2170308
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=9f1d2cce-f096-4073-ad31-709fa2170308
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=a2e8b5ed-31e0-477b-a565-f09872170308
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=a2e8b5ed-31e0-477b-a565-f09872170308
https://crash-stats.mozilla.com/api/RawCrash/?crash_id=c49f6e3c-fcab-418b-8dda-527542170308
https://crash-stats.mozilla.com/api/ProcessedCrash/?crash_id=c49f6e3c-fcab-418b-8dda-527542170308

Done testing, all crash reports passed.

13 keys in JSON Schema, but never in any of the tested crashes:
   KEY                                                                    TYPE(S)
   classifications.jit.category                                           [u'string', u'null']
   classifications.jit.category_return_code                               [u'string', u'null']
   classifications.skunk_works.classification                             [u'string', u'null']
   classifications.skunk_works.classification_data                        [u'string', u'null']
   classifications.skunk_works.classification_version                     [u'string', u'null']
   classifications.support.classification                                 [u'string', u'null']
   classifications.support.classification_data                            [u'string', u'null']
   classifications.support.classification_version                         [u'string', u'null']
   cpu_arch                                                               [u'string', u'null']
   crash_id                                                               [u'string', u'null']
   memory_report.hasMozMallocUsableSize                                   boolean
   memory_report.reports                                                  array
   memory_report.version                                                  [u'integer', u'null']
```

I tested it by running it once. Doing some more supersearch queries until more and more keys disappeared off the list of those that are excessive. 