### PR TITLE
Fix elasticsearch tests

### DIFF
--- a/socorro/unittest/external/es/base.py
+++ b/socorro/unittest/external/es/base.py
@@ -837,6 +837,10 @@ class ElasticsearchTestCase(TestCase):
             request_timeout=1
         )
 
+    def get_url(self):
+        """Returns the first url in the elasticsearch_urls list"""
+        return self.config.elasticsearch.elasticsearch_urls[0]
+
     def get_tuned_config(self, sources, extra_values=None):
         if not isinstance(sources, (list, tuple)):
             sources = [sources]

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -4,7 +4,6 @@
 
 import datetime
 import json
-import time
 
 import requests_mock
 from nose.tools import assert_raises, eq_, ok_
@@ -1886,9 +1885,6 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
 
     @minimum_es_version('1.0')
     def test_get_with_zero(self):
-        # !FIXME Wait for Elasticsearch to be ready.
-        time.sleep(0.1)
-
         res = self.api.get(
             _results_number=0,
         )
@@ -1905,9 +1901,6 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
     @minimum_es_version('1.0')
     @requests_mock.Mocker(real_http=True)
     def test_get_with_failing_shards(self, mock_requests):
-        # !FIXME Wait for Elasticsearch to be ready.
-        time.sleep(0.1)
-
         # Test with one failing shard.
         es_results = {
             'hits': {

--- a/socorro/unittest/external/es/test_supersearch.py
+++ b/socorro/unittest/external/es/test_supersearch.py
@@ -34,6 +34,9 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
         self.api = SuperSearchWithFields(config=self.config)
         self.now = datetimeutil.utc_now()
 
+        # Wait until the cluster is yellow before proceeding.
+        self.health_check()
+
     def test_get_indices(self):
         now = datetime.datetime(2001, 1, 2, 0, 0)
         lastweek = now - datetime.timedelta(weeks=1)
@@ -1930,8 +1933,9 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
         }
 
         mock_requests.get(
-            'http://localhost:9200/{}/crash_reports/_search'.format(
-                self.config.elasticsearch.elasticsearch_index
+            '{url}/{index}/crash_reports/_search'.format(
+                url=self.get_url(),
+                index=self.config.elasticsearch.elasticsearch_index
             ),
             text=json.dumps(es_results)
         )
@@ -1985,8 +1989,9 @@ class IntegrationTestSuperSearch(ElasticsearchTestCase):
         }
 
         mock_requests.get(
-            'http://localhost:9200/{}/crash_reports/_search'.format(
-                self.config.elasticsearch.elasticsearch_index
+            '{url}/{index}/crash_reports/_search'.format(
+                url=self.get_url(),
+                index=self.config.elasticsearch.elasticsearch_index
             ),
             text=json.dumps(es_results)
         )


### PR DESCRIPTION
This fixes two things about the elasticsearch tests:

1. reduces errors due to the cluster not being ready
2. fixes a test that assumed the cluster was at localhost:9200 which it might
   not be