### PR TITLE
Submit to Treeherder; bump shared-library version

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
           archiveArtifacts 'e2e-tests/results/*'
           junit 'e2e-tests/results/*.xml'
           submitToActiveData('e2e-tests/results/py27_raw.txt')
-          submitToTreeherder('socorro-tests', 'e2e', 'End-to-end integration tests', 'e2e-tests/results/*', 'e2e-tests/results/py27_tbpl.txt')
+          submitToTreeherder('socorro', 'e2e', 'End-to-end integration tests', 'e2e-tests/results/*', 'e2e-tests/results/py27_tbpl.txt')
           publishHTML(target: [
             allowMissing: false,
             alwaysLinkToLastBuild: true,

--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('fxtest@1.3') _
+@Library('fxtest@1.6') _
 
 /** Desired capabilities */
 def capabilities = [
@@ -17,6 +17,7 @@ pipeline {
   environment {
     /** See https://issues.jenkins-ci.org/browse/JENKINS-42771 - we'd like to expand this out into multi-line concatenations */
     PYTEST_ADDOPTS = "-n=10 --tb=short --color=yes --driver=SauceLabs --variables=capabilities.json"
+    PULSE = credentials('PULSE')
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
   }
   stages {
@@ -34,7 +35,8 @@ pipeline {
         always {
           archiveArtifacts 'e2e-tests/results/*'
           junit 'e2e-tests/results/*.xml'
-          submitToActiveData('e2e-tests/results/py27.log')
+          submitToActiveData('e2e-tests/results/py27_raw.txt')
+          submitToTreeherder('socorro-tests', 'e2e', 'End-to-end integration tests', 'e2e-tests/results/*', 'e2e-tests/results/py27_tbpl.txt')
           publishHTML(target: [
             allowMissing: false,
             alwaysLinkToLastBuild: true,

--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands = pytest \
     --junit-xml=results/{envname}.xml \
     --html=results/{envname}.html --self-contained-html \
-    --log-raw=results/{envname}.txt \
+    --log-raw=results/{envname}_raw.txt \
     --log-tbpl=results/{envname}_tbpl.txt \
     {posargs}
 

--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -20,8 +20,9 @@ deps =
     requests==2.13.0
 commands = pytest \
     --junit-xml=results/{envname}.xml \
-    --html=results/{envname}.html \
-    --log-raw=results/{envname}.log \
+    --html=results/{envname}.html --self-contained-html \
+    --log-raw=results/{envname}.txt \
+    --log-tbpl=results/{envname}_tbpl.txt \
     {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
@willkg  / @davehunt r?

Will, Dave put up a blog post about why he/we are doing so, in http://davehunt.co.uk/2017/04/10/reporting-test-results-to-treeherder

We probably shouldn't merge this until we figure out and fix (here) or ask for "socorro-tests" to be a recognized (and perhaps unique?) name in Treeherder.

Right now, "socorro" submits to Treeherder, itself, which is pretty cool:

https://treeherder.mozilla.org/#/jobs?repo=socorro
