### PR TITLE
Bump pytest-metadata to 1.4.0

### DIFF
--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest==3.0.7
     pytest-base-url==1.3.0
     pytest-html==1.14.2
-    pytest-metadata==1.3.0
+    pytest-metadata==1.4.0
     pytest-selenium==1.10.0
     pytest-variables==1.6.1
     pytest-xdist==1.16.0


### PR DESCRIPTION
Changelog is here, FWIW: https://github.com/davehunt/pytest-metadata/commit/9eb23a5f48d105ead2b0f0cfbdd7cabee0a4aa21

Ad-hoc run (passing): https://gist.github.com/stephendonner/781e346b7356dec7625894a5fbeba81a

r?