### PR TITLE
Fixes bug 1250132 - Added a Rule to rewrite addons. 

### DIFF
--- a/socorro/processor/mozilla_processor_2015.py
+++ b/socorro/processor/mozilla_processor_2015.py
@@ -57,6 +57,7 @@ mozilla_processor_rule_sets = [
         "socorro.processor.mozilla_transform_rules.ThemePrettyNameRule, "
         "socorro.processor.rules.memory_report_extraction"
         ".MemoryReportExtraction, "
+        "socorro.processor.rules.addons_rewrite.AddonsRewriteRule, "
         "socorro.processor.signature_utilities.SignatureGenerationRule,"
         "socorro.processor.signature_utilities.StackwalkerErrorSignatureRule, "
         "socorro.processor.signature_utilities.OOMSignature, "

--- a/socorro/processor/rules/addons_rewrite.py
+++ b/socorro/processor/rules/addons_rewrite.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from socorro.lib.transform_rules import Rule
+
+
+class AddonsRewriteRule(Rule):
+    """Rewrite the `addons` field so make it easier to query.
+
+    The `addons` field contains a list of add-on ids and versions, but it
+    doesn't associate those. That makes it hard to query with tools like
+    Elasticsearch. We thus rewrite that field so ids and versions are in a
+    single string, separated by a colon.
+
+    In case the original list of add-ons has an odd number of elements, we
+    keep the last element as is.
+
+    For example:
+
+    >>> processed_crash['addons'] = [
+    ...     ['addon_1', '12.0'],
+    ...     ['mySuperADDON', '1.143.2'],
+    ...     ['{xws2r28dsoqq}', '42']
+    ... ]
+    >>> AddonsRewriteRule().act({}, {}, processed_crash, {})
+    >>> print(processed_crash['addons'])
+    ['addon_1:12.0', 'mySuperADDON:1.143.2', '{xws2r28dsoqq}:42']
+
+    """
+
+    def version(self):
+        return '1.0'
+
+    def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
+        """Verify that the `addons` field is present in the processed_crash
+        and that it is exploitable. """
+        return (
+            'addons' in processed_crash and
+            isinstance(processed_crash['addons'], (tuple, list)) and
+            len(processed_crash['addons']) > 0
+        )
+
+    def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
+        """Transform the `addons` field into a list of 'id:version' elements.
+        """
+        old_addons = processed_crash['addons']
+        new_addons = []
+
+        for parts in old_addons:
+            addon_str = parts
+            if isinstance(parts, (tuple, list)):
+                addon_str = ':'.join(unicode(x) for x in parts)
+
+            new_addons.append(addon_str)
+
+        processed_crash['addons'] = new_addons
+        return True

--- a/socorro/unittest/processor/rules/test_addons_rewrite.py
+++ b/socorro/unittest/processor/rules/test_addons_rewrite.py
@@ -1,0 +1,96 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+from nose.tools import eq_, ok_
+
+from socorro.processor.rules.addons_rewrite import (
+    AddonsRewriteRule,
+)
+from socorro.unittest.testbase import TestCase
+from socorro.unittest.processor.test_signature_utilities import (
+    create_basic_fake_processor
+)
+
+
+HERE = os.path.dirname(__file__)
+
+
+class TestAddonsRewriteRule(TestCase):
+    def get_config(self):
+        fake_processor = create_basic_fake_processor()
+        return fake_processor.config
+
+    def test_predicate_success(self):
+        config = self.get_config()
+        rule = AddonsRewriteRule(config)
+
+        processed_crash = {}
+        processed_crash['addons'] = [['abcd', '1']]
+
+        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        ok_(predicate_result)
+
+    def test_predicate_no_match(self):
+        config = self.get_config()
+        rule = AddonsRewriteRule(config)
+
+        processed_crash = {}
+
+        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        ok_(not predicate_result)
+
+        processed_crash['addons'] = []
+        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        ok_(not predicate_result)
+
+        processed_crash['addons'] = None
+        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        ok_(not predicate_result)
+
+        processed_crash['addons'] = ''
+        predicate_result = rule.predicate({}, {}, processed_crash, {})
+        ok_(not predicate_result)
+
+    def test_action_success(self):
+        config = self.get_config()
+        rule = AddonsRewriteRule(config)
+
+        processed_crash = {}
+        processed_crash['addons'] = [
+            ['abcd', '1'],
+            ['efgh', 32],
+        ]
+
+        action_result = rule.action({}, {}, processed_crash, {})
+        ok_(action_result)
+        ok_('addons' in processed_crash)
+
+        expected_res = [
+            'abcd:1',
+            'efgh:32',
+        ]
+        eq_(processed_crash['addons'], expected_res)
+
+    def test_action_success_with_odd_number_of_addons(self):
+        config = self.get_config()
+        rule = AddonsRewriteRule(config)
+
+        processed_crash = {}
+        processed_crash['addons'] = [
+            ['abcd', '1'],
+            ['xyz'],  # note the lonely id here
+            ['efgh', 32],
+        ]
+
+        action_result = rule.action({}, {}, processed_crash, {})
+        ok_(action_result)
+        ok_('addons' in processed_crash)
+
+        expected_res = [
+            'abcd:1',
+            'xyz',
+            'efgh:32',
+        ]
+        eq_(processed_crash['addons'], expected_res)


### PR DESCRIPTION
The addons field as it is now is not very useful for aggregating and searching, as it is a list of mixed ids and versions. We thus want to change it so that ids and versions are associated. For example, ["aaa", "12", "bcd", 1] would become ["aaa:12", "bcd:1"].