### PR TITLE
bug 1362434 - send processor exceptions to sentry

### DIFF
--- a/socorro/lib/transform_rules.py
+++ b/socorro/lib/transform_rules.py
@@ -3,9 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
-import configman
 import collections
 import inspect
+
+import raven
+import configman
 
 from configman import RequiredConfig, Namespace
 from configman.dotdict import DotDict
@@ -47,11 +49,60 @@ class Rule(RequiredConfig):
         default=False,
     )
 
-
     #--------------------------------------------------------------------------
     def __init__(self, config=None, quit_check_callback=None):
         self.config = config
         self.quit_check_callback = quit_check_callback
+
+    def _send_to_sentry(self, tag, *args, **kwargs):
+        """Execute this when an exception has happened only.
+        If self.config.sentry.dsn is set up, it will try to send it
+        to Sentry. If not configured, nothing happens.
+        """
+        try:
+            dsn = self.config.sentry.dsn
+        except KeyError:
+            # if self.config is not a DotDict, we can't access the sentry.dsn
+            dsn = None
+        if dsn:
+            extra = {
+                'class': self.__class__.__name__,
+                'tag': tag,  # this can 'predicate' or 'action'
+            }
+
+            # For every crash acted on, it's always
+            # act(raw_crash, ...) etc.
+            # But be defensive in case the first argument isn't there,
+            # isn't a dict or doesn't have a 'uuid'.
+            if args and isinstance(args[0], collections.Mapping):
+                crash_id = args[0].get('uuid')
+                if crash_id:
+                    extra['crash_id'] = crash_id
+
+            try:
+                client = raven.Client(dsn=dsn)
+                client.context.activate()
+                client.context.merge({'extra': extra})
+                try:
+                    identifier = client.captureException()
+                    self.config.logger.info(
+                        'Error captured in Sentry! '
+                        'Reference: {}'.format(
+                            identifier
+                        )
+                    )
+                    return True  # it worked!
+                finally:
+                    client.context.clear()
+            except Exception:
+                self.config.logger.error(
+                    'Unable to report error with Raven',
+                    exc_info=True,
+                )
+        else:
+            self.config.logger.warning(
+                'Raven DSN is not configured and an exception happened'
+            )
 
     #--------------------------------------------------------------------------
     def predicate(self, *args, **kwargs):
@@ -63,13 +114,15 @@ class Rule(RequiredConfig):
         """
         try:
             return self._predicate(*args, **kwargs)
-        except Exception, x:
-            self.config.logger.debug(
-                'Rule %s predicicate failed because of "%s"',
-                to_str(self.__class__),
-                x,
-                exc_info=True
-            )
+        except Exception as exception:
+            if not self._send_to_sentry('predicate', *args, **kwargs):
+                # Only log if it couldn't be sent to Sentry
+                self.config.logger.debug(
+                    'Rule %s predicicate failed because of "%s"',
+                    to_str(self.__class__),
+                    exception,
+                    exc_info=True
+                )
             return False
 
     #--------------------------------------------------------------------------
@@ -94,18 +147,22 @@ class Rule(RequiredConfig):
         try:
             return self._action(*args, **kwargs)
         except KeyError, x:
-            self.config.logger.debug(
-                'Rule %s action failed because of missing key "%s"',
-                to_str(self.__class__),
-                x,
-            )
+            if not self._send_to_sentry('action', *args, **kwargs):
+                # Only log if it couldn't be sent to Sentry
+                self.config.logger.debug(
+                    'Rule %s action failed because of missing key "%s"',
+                    to_str(self.__class__),
+                    x,
+                )
         except Exception, x:
-            self.config.logger.debug(
-                'Rule %s action failed because of "%s"',
-                to_str(self.__class__),
-                x,
-                exc_info=True
-            )
+            if not self._send_to_sentry('action', *args, **kwargs):
+                # Only log if it couldn't be sent to Sentry
+                self.config.logger.debug(
+                    'Rule %s action failed because of "%s"',
+                    to_str(self.__class__),
+                    x,
+                    exc_info=True
+                )
         return False
 
     #--------------------------------------------------------------------------

--- a/socorro/processor/processor_2015.py
+++ b/socorro/processor/processor_2015.py
@@ -232,7 +232,7 @@ class Processor2015(RequiredConfig):
                     raw_crash,
                     raw_dumps,
                     processed_crash,
-                    processor_meta_data
+                    processor_meta_data,
                 )
                 self.quit_check()
 
@@ -240,15 +240,15 @@ class Processor2015(RequiredConfig):
             # raised, call it a success.
             processed_crash.success = True
 
-        except Exception, x:
+        except Exception as exception:
             self.config.logger.warning(
                 'Error while processing %s: %s',
                 crash_id,
-                str(x),
+                str(exception),
                 exc_info=True
             )
             processor_meta_data.processor_notes.append(
-                'unrecoverable processor error: %s' % x
+                'unrecoverable processor error: %s' % exception
             )
 
         # the processor notes are in the form of a list.  Join them all
@@ -296,4 +296,3 @@ class Processor2015(RequiredConfig):
                 # guess we don't need to close that rule
                 pass
         self.config.logger.debug('done closing rules')
-


### PR DESCRIPTION
So this PR just tackles *one* problem. It injects itself in every `._predidate(...)` and `._action(...)` call. Only. 

In [processor_2015.py it does a loop and calls .act() on every rule in a set](https://github.com/mozilla/socorro/blob/fc6841672e8179cd6721a52cdc1a34d233338bf2/socorro/processor/processor_2015.py#L231-L236).

I *could* inject this sentry code in the `Rule.act` method (which is overwritten in `TransformRule.act` by the way) but I don't think that's safe. 
I actually wanted to be very defensive here. I didn't want to mess too much which how the whole rule act of predicate and action works. What I just try to do is stop swallowing real Python exceptions whenever a `_predicate` or `_action` is called on **any** rule. 

Who knows. There could be some rule where exceptions is "kinda expected" and is abused as a way of saying it shouldn't run. For example:

```python
class MyCoolTransformRule(TransformRule):
    def _predicate(self, *args, **kwargs):
         if datetime.now().strftime("%A") == "Monday":
             raise Exception("Don't run this transform rule on Mondays")
         return True
```
This would be a way of basically saying "Don't run the _action on this transform rule". 
Instead, what the code should be is:

```python
class MyCoolTransformRule(TransformRule):
    def _predicate(self, *args, **kwargs):
         if datetime.now().strftime("%A") == "Monday":
             return False
         return True
```
But how do we hunt these down? Exceptions should NOT be OK unless it's extreme. Almost all cases of letting an exception mean "don't run" can be changed. And that's what this PR sets us in the right direction of. 