### PR TITLE
Fixes bug 1362125 - Fixed KeyError in JitCrashCategorizeRule.

### DIFF
--- a/socorro/processor/breakpad_transform_rules.py
+++ b/socorro/processor/breakpad_transform_rules.py
@@ -695,9 +695,12 @@ class JitCrashCategorizeRule(ExternalProcessRule):
             # we don't want any of these
             return False
 
-        if processed_crash.json_dump['crashing_thread']['frames'][0].get(
-            'module',
-            False
+        if (
+            'crashing_thread' in processed_crash.json_dump and
+            processed_crash.json_dump['crashing_thread']['frames'][0].get(
+                'module',
+                False
+            )
         ):  # there is a module at the top of the stack, we don't want this
             return False
 


### PR DESCRIPTION
The JitCrashCategorizeRule assumed a crashing_thread was always present in the json_dump, and that turned out not to always be true. We want to verify that there is one before running the rule.