### PR TITLE
Add object-src 'none' to CSP

### DIFF
--- a/webapp-django/crashstats/settings/base.py
+++ b/webapp-django/crashstats/settings/base.py
@@ -733,6 +733,9 @@ GOOGLE_AUTH_HELP_URL = 'https://wiki.mozilla.org/Socorro/GoogleAuth'
 CSP_DEFAULT_SRC = (
     "'self'",
 )
+CSP_OBJECT_SRC = (
+    "'none'",
+)
 CSP_SCRIPT_SRC = (
     "'self'",
     'apis.google.com',


### PR DESCRIPTION
Assuming we don't use flash, java and other plugins, we shouldn't run them at all even from our origin.

Our CSP object-src currently falls back to the default-src of 'self' allowing clients to run plugins from our origin. 

This PR locks things down further to prevent plugin execution in the unlikely event that someone can inject object/embed html and upload a plugin to our domain.