### PR TITLE
fixes bug 1352385 - Use active versions if 0 featured versions

### DIFF
--- a/webapp-django/crashstats/base/jinja2/crashstats_base.html
+++ b/webapp-django/crashstats/base/jinja2/crashstats_base.html
@@ -59,26 +59,30 @@
                     <optgroup label=" ">
                         <option value="Current Versions">Current Versions</option>
                     </optgroup>
+
+                    {% set pvs = filter_featured_versions(active_versions[product]) %}
+                    {% if pvs %}
                     <optgroup label=" ">
-                    {% for pv in active_versions[product] %}
-                        {% if pv.is_featured %}
+                    {% for pv in pvs %}
                         <option
                             value="{{ pv.version }}"
                             {% if pv.version == version %}selected{% endif %}
                         >{{ pv.version }}</option>
-                        {% endif %}
-                    {% endfor  %}
+                    {% endfor %}
                     </optgroup>
+                    {% endif %}
+
+                    {% set pvs = filter_not_featured_versions(active_versions[product]) %}
+                    {% if pvs %}
                     <optgroup label=" ">
-                    {% for pv in active_versions[product] %}
-                        {% if not pv.is_featured %}
+                    {% for pv in pvs %}
                         <option
                             value="{{ pv.version }}"
                             {% if pv.version == version %}selected{% endif %}
                         >{{ pv.version }}</option>
-                        {% endif %}
-                    {% endfor  %}
+                    {% endfor %}
                     </optgroup>
+                    {% endif %}
                 </select>
             </li>
             <li>

--- a/webapp-django/crashstats/base/templatetags/jinja_helpers.py
+++ b/webapp-django/crashstats/base/templatetags/jinja_helpers.py
@@ -109,3 +109,13 @@ def is_dangerous_cpu(cpu_info):
         cpu_info.startswith('AuthenticAMD family 20 model 1') or
         cpu_info.startswith('AuthenticAMD family 20 model 2')
     )
+
+
+@library.global_function
+def filter_featured_versions(product_versions):
+    return [pv for pv in product_versions if pv['is_featured']]
+
+
+@library.global_function
+def filter_not_featured_versions(product_versions):
+    return [pv for pv in product_versions if not pv['is_featured']]

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -323,7 +323,7 @@ class BaseTestViews(DjangoTestCase):
                     'throttle': '99.00',
                     'end_date': yesterday,
                     'start_date': '2012-03-08',
-                    'is_featured': True,
+                    'is_featured': False,
                     'version': '9.5',
                     'build_type': 'Alpha',
                     'has_builds': True,
@@ -333,7 +333,7 @@ class BaseTestViews(DjangoTestCase):
                     'throttle': '99.00',
                     'end_date': end_date,
                     'start_date': '2012-03-08',
-                    'is_featured': True,
+                    'is_featured': False,
                     'version': '10.5',
                     'build_type': 'nightly',
                     'has_builds': True,
@@ -936,6 +936,59 @@ class TestViews(BaseTestViews):
         ok_(first_row[2].isdigit())  # adi
         ok_(is_percentage(first_row[3]))  # throttle
         ok_(is_percentage(first_row[4]))  # ratio
+
+    def test_crashes_per_day_product_sans_featued_versions(self):
+        url = reverse('crashstats:crashes_per_day')
+
+        def mocked_adi_get(**options):
+            eq_(options['versions'], ['9.5', '10.5'])
+            response = {
+                'total': 0,
+                'hits': []
+            }
+            return response
+
+        def mocked_product_build_types_get(**options):
+            return {
+                'hits': {
+                    'release': 0.1,
+                    'beta': 1.0,
+                }
+            }
+
+        models.ProductBuildTypes.implementation().get.side_effect = (
+            mocked_product_build_types_get
+        )
+
+        models.ADI.implementation().get.side_effect = mocked_adi_get
+
+        def mocked_supersearch_get(**params):
+            eq_(params['product'], ['SeaMonkey'])
+            eq_(params['version'], ['9.5', '10.5'])
+            response = {
+                'facets': {
+                    'histogram_date': [],
+                    'signature': [],
+                    'version': []
+                },
+                'hits': [],
+                'total': 0
+            }
+            return response
+
+        SuperSearchUnredacted.implementation().get.side_effect = (
+            mocked_supersearch_get
+        )
+
+        response = self.client.get(url, {
+            'p': 'SeaMonkey',
+            # Note that no version is passed explicitly
+        })
+        eq_(response.status_code, 200)
+        # Not going to do more testing of the response content. That's
+        # what test_crashes_per_day() does.
+        # This tests' mocking methods checks that the right versions
+        # (9.5 and 10.5) are pulled out for the various data queries.
 
     def test_crashes_per_day_failing_shards(self):
         url = reverse('crashstats:crashes_per_day')

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -937,7 +937,7 @@ class TestViews(BaseTestViews):
         ok_(is_percentage(first_row[3]))  # throttle
         ok_(is_percentage(first_row[4]))  # ratio
 
-    def test_crashes_per_day_product_sans_featued_versions(self):
+    def test_crashes_per_day_product_sans_featured_versions(self):
         url = reverse('crashstats:crashes_per_day')
 
         def mocked_adi_get(**options):
@@ -947,6 +947,8 @@ class TestViews(BaseTestViews):
                 'hits': []
             }
             return response
+
+        models.ADI.implementation().get.side_effect = mocked_adi_get
 
         def mocked_product_build_types_get(**options):
             return {
@@ -959,8 +961,6 @@ class TestViews(BaseTestViews):
         models.ProductBuildTypes.implementation().get.side_effect = (
             mocked_product_build_types_get
         )
-
-        models.ADI.implementation().get.side_effect = mocked_adi_get
 
         def mocked_supersearch_get(**params):
             eq_(params['product'], ['SeaMonkey'])

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -472,8 +472,8 @@ def crashes_per_day(request, default_context=None):
                 params['versions'].append(pv['version'])
         if not params['versions'] and active_versions:
             # There were no featured versions, but there were active
-            # versions. Use the top 4 active versions instead.
-            for pv in active_versions[:4]:
+            # versions. Use the top X active versions instead.
+            for pv in active_versions[:settings.NUMBER_OF_FEATURED_VERSIONS]:
                 params['versions'].append(pv['version'])
 
     context['available_versions'] = []

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -466,8 +466,14 @@ def crashes_per_day(request, default_context=None):
     if not params['versions']:
         # need to pick the default featured ones
         params['versions'] = []
-        for pv in context['active_versions'][context['product']]:
+        active_versions = context['active_versions'][context['product']]
+        for pv in active_versions:
             if pv['is_featured']:
+                params['versions'].append(pv['version'])
+        if not params['versions'] and active_versions:
+            # There were no featured versions, but there were active
+            # versions. Use the top 4 active versions instead.
+            for pv in active_versions[:4]:
                 params['versions'].append(pv['version'])
 
     context['available_versions'] = []

--- a/webapp-django/crashstats/home/tests/test_views.py
+++ b/webapp-django/crashstats/home/tests/test_views.py
@@ -26,6 +26,20 @@ class TestViews(BaseTestViews):
         ok_('WaterWolf 4.0.1' in response.content)
         ok_('WaterWolf 19.0' not in response.content)
 
+    def test_home_product_without_featued_versions(self):
+        url = reverse('home:home', args=('SeaMonkey',))
+        response = self.client.get(url)
+        eq_(response.status_code, 200)
+        ok_('SeaMonkey Crash Data' in response.content)
+        ok_('SeaMonkey 10.5' in response.content)
+        ok_('SeaMonkey 9.5' in response.content)
+
+        # Test with a different version.
+        response = self.client.get(url, {'version': '10.5'})
+        eq_(response.status_code, 200)
+        ok_('SeaMonkey 10.5' in response.content)
+        ok_('SeaMonkey 9.5' not in response.content)
+
     def test_homepage_redirect(self):
         response = self.client.get('/')
         eq_(response.status_code, 302)

--- a/webapp-django/crashstats/home/tests/test_views.py
+++ b/webapp-django/crashstats/home/tests/test_views.py
@@ -26,7 +26,7 @@ class TestViews(BaseTestViews):
         ok_('WaterWolf 4.0.1' in response.content)
         ok_('WaterWolf 19.0' not in response.content)
 
-    def test_home_product_without_featued_versions(self):
+    def test_home_product_without_featured_versions(self):
         url = reverse('home:home', args=('SeaMonkey',))
         response = self.client.get(url)
         eq_(response.status_code, 200)

--- a/webapp-django/crashstats/home/views.py
+++ b/webapp-django/crashstats/home/views.py
@@ -34,7 +34,7 @@ def home(request, product, default_context=None):
             context['versions'] = [
                 x['version']
                 for x in context['active_versions'][product]
-            ][:4]
+            ][:settings.NUMBER_OF_FEATURED_VERSIONS]
 
     # Set selected version for the navigation bar.
     if len(context['versions']) == 1:

--- a/webapp-django/crashstats/home/views.py
+++ b/webapp-django/crashstats/home/views.py
@@ -26,6 +26,15 @@ def home(request, product, default_context=None):
             for x in context['active_versions'][product]
             if x['is_featured']
         ]
+        # If there are no featured versions but there are active
+        # versions, then fall back to use that instead.
+        if not context['versions'] and context['active_versions'][product]:
+            # But when we do that, we have to make a manual cut-off of
+            # the number of versions to return. So make it max 4.
+            context['versions'] = [
+                x['version']
+                for x in context['active_versions'][product]
+            ][:4]
 
     # Set selected version for the navigation bar.
     if len(context['versions']) == 1:

--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -754,3 +754,9 @@ CSP_CHILD_SRC = (
 CSP_CONNECT_SRC = (
     "'self'",
 )
+
+
+# This is the number of versions to display if a particular product
+# has no 'featured versions'. Then we use the active versions, but capped
+# up to this number.
+NUMBER_OF_FEATURED_VERSIONS = config('NUMBER_OF_FEATURED_VERSIONS', 4)

--- a/webapp-django/crashstats/topcrashers/views.py
+++ b/webapp-django/crashstats/topcrashers/views.py
@@ -213,6 +213,15 @@ def topcrashers(request, days=None, possible_days=None, default_context=None):
                     request.build_absolute_uri(), urlquote(pv['version'])
                 )
                 return redirect(url)
+        if context['active_versions'][product]:
+            # Not a single version was featured, but there were active
+            # versions. In this case, use the first available
+            # *active* version.
+            for pv in context['active_versions'][product]:
+                url = '%s&version=%s' % (
+                    request.build_absolute_uri(), urlquote(pv['version'])
+                )
+                return redirect(url)
 
     # See if all versions support builds. If not, refuse to show the "by build"
     # range option in the UI.


### PR DESCRIPTION
This basically makes the home page, Top Crashers, Crashes Per Day work again if the product *has* active versions but *no featured* versions. 