### PR TITLE
Pass in 'xterm' to ansiColor()

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -10,7 +10,7 @@ def capabilities = [
 pipeline {
   agent any
   options {
-    ansiColor()
+    ansiColor('xterm')
     timestamps()
     timeout(time: 1, unit: 'HOURS')
   }


### PR DESCRIPTION
(Sadly, needed due to a change in Pipeline Model/plugins.)

@davehunt @willkg @m8ttyB ?