### PR TITLE
fixes bug 1362371 - Don't assume BZAPI always works

### DIFF
--- a/webapp-django/crashstats/base/utils.py
+++ b/webapp-django/crashstats/base/utils.py
@@ -32,7 +32,11 @@ def urlencode_obj(thing):
     return res.replace('+', '%20')
 
 
-def requests_retry_session(retries=3, backoff_factor=0.3):
+def requests_retry_session(
+    retries=3,
+    backoff_factor=0.3,
+    status_forcelist=None,
+):
     """Opinionated wrapper that creates a requests session with a
     HTTPAdapter that sets up a Retry policy that includes connection
     retries.
@@ -51,6 +55,15 @@ def requests_retry_session(retries=3, backoff_factor=0.3):
     A default of retries=3 and backoff_factor=0.3 means it will sleep like::
 
         [0.3, 0.6, 1.2]
+
+    Optionally you can pass in a list of status codes that you consider
+    worthy of retries (just like a ConnectionError). For example::
+
+        session = requests_retry_session(status_forcelist=(500, 502))
+        session.get(...)
+
+    Now, if the server responds with one of these errors, the session
+    will just try again.
     """  # noqa
     session = requests.Session()
     retry = Retry(
@@ -58,6 +71,7 @@ def requests_retry_session(retries=3, backoff_factor=0.3):
         read=retries,
         connect=retries,
         backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
     )
     adapter = HTTPAdapter(max_retries=retry)
     session.mount('http://', adapter)

--- a/webapp-django/crashstats/crashstats/tests/test_models.py
+++ b/webapp-django/crashstats/crashstats/tests/test_models.py
@@ -112,6 +112,22 @@ class TestModels(DjangoTestCase):
             'summary': 'Some summary'
         }])
 
+    @mock.patch('requests.Session')
+    def test_bugzilla_api_bad_status_code(self, rsession):
+        model = models.BugzillaBugInfo
+
+        api = model()
+
+        def mocked_get(url, **options):
+            return Response("I'm a teapot", status_code=418)
+
+        rsession().get.side_effect = mocked_get
+        assert_raises(
+            models.BugzillaRestHTTPUnexpectedError,
+            api.get,
+            '123456789'
+        )
+
     def test_processed_crash(self):
         model = models.ProcessedCrash
         api = model()


### PR DESCRIPTION
I didn't bother writing a test because then we'd have to mock urllib3 from within the requests vendor package. 

I've tried a similar solution on my songsear.ch for many weeks and it's been great. 