### PR TITLE
bug 1341755 - don't bash lock crontabber

### DIFF
--- a/scripts/crons/crontabber.sh
+++ b/scripts/crons/crontabber.sh
@@ -8,7 +8,6 @@
 
 NAME=`basename $0 .sh`
 CT_INI="/etc/socorro/crontabber.ini"
-lock --ignore-existing $NAME
 export CMD="${PYTHON} ${APPDIR}/socorro/cron/crontabber_app.py"
 LOG=/var/log/socorro/crontabber.log
 if [ -f $CT_INI ] && [ -r $CT_INI ]; then
@@ -17,6 +16,5 @@ else
     envconsul -once -prefix socorro/common -prefix socorro/crontabber bash -c "$CMD" >> $LOG 2>&1
 fi
 EXIT_CODE=$?
-unlock $NAME
 
 exit $EXIT_CODE


### PR DESCRIPTION
[The `lock` function](https://github.com/mozilla/socorro/blob/master/scripts/crons/socorrorc#L16) is used in other `.sh` files that I doubt we use but I'd rather deal with that separately. 