### PR TITLE
fixes bug 1352440 - Cleanup old use of mocking

### DIFF
--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -617,7 +617,7 @@ class TestViews(BaseTestViews):
         cache_key = 'buginfo:987'
         eq_(cache.get(cache_key), struct['bugs'][0])
 
-    def test_exploitability_report(self, rpost):
+    def test_exploitability_report(self):
         url = reverse('crashstats:exploitability_report')
 
         def mocked_bugs_threesigs(**options):

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -95,13 +95,6 @@ _SAMPLE_UNREDACTED = {
     }
 }
 
-BUG_STATUS = {
-    'hits': [
-        {'id': '222222', 'signature': 'FakeSignature1'},
-        {'id': '333333', 'signature': 'FakeSignature1'},
-        {'id': '444444', 'signature': 'Other FakeSignature'}
-    ]
-}
 
 SAMPLE_SIGNATURE_SUMMARY = {
     'reports': {
@@ -190,34 +183,6 @@ SAMPLE_SIGNATURE_SUMMARY = {
 }
 
 
-# Helper mocks for several tests
-def mocked_post_123(**options):
-    return {
-        'hits': [{
-            'id': '123456789',
-            'signature': 'Something'
-        }]
-    }
-
-
-def mocked_post_threesigs(**options):
-    return {
-        'hits': [
-            {'id': '111111111', 'signature': 'FakeSignature 1'},
-            {'id': '222222222', 'signature': 'FakeSignature 3'},
-            {'id': '101010101', 'signature': 'FakeSignature'}
-        ]
-    }
-
-
-def mocked_post_nohits(**options):
-    return {'hits': [], 'total': 0}
-
-
-def mocked_post_threeothersigs(**options):
-    return BUG_STATUS
-
-
 class RobotsTestViews(DjangoTestCase):
 
     @override_settings(ENGAGE_ROBOTS=True)
@@ -253,8 +218,7 @@ class FaviconTestViews(DjangoTestCase):
 
 class BaseTestViews(DjangoTestCase):
 
-    @mock.patch('requests.get')
-    def setUp(self, rget):
+    def setUp(self):
         super(BaseTestViews, self).setUp()
 
         # Tests assume and require a non-persistent cache backend
@@ -426,6 +390,17 @@ class BaseTestViews(DjangoTestCase):
 
         models.ProductVersions().get(active=True)
         models.Platforms().get()
+
+        def mocked_bugs_get(**options):
+            return {
+                'hits': [{
+                    'id': '123456789',
+                    'signature': 'Something'
+                }]
+            }
+
+        # The default mocking of Bugs.get
+        models.Bugs.implementation().get.side_effect = mocked_bugs_get
 
     def tearDown(self):
         super(BaseTestViews, self).tearDown()
@@ -642,10 +617,19 @@ class TestViews(BaseTestViews):
         cache_key = 'buginfo:987'
         eq_(cache.get(cache_key), struct['bugs'][0])
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
     def test_exploitability_report(self, rpost):
         url = reverse('crashstats:exploitability_report')
-        rpost.side_effect = mocked_post_threesigs
+
+        def mocked_bugs_threesigs(**options):
+            return {
+                'hits': [
+                    {'id': '111111111', 'signature': 'FakeSignature 1'},
+                    {'id': '222222222', 'signature': 'FakeSignature 3'},
+                    {'id': '101010101', 'signature': 'FakeSignature'}
+                ]
+            }
+
+        models.Bugs.implementation().get.side_effect = mocked_bugs_threesigs
 
         queried_versions = []
 
@@ -786,8 +770,7 @@ class TestViews(BaseTestViews):
 
         assert queried_versions == [['19.0'], None]
 
-    @mock.patch('requests.get')
-    def test_crashes_per_day(self, rget):
+    def test_crashes_per_day(self):
         url = reverse('crashstats:crashes_per_day')
 
         def mocked_adi_get(**options):
@@ -954,8 +937,7 @@ class TestViews(BaseTestViews):
         ok_(is_percentage(first_row[3]))  # throttle
         ok_(is_percentage(first_row[4]))  # ratio
 
-    @mock.patch('requests.get')
-    def test_crashes_per_day_failing_shards(self, rget):
+    def test_crashes_per_day_failing_shards(self):
         url = reverse('crashstats:crashes_per_day')
 
         def mocked_adi_get(**options):
@@ -1009,8 +991,7 @@ class TestViews(BaseTestViews):
         ok_('Our database is experiencing troubles' in response.content)
         ok_('week of 2010-01-04 is ~20% lower' in response.content)
 
-    @mock.patch('requests.get')
-    def test_crashes_per_day_bad_argument_error(self, rget):
+    def test_crashes_per_day_bad_argument_error(self):
         url = reverse('crashstats:crashes_per_day')
 
         def mocked_adi_get(**options):
@@ -1066,8 +1047,7 @@ class TestViews(BaseTestViews):
         ok_('date_range_type=build' not in parsed.query)
         ok_('date_range_type=' not in parsed.query)
 
-    @mock.patch('requests.get')
-    def test_crashes_per_day_with_beta_versions(self, rget):
+    def test_crashes_per_day_with_beta_versions(self):
         """This is a variation on test_crashes_per_day() (above)
         but with fewer basic assertions. The point of this
         test is to request it for '18.0b' and '19.0'. The '18.0b'
@@ -1310,20 +1290,21 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         eq_(response.status_code, 200)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index(self, rget, rpost):
+    def test_report_index(self):
         dump = 'OS|Mac OS X|10.6.8 10K549\nCPU|amd64|family 6 mod|1'
         comment0 = 'This is a comment\nOn multiple lines'
         comment0 += '\npeterbe@example.com'
         comment0 += '\nwww.p0rn.com'
 
-        rpost.side_effect = mocked_post_threeothersigs
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
+        def mocked_bugs_get(**options):
+            return {
+                'hits': [
+                    {'id': '222222', 'signature': 'FakeSignature1'},
+                    {'id': '333333', 'signature': 'FakeSignature1'},
+                    {'id': '444444', 'signature': 'Other FakeSignature'}
+                ]
+            }
+        models.Bugs.implementation().get.side_effect = mocked_bugs_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1421,18 +1402,9 @@ class TestViews(BaseTestViews):
         ok_(_SAMPLE_META['Email'] not in response.content)
         ok_(_SAMPLE_META['URL'] not in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_additional_raw_dump_links(self, rget, rpost):
+    def test_report_index_with_additional_raw_dump_links(self):
         # using \\n because it goes into the JSON string
         dump = 'OS|Mac OS X|10.6.8 10K549\\nCPU|amd64|family 6 mod|1'
-
-        rpost.side_effect = mocked_post_threeothersigs
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_processed_crash_get(**params):
             assert 'datatype' in params
@@ -1509,10 +1481,7 @@ class TestViews(BaseTestViews):
         )
         ok_(bar_dmp_url in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_symbol_url_in_modules(self, rget, rpost):
-        rpost.side_effect = mocked_post_threeothersigs
+    def test_report_index_with_symbol_url_in_modules(self):
         json_dump = {
             'status': 'OK',
             'sensitive': {
@@ -1543,11 +1512,6 @@ class TestViews(BaseTestViews):
                 },
             ]
         }
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1585,10 +1549,7 @@ class TestViews(BaseTestViews):
             response.content
         )
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_shutdownhang_signature(self, rget, rpost):
-        rpost.side_effect = mocked_post_threeothersigs
+    def test_report_index_with_shutdownhang_signature(self):
         json_dump = {
             'crash_info': {
                 'crashing_thread': 2,
@@ -1601,11 +1562,6 @@ class TestViews(BaseTestViews):
             ],
             'modules': [],
         }
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1639,19 +1595,10 @@ class TestViews(BaseTestViews):
         ok_('Crashing Thread (2)' not in response.content)
         ok_('Crashing Thread (0)' in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_fennecandroid_report(self, rget, rpost):
+    def test_report_index_fennecandroid_report(self):
         comment0 = 'This is a comment\nOn multiple lines'
         comment0 += '\npeterbe@mozilla.com'
         comment0 += '\nwww.p0rn.com'
-
-        rpost.side_effect = mocked_post_threeothersigs
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1696,22 +1643,13 @@ class TestViews(BaseTestViews):
             link = doc('a.sig-overview').eq(0)
             ok_('product=WinterSun' in link.attr('href'))
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_odd_product_and_version(self, rget, rpost):
+    def test_report_index_odd_product_and_version(self):
         """If the processed JSON references an unfamiliar product and
         version it should not use that to make links in the nav to
         reports for that unfamiliar product and version."""
         comment0 = 'This is a comment\nOn multiple lines'
         comment0 += '\npeterbe@mozilla.com'
         comment0 += '\nwww.p0rn.com'
-
-        rpost.side_effect = mocked_post_threeothersigs
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1753,15 +1691,7 @@ class TestViews(BaseTestViews):
         bad_url = reverse('home:home', args=('SummerWolf',))
         ok_(bad_url not in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_no_dump(self, rget, rpost):
-        rpost.side_effect = mocked_post_threesigs
-
-        def mocked_get(url, params, **options):
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
+    def test_report_index_no_dump(self):
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1802,21 +1732,7 @@ class TestViews(BaseTestViews):
         ok_('Invalid crash ID' in response.content)
         eq_(response['Content-Type'], 'text/html; charset=utf-8')
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_valid_install_time(self, rget, rpost):
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if 'crashes/comments' in url:
-                return Response({
-                    'hits': [],
-                    'total': 0,
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
+    def test_report_index_with_valid_install_time(self):
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1852,22 +1768,7 @@ class TestViews(BaseTestViews):
         # This is what 1461170304 is in human friendly format.
         ok_('2016-04-20 16:38:24' in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_invalid_install_time(self, rget, rpost):
-
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if 'crashes/comments' in url:
-                return Response({
-                    'hits': [],
-                    'total': 0,
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
+    def test_report_index_with_invalid_install_time(self):
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1906,22 +1807,7 @@ class TestViews(BaseTestViews):
             if pyquery.PyQuery(row).find('th').text() == 'Install Time':
                 eq_(pyquery.PyQuery(row).find('td').text(), '')
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_empty_os_name(self, rget, rpost):
-
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if 'crashes/comments' in url:
-                return Response({
-                    'hits': [],
-                    'total': 0,
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
+    def test_report_index_empty_os_name(self):
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -1959,9 +1845,7 @@ class TestViews(BaseTestViews):
         for node in doc('#mainbody'):
             eq_(node.attrib['data-platform'], '')
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_invalid_parsed_dump(self, rget, rpost):
+    def test_report_index_with_invalid_parsed_dump(self):
         json_dump = {
             'crash_info': {
                 'address': '0x88',
@@ -1989,29 +1873,6 @@ class TestViews(BaseTestViews):
             'thread_count': 1,
             'threads': [{'frame_count': 0, 'frames': []}]
         }
-
-        comment0 = "This is a comment"
-        email1 = "some@otheremailaddress.com"
-
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if 'crashes/comments' in url:
-                return Response({
-                    "hits": [
-                        {
-                            "user_comments": comment0,
-                            "date_processed": "2012-08-21T11:17:28-07:00",
-                            "email": email1,
-                            "uuid": "469bde48-0e8f-3586-d486-b98810120830"
-                        }
-                    ],
-                    "total": 1
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2042,33 +1903,8 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         ok_('<th>Install Time</th>' not in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_sparse_json_dump(self, rget, rpost):
+    def test_report_index_with_sparse_json_dump(self):
         json_dump = {'status': 'ERROR_NO_MINIDUMP_HEADER', 'sensitive': {}}
-
-        comment0 = 'This is a comment'
-        email1 = 'some@otheremailaddress.com'
-
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if 'crashes/comments' in url:
-                return Response({
-                    'hits': [
-                        {
-                            'user_comments': comment0,
-                            'date_processed': '2012-08-21T11:17:28-07:00',
-                            'email': email1,
-                            'uuid': '469bde48-0e8f-3586-d486-b98810120830',
-                        }
-                    ],
-                    'total': 1
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2099,33 +1935,8 @@ class TestViews(BaseTestViews):
         response = self.client.get(url)
         eq_(response.status_code, 200)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_with_crash_exploitability(self, rget, rpost):
-        comment0 = 'This is a comment'
-        email1 = 'some@otheremailaddress.com'
-
+    def test_report_index_with_crash_exploitability(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
-
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if '/crashes/comments' in url:
-                return Response({
-                    'hits': [
-                        {
-                            'user_comments': comment0,
-                            'date_processed': '2012-08-21T11:17:28-07:00',
-                            'email': email1,
-                            'uuid': '469bde48-0e8f-3586-d486-b98810120830',
-                        }
-                    ],
-                    'total': 1
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2165,12 +1976,8 @@ class TestViews(BaseTestViews):
         ok_('Exploitability</th>' in response.content)
         ok_('Unknown Exploitability' in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_your_crash(self, rget, rpost):
+    def test_report_index_your_crash(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
-
-        rpost.side_effect = mocked_post_123
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2214,12 +2021,8 @@ class TestViews(BaseTestViews):
         ok_('peterbe@example.com' in response.content)
         ok_('https://embarrassing.example.com' in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_not_your_crash(self, rget, rpost):
+    def test_report_index_not_your_crash(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
-
-        rpost.side_effect = mocked_post_123
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2259,11 +2062,8 @@ class TestViews(BaseTestViews):
         ok_('peterbe@example.com' not in response.content)
         ok_('https://embarrassing.example.com' not in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    def test_report_index_raw_crash_not_found(self, rpost):
+    def test_report_index_raw_crash_not_found(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
-
-        rpost.side_effect = mocked_post_123
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2283,11 +2083,8 @@ class TestViews(BaseTestViews):
         eq_(response.status_code, 404)
         ok_('Crash Not Found' in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    def test_report_index_processed_crash_not_found(self, rpost):
+    def test_report_index_processed_crash_not_found(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
-
-        rpost.side_effect = mocked_post_123
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params
@@ -2329,8 +2126,7 @@ class TestViews(BaseTestViews):
             response.content
         )
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    def test_report_index_with_invalid_date_processed(self, rpost):
+    def test_report_index_with_invalid_date_processed(self):
         crash_id = '11cb72f5-eb28-41e1-a8e4-849982120611'
 
         def mocked_raw_crash_get(**params):
@@ -2364,31 +2160,7 @@ class TestViews(BaseTestViews):
         # to a more human format.
         ok_('2015-10-10 15:32:07.620535' in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.get')
-    def test_report_index_redirect_by_prefix(self, rget, rpost):
-        comment0 = "This is a comment"
-        email1 = "some@otheremailaddress.com"
-
-        rpost.side_effect = mocked_post_123
-
-        def mocked_get(url, params, **options):
-            if 'crashes/comments' in url:
-                return Response({
-                    'hits': [
-                        {
-                            'user_comments': comment0,
-                            'date_processed': '2012-08-21T11:17:28-07:00',
-                            'email': email1,
-                            'uuid': '469bde48-0e8f-3586-d486-b98810120830'
-                        }
-                    ],
-                    'total': 1
-                })
-
-            raise NotImplementedError(url)
-
-        rget.side_effect = mocked_get
+    def test_report_index_redirect_by_prefix(self):
 
         def mocked_raw_crash_get(**params):
             assert 'datatype' in params

--- a/webapp-django/crashstats/supersearch/tests/test_views.py
+++ b/webapp-django/crashstats/supersearch/tests/test_views.py
@@ -374,15 +374,9 @@ class TestViews(BaseTestViews):
         ok_('<script>' not in response.content)
         ok_('&lt;script&gt;' in response.content)
 
-    @mock.patch('requests.post')
-    def test_search_results_admin_mode(self, rpost):
+    def test_search_results_admin_mode(self):
         """Test that an admin can see more fields, and that a non-admin cannot.
         """
-        def mocked_post(**options):
-            assert 'bugs' in options['url'], options['url']
-            return Response({"hits": [], "total": 0})
-
-        rpost.side_effect = mocked_post
 
         def mocked_supersearch_get(**params):
             assert '_columns' in params
@@ -524,16 +518,7 @@ class TestViews(BaseTestViews):
         ok_('Version' in response.content)
         ok_('1.0' in response.content)
 
-    @mock.patch('requests.post')
-    def test_search_results_parameters(self, rpost):
-        def mocked_post(**options):
-            assert 'bugs' in options['url'], options['url']
-            return Response({
-                "hits": [],
-                "total": 0
-            })
-
-        rpost.side_effect = mocked_post
+    def test_search_results_parameters(self):
 
         def mocked_supersearch_get(**params):
             # Verify that all expected parameters are in the URL.
@@ -574,17 +559,9 @@ class TestViews(BaseTestViews):
         )
         eq_(response.status_code, 200)
 
-    @mock.patch('requests.post')
-    def test_search_results_pagination(self, rpost):
+    def test_search_results_pagination(self):
         """Test that the pagination of results works as expected.
         """
-        def mocked_post(**options):
-            assert 'bugs' in options['url'], options['url']
-            return Response("""
-                {"hits": [], "total": 0}
-            """)
-
-        rpost.side_effect = mocked_post
 
         def mocked_supersearch_get(**params):
             assert '_columns' in params

--- a/webapp-django/crashstats/topcrashers/tests/test_views.py
+++ b/webapp-django/crashstats/topcrashers/tests/test_views.py
@@ -1,26 +1,21 @@
 import datetime
 
 import freezegun
-import mock
 import pyquery
 from nose.tools import eq_, ok_
 
 from django.core.urlresolvers import reverse
 from django.utils.timezone import utc
 
-from crashstats.crashstats.models import SignatureFirstDate
-from crashstats.crashstats.tests.test_views import (
-    BaseTestViews, mocked_post_123
-)
+from crashstats.crashstats.models import SignatureFirstDate, Bugs
+from crashstats.crashstats.tests.test_views import BaseTestViews
 from crashstats.supersearch.models import SuperSearchUnredacted
 
 
 class TestViews(BaseTestViews):
     base_url = reverse('topcrashers:topcrashers')
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    @mock.patch('requests.post')
-    def test_topcrashers(self, rpost, bugs_get):
+    def test_topcrashers(self):
 
         def mocked_bugs(**options):
             return {
@@ -33,7 +28,7 @@ class TestViews(BaseTestViews):
                      "signature": u"FakeSignature1 \u7684 Japanese"}
                 ]
             }
-        bugs_get.side_effect = mocked_bugs
+        Bugs.implementation().get.side_effect = mocked_bugs
 
         def mocked_signature_first_date_get(**options):
             return {
@@ -247,15 +242,12 @@ class TestViews(BaseTestViews):
         })
         eq_(response.status_code, 400)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    def test_topcrasher_without_any_signatures(self, rpost):
+    def test_topcrasher_without_any_signatures(self):
         url = self.base_url + '?product=WaterWolf&version=19.0'
         response = self.client.get(self.base_url, {
             'product': 'WaterWolf',
         })
         ok_(url in response['Location'])
-
-        rpost.side_effect = mocked_post_123
 
         def mocked_supersearch_get(**params):
             return {
@@ -275,9 +267,7 @@ class TestViews(BaseTestViews):
         })
         eq_(response.status_code, 200)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    def test_topcrasher_modes(self, rpost):
-        rpost.side_effect = mocked_post_123
+    def test_topcrasher_modes(self):
 
         def mocked_supersearch_get(**params):
             return {
@@ -317,9 +307,7 @@ class TestViews(BaseTestViews):
             ok_(today in response.content)
             ok_(now not in response.content)
 
-    @mock.patch('crashstats.crashstats.models.Bugs.get')
-    def test_topcrasher_by_build(self, rpost):
-        rpost.side_effect = mocked_post_123
+    def test_topcrasher_by_build(self):
 
         def mocked_supersearch_get(**params):
             ok_('build_id' in params)


### PR DESCRIPTION
I know this looks like a lot but it's not. 

It's a leftover legacy from when we switched from mocking the middleware to implementations. I also did some cleaning up for stuff that was made global and didn't need to be. 

Sooo much less mocking now. 