### PR TITLE
Restore original PYTEST_ADDOPTS formatting

### DIFF
--- a/e2e-tests/Jenkinsfile
+++ b/e2e-tests/Jenkinsfile
@@ -15,8 +15,12 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   environment {
-    /** See https://issues.jenkins-ci.org/browse/JENKINS-42771 - we'd like to expand this out into multi-line concatenations */
-    PYTEST_ADDOPTS = "-n=10 --tb=short --color=yes --driver=SauceLabs --variables=capabilities.json"
+    PYTEST_ADDOPTS =
+    "-n=10 " +
+    "--tb=short " +
+    "--color=yes " +
+    "--driver=SauceLabs " +
+    "--variables=capabilities.json"
     PULSE = credentials('PULSE')
     SAUCELABS_API_KEY = credentials('SAUCELABS_API_KEY')
   }


### PR DESCRIPTION
@davehunt @willkg r?  Now that the Jenkins issue is fixed, we can restore our originally intended formatting style, for readability.

Adhoc has one (unrelated) failure: https://fx-test-jenkins-dev.stage.mozaws.net:8443/view/Web/job/socorro.adhoc/28/console, which also exists on master: https://fx-test-jenkins-dev.stage.mozaws.net:8443/view/Web/job/socorro.adhoc/30/console