### PR TITLE
fixes bug 1357536 - UnicodeEncodeErrors on broken raw crashes

### DIFF
--- a/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
+++ b/webapp-django/crashstats/crashstats/jinja2/crashstats/report_index.html
@@ -686,7 +686,7 @@
                     <table class="record data-table vertical">
                         <tbody>
                             {% for key in raw_keys %}
-                            <tr title="{{ fields_desc.get('raw_crash.{}'.format(key), empty_desc) }}">
+                            <tr title="{{ fields_desc.get(make_raw_crash_key(key), empty_desc) }}">
                                 <th scope="row">{{ key }}</th>
                                 {% if key == 'Comments' %}
                                 <td><pre>{{ raw[key] | scrub_pii }}</pre></td>

--- a/webapp-django/crashstats/crashstats/views.py
+++ b/webapp-django/crashstats/crashstats/views.py
@@ -955,6 +955,20 @@ def report_index(request, crash_id, default_context=None):
             field['is_exposed'] and field['name'] or 'N/A',
         )
 
+    def make_raw_crash_key(key):
+        """In the report_index.html template we need to create a key
+        that we can use to look up against the 'fields_desc' dict.
+        Because you can't do something like this in jinja::
+
+            {{ fields_desc.get(u'raw_crash.{}'.format(key), empty_desc) }}
+
+        we do it here in the function instead.
+        The trick is that the lookup key has to be a unicode object or
+        else you get UnicodeEncodeErrors in the template rendering.
+        """
+        return u'raw_crash.{}'.format(key)
+
+    context['make_raw_crash_key'] = make_raw_crash_key
     context['fields_desc'] = descriptions
     context['empty_desc'] = 'No description for this field. Search: unknown'
 


### PR DESCRIPTION
Assuming you're using stage data, open https://crash-stats.allizom.org/report/index/c7c20b2e-ad32-487a-9363-fa5080170414 locally and see that it breaks before applying this PR. 


CC @willkg  if you're curious. 