### PR TITLE
fixes bug 1356571 - ignore version checking on certain products

### DIFF
--- a/e2e-tests/tests/test_api.py
+++ b/e2e-tests/tests/test_api.py
@@ -8,9 +8,9 @@ import requests
 import pytest
 
 
-# Because there are so few crashes for these product, instead of
+# Because there are so few crashes for these products, instead of
 # looking for crashes from the *active* versions, we'll for any
-# any recent crashes for these.
+# version of any recent crashes for these.
 ANY_VERSION_PRODUCTS = ('SeaMonkey',)
 
 
@@ -32,7 +32,7 @@ class TestAPI:
         # for a single crash for that product
         product_to_uuid = {}
         for product, versions in product_versions.items():
-            if product == ANY_VERSION_PRODUCTS:
+            if product in ANY_VERSION_PRODUCTS:
                 # Effectively, don't filter by any particular version
                 versions = None
             response = requests.get(base_url + '/api/SuperSearch/', {

--- a/e2e-tests/tests/test_api.py
+++ b/e2e-tests/tests/test_api.py
@@ -8,6 +8,12 @@ import requests
 import pytest
 
 
+# Because there are so few crashes for these product, instead of
+# looking for crashes from the *active* versions, we'll for any
+# any recent crashes for these.
+ANY_VERSION_PRODUCTS = ('SeaMonkey',)
+
+
 class TestAPI:
 
     @pytest.mark.nondestructive
@@ -26,6 +32,9 @@ class TestAPI:
         # for a single crash for that product
         product_to_uuid = {}
         for product, versions in product_versions.items():
+            if product == ANY_VERSION_PRODUCTS:
+                # Effectively, don't filter by any particular version
+                versions = None
             response = requests.get(base_url + '/api/SuperSearch/', {
                 '_columns': ['uuid'],
                 'product': product,


### PR DESCRIPTION
cc @willkg @m8ttyB 

Another SeaMonkey thing. Thus I'm not going to scrutinize this problem too much. 

I do see SeaMonkey crashes coming in to stage. But none of the recent ones come from any of *active* SeaMonkey versions.