### PR TITLE
fixes bug 1357159 - Stop using SocorroCommon.fetch for bugzilla API

### DIFF
--- a/webapp-django/crashstats/base/utils.py
+++ b/webapp-django/crashstats/base/utils.py
@@ -1,5 +1,9 @@
 import urllib
 
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
 from django.template import engines
 
 
@@ -26,3 +30,36 @@ def urlencode_obj(thing):
     else:
         res = urllib.urlencode(thing, True)
     return res.replace('+', '%20')
+
+
+def requests_retry_session(retries=3, backoff_factor=0.3):
+    """Opinionated wrapper that creates a requests session with a
+    HTTPAdapter that sets up a Retry policy that includes connection
+    retries.
+
+    If you do the more naive retry by simply setting a number. E.g.::
+
+        adapter = HTTPAdapter(max_retries=3)
+
+    then it will raise immediately on any connection errors.
+    Retrying on connection errors guards better on unpredictable networks.
+    From http://docs.python-requests.org/en/master/api/?highlight=retries#requests.adapters.HTTPAdapter
+    it says: "By default, Requests does not retry failed connections."
+
+    The backoff_factor is documented here:
+    https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
+    A default of retries=3 and backoff_factor=0.3 means it will sleep like::
+
+        [0.3, 0.6, 1.2]
+    """  # noqa
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session

--- a/webapp-django/crashstats/crashstats/models.py
+++ b/webapp-django/crashstats/crashstats/models.py
@@ -194,7 +194,6 @@ def measure_fetches(method):
         self = args[0]
         url_or_implementation = args[1]
         if isinstance(url_or_implementation, basestring):
-            raise NotImplementedError(url_or_implementation)
             url = url_or_implementation
         else:
             url = url_or_implementation.__class__.__name__

--- a/webapp-django/crashstats/crashstats/tests/test_views.py
+++ b/webapp-django/crashstats/crashstats/tests/test_views.py
@@ -537,12 +537,12 @@ class TestViews(BaseTestViews):
         eq_(result['path'], url)
         eq_(result['query_string'], 'foo=bar')
 
-    @mock.patch('requests.get')
-    def test_buginfo(self, rget):
+    @mock.patch('requests.Session')
+    def test_buginfo(self, rsession):
         url = reverse('crashstats:buginfo')
 
-        def mocked_get(url, params, **options):
-            if 'bug?id=' in url:
+        def mocked_get(url, **options):
+            if 'bug?id=123,456' in url:
                 return Response({
                     'bugs': [{
                         'id': 123,
@@ -559,7 +559,7 @@ class TestViews(BaseTestViews):
 
             raise NotImplementedError(url)
 
-        rget.side_effect = mocked_get
+        rsession().get.side_effect = mocked_get
 
         response = self.client.get(url)
         eq_(response.status_code, 400)
@@ -574,12 +574,12 @@ class TestViews(BaseTestViews):
         ok_(struct['bugs'])
         eq_(struct['bugs'][0]['summary'], 'Some Summary')
 
-    @mock.patch('requests.get')
-    def test_buginfo_with_caching(self, rget):
+    @mock.patch('requests.Session')
+    def test_buginfo_with_caching(self, rsession):
         url = reverse('crashstats:buginfo')
 
-        def mocked_get(url, params, **options):
-            if 'bug?id=' in url:
+        def mocked_get(url, **options):
+            if 'bug?id=987,654' in url:
                 return Response({
                     'bugs': [
                         {
@@ -597,7 +597,7 @@ class TestViews(BaseTestViews):
 
             raise NotImplementedError(url)
 
-        rget.side_effect = mocked_get
+        rsession().get.side_effect = mocked_get
 
         response = self.client.get(url, {
             'bug_ids': '987,654',


### PR DESCRIPTION
CC @willkg 
Check out the new `requests_retry_session()` function. I think it can be useful. In particular because bugzilla can be quite flaky. 
If you do it like this, it'll retry on even making a connection which is akin or our web head not having a reliable network. 

Also, I tested this code by running it in a little test file, with decent backoff, whilst my WiFi was switched off. Then, whilst it was sitting there, I turned on the WiFi and, voila, got a 200 OK eventually. 

So, with 3 retries (connection errors) the worst that can happen is that it takes 0.3+0.6+1.2=2.1 seconds. And if it keeps timing out, it'll take a total of 5+0.3+5+0.6+5+1.2=17.1 seconds. But that's very unlikely to happen because timeouts are not systemic, unlike broken DNS or 500 errors. 