### PR TITLE
fixes bug 1353482 - Create 0-permission API tokens in admin

### DIFF
--- a/webapp-django/crashstats/manage/forms.py
+++ b/webapp-django/crashstats/manage/forms.py
@@ -69,6 +69,7 @@ class APITokenForm(BaseModelForm):
         self.possible_permissions = kwargs.pop('possible_permissions', [])
         expires_choices = kwargs.pop('expires_choices', [])
         super(APITokenForm, self).__init__(*args, **kwargs)
+        self.fields['permissions'].required = False
         self.fields['permissions'].choices = (
             (x.pk, x.name) for x in self.possible_permissions
         )


### PR DESCRIPTION
I looked the docs and there appears to be no way to use meta fields to override `required` for ModelForm classes. 
https://docs.djangoproject.com/en/1.8/topics/forms/modelforms/#overriding-the-default-fields