### PR TITLE
Reformat PYTEST_ADDOPTS args, due to Jenkins issue

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   environment {
-    /** See https://issues.jenkins-ci.org/browse/JENKINS-42857 - we'd like to expand this out into multi-line concatenations */
+    /** See https://issues.jenkins-ci.org/browse/JENKINS-42771 - we'd like to expand this out into multi-line concatenations */
     PYTEST_ADDOPTS = "-n=10 --tb=short --color=yes --driver=SauceLabs --variables=capabilities.json"
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
   }

--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -15,12 +15,8 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   environment {
-    PYTEST_ADDOPTS =
-      "-n=10 " +
-      "--color=yes " +
-      "--tb=short " +
-      "--driver=SauceLabs " +
-      "--variables=capabilities.json"
+    /** See https://issues.jenkins-ci.org/browse/JENKINS-42857 - we'd like to expand this out into multi-line concatenations */
+    PYTEST_ADDOPTS = "-n=10 --tb=short --color=yes --driver=SauceLabs --variables=capabilities.json"
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
   }
   stages {


### PR DESCRIPTION
@willkg / @davehunt @m8ttyB r?

Passing ad-hoc build here: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/socorro.adhoc/35/console

See https://issues.jenkins-ci.org/browse/JENKINS-42857