### PR TITLE
Fixes bug 1362061 - Use actual new addons format in ThemePrettyNameRule.

### DIFF
--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -99,13 +99,13 @@ class Rule(RequiredConfig):
                 to_str(self.__class__),
                 x,
             )
-        except Exception, x:
-            self.config.logger.debug(
-                'Rule %s action failed because of "%s"',
-                to_str(self.__class__),
-                x,
-                exc_info=True
-            )
+        # except Exception, x:
+        #     self.config.logger.debug(
+        #         'Rule %s action failed because of "%s"',
+        #         to_str(self.__class__),
+        #         x,
+        #         exc_info=True
+        #     )
         return False
 
     #--------------------------------------------------------------------------

--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -99,13 +99,13 @@ class Rule(RequiredConfig):
                 to_str(self.__class__),
                 x,
             )
-        # except Exception, x:
-        #     self.config.logger.debug(
-        #         'Rule %s action failed because of "%s"',
-        #         to_str(self.__class__),
-        #         x,
-        #         exc_info=True
-        #     )
+        except Exception, x:
+            self.config.logger.debug(
+                'Rule %s action failed because of "%s"',
+                to_str(self.__class__),
+                x,
+                exc_info=True
+            )
         return False
 
     #--------------------------------------------------------------------------

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -1089,11 +1089,11 @@ class ThemePrettyNameRule(Rule):
 
     #--------------------------------------------------------------------------
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        '''addons is a list of tuples containing (extension, version)'''
+        '''addons is a list of string like 'extension:version'. '''
         addons = processed_crash.get('addons', [])
 
         for addon in addons:
-            extension, version = addon.split(':', 1)
+            extension = addon.split(':')[0]
             if extension in self.conversions:
                 return True
         return False
@@ -1103,9 +1103,12 @@ class ThemePrettyNameRule(Rule):
         addons = processed_crash.addons
 
         for index, addon in enumerate(addons):
-            extension, version = addon.split(':', 1)
-            if extension in self.conversions:
-                addons[index] = ':'.join(
-                    (self.conversions[extension], version)
-                )
+            if ':' in addon:
+                extension, version = addon.split(':', 1)
+                if extension in self.conversions:
+                    addons[index] = ':'.join(
+                        (self.conversions[extension], version)
+                    )
+            elif addon in self.conversions:
+                addons[index] = self.conversions[addons]
         return True

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -1113,5 +1113,5 @@ class ThemePrettyNameRule(Rule):
                         (self.conversions[extension], version)
                     )
             elif addon in self.conversions:
-                addons[index] = self.conversions[addons]
+                addons[index] = self.conversions[addon]
         return True

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -1089,7 +1089,10 @@ class ThemePrettyNameRule(Rule):
 
     #--------------------------------------------------------------------------
     def _predicate(self, raw_crash, raw_dumps, processed_crash, proc_meta):
-        '''addons is a list of string like 'extension:version'. '''
+        '''addons is expected to be a list of strings like 'extension:version',
+        but we are being overly cautious and consider the case where they
+        lack the ':version' part, because user inputs are never reliable.
+        '''
         addons = processed_crash.get('addons', [])
 
         for addon in addons:

--- a/socorro/processor/mozilla_transform_rules.py
+++ b/socorro/processor/mozilla_transform_rules.py
@@ -1092,7 +1092,8 @@ class ThemePrettyNameRule(Rule):
         '''addons is a list of tuples containing (extension, version)'''
         addons = processed_crash.get('addons', [])
 
-        for extension, version in addons:
+        for addon in addons:
+            extension, version = addon.split(':', 1)
             if extension in self.conversions:
                 return True
         return False
@@ -1101,7 +1102,10 @@ class ThemePrettyNameRule(Rule):
     def _action(self, raw_crash, raw_dumps, processed_crash, processor_meta):
         addons = processed_crash.addons
 
-        for index, (extension, version) in enumerate(addons):
+        for index, addon in enumerate(addons):
+            extension, version = addon.split(':', 1)
             if extension in self.conversions:
-                addons[index] = (self.conversions[extension], version)
+                addons[index] = ':'.join(
+                    (self.conversions[extension], version)
+                )
         return True

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -2218,3 +2218,23 @@ class TestThemePrettyNameRule(TestCase):
         ]
         res = rule._predicate({}, {}, processed_crash, processor_meta)
         ok_(not res)
+
+    #--------------------------------------------------------------------------
+    def test_with_malformed_addons_field(self):
+        config = self.get_basic_config()
+        rule = ThemePrettyNameRule(config)
+
+        processed_crash = DotDict()
+        processor_meta = self.get_basic_processor_meta()
+
+        processed_crash.addons = [
+            'addon_with_no_version',
+            '{972ce4c6-7e08-4474-a285-3208198ce6fd}:12.0',
+        ]
+        rule.act({}, {}, processed_crash, processor_meta)
+
+        expected_addon_list = [
+            'addon_with_no_version',
+            '{972ce4c6-7e08-4474-a285-3208198ce6fd} (default theme):12.0',
+        ]
+        eq_(processed_crash.addons, expected_addon_list)

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -2158,17 +2158,17 @@ class TestThemePrettyNameRule(TestCase):
         rule = ThemePrettyNameRule(config)
 
         processed_crash.addons = [
-            ('adblockpopups@jessehakanen.net', '0.3'),
-            ('dmpluginff@westbyte.com', '1,4.8'),
-            ('firebug@software.joehewitt.com', '1.9.1'),
-            ('killjasmin@pierros14.com', '2.4'),
-            ('support@surfanonymous-free.com', '1.0'),
-            ('uploader@adblockfilters.mozdev.org', '2.1'),
-            ('{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}', '20111107'),
-            ('{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}', '2.0.3'),
-            ('anttoolbar@ant.com', '2.4.6.4'),
-            ('{972ce4c6-7e08-4474-a285-3208198ce6fd}', '12.0'),
-            ('elemhidehelper@adblockplus.org', '1.2.1')
+            'adblockpopups@jessehakanen.net:0.3',
+            'dmpluginff@westbyte.com:1,4.8',
+            'firebug@software.joehewitt.com:1.9.1',
+            'killjasmin@pierros14.com:2.4',
+            'support@surfanonymous-free.com:1.0',
+            'uploader@adblockfilters.mozdev.org:2.1',
+            '{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}:20111107',
+            '{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}:2.0.3',
+            'anttoolbar@ant.com:2.4.6.4',
+            '{972ce4c6-7e08-4474-a285-3208198ce6fd}:12.0',
+            'elemhidehelper@adblockplus.org:1.2.1',
         ]
 
         # the call to be tested
@@ -2179,18 +2179,17 @@ class TestThemePrettyNameRule(TestCase):
         eq_(raw_dumps, {})
 
         expected_addon_list = [
-            ('adblockpopups@jessehakanen.net', '0.3'),
-            ('dmpluginff@westbyte.com', '1,4.8'),
-            ('firebug@software.joehewitt.com', '1.9.1'),
-            ('killjasmin@pierros14.com', '2.4'),
-            ('support@surfanonymous-free.com', '1.0'),
-            ('uploader@adblockfilters.mozdev.org', '2.1'),
-            ('{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}', '20111107'),
-            ('{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}', '2.0.3'),
-            ('anttoolbar@ant.com', '2.4.6.4'),
-            ('{972ce4c6-7e08-4474-a285-3208198ce6fd} (default theme)',
-             '12.0'),
-            ('elemhidehelper@adblockplus.org', '1.2.1')
+            'adblockpopups@jessehakanen.net:0.3',
+            'dmpluginff@westbyte.com:1,4.8',
+            'firebug@software.joehewitt.com:1.9.1',
+            'killjasmin@pierros14.com:2.4',
+            'support@surfanonymous-free.com:1.0',
+            'uploader@adblockfilters.mozdev.org:2.1',
+            '{a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7}:20111107',
+            '{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}:2.0.3',
+            'anttoolbar@ant.com:2.4.6.4',
+            '{972ce4c6-7e08-4474-a285-3208198ce6fd} (default theme):12.0',
+            'elemhidehelper@adblockplus.org:1.2.1',
         ]
         eq_(processed_crash.addons, expected_addon_list)
 
@@ -2214,8 +2213,8 @@ class TestThemePrettyNameRule(TestCase):
 
         # Test with key missing from list.
         processed_crash.addons = [
-            ('adblockpopups@jessehakanen.net', '0.3'),
-            ('dmpluginff@westbyte.com', '1,4.8'),
+            'adblockpopups@jessehakanen.net:0.3',
+            'dmpluginff@westbyte.com:1,4.8',
         ]
         res = rule._predicate({}, {}, processed_crash, processor_meta)
         ok_(not res)

--- a/socorro/unittest/processor/test_mozilla_transform_rules.py
+++ b/socorro/unittest/processor/test_mozilla_transform_rules.py
@@ -2229,12 +2229,14 @@ class TestThemePrettyNameRule(TestCase):
 
         processed_crash.addons = [
             'addon_with_no_version',
-            '{972ce4c6-7e08-4474-a285-3208198ce6fd}:12.0',
+            '{972ce4c6-7e08-4474-a285-3208198ce6fd}',
+            'elemhidehelper@adblockplus.org:1.2.1',
         ]
         rule.act({}, {}, processed_crash, processor_meta)
 
         expected_addon_list = [
             'addon_with_no_version',
-            '{972ce4c6-7e08-4474-a285-3208198ce6fd} (default theme):12.0',
+            '{972ce4c6-7e08-4474-a285-3208198ce6fd} (default theme)',
+            'elemhidehelper@adblockplus.org:1.2.1',
         ]
         eq_(processed_crash.addons, expected_addon_list)


### PR DESCRIPTION
The change to the addons field format in bug 1250132 broke the ThemePrettyNameRule rule. This commit makes that rule use the current format.