### PR TITLE
Fix postgresql tests

### DIFF
--- a/socorro/external/postgresql/server_status.py
+++ b/socorro/external/postgresql/server_status.py
@@ -11,6 +11,19 @@ from socorro.external.postgresql.base import PostgreSQLBase
 logger = logging.getLogger("webapi")
 
 
+def get_file(fn):
+    """Retrieves the contents of the specified resource file
+
+    Doing this as a separate function makes it easier to mock in the tests.
+
+    :arg str fn: the file name to retrieve
+
+    :returns: the contents as a string
+
+    """
+    return resource_string('socorro', fn)
+
+
 class ServerStatus(PostgreSQLBase):
     """Implement the /server_status service with PostgreSQL. """
 
@@ -33,8 +46,8 @@ class ServerStatus(PostgreSQLBase):
             schema_revision = "Unknown"
 
         # Find the current breakpad and socorro revisions
-        socorro_revision = resource_string('socorro', 'socorro_revision.txt')
-        breakpad_revision = resource_string('socorro', 'breakpad_revision.txt')
+        socorro_revision = get_file('socorro_revision.txt')
+        breakpad_revision = get_file('breakpad_revision.txt')
 
         return {
             "socorro_revision": socorro_revision.strip(),

--- a/socorro/unittest/external/postgresql/test_crash_data.py
+++ b/socorro/unittest/external/postgresql/test_crash_data.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
+
 from nose.tools import eq_, ok_, assert_raises
 from configman import ConfigurationManager, Namespace
 from mock import Mock
@@ -129,9 +131,9 @@ class TestIntegrationPostgresCrashData(TestCase):
             values_source_list=[{'database': {
                 'logger': mock_logging,
                 'database_name': 'socorro_integration_test',
-                'database_hostname': 'localhost',
-                'database_username': 'test',
-                'database_password': 'aPassword',
+                'database_hostname': os.environ['database_hostname'],
+                'database_username': os.environ['database_username'],
+                'database_password': os.environ['database_password'],
             }}]
         )
         return config_manager

--- a/socorro/unittest/external/postgresql/test_server_status.py
+++ b/socorro/unittest/external/postgresql/test_server_status.py
@@ -2,13 +2,31 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-import socorro
+import contextlib
+import tempfile
+
 from nose.tools import eq_
 
 from socorro.external.postgresql import server_status
 
 from unittestbase import PostgreSQLTestCase
+
+TEMP_DIR = tempfile.gettempdir()
+
+
+@contextlib.contextmanager
+def mock_get_file():
+    def mock_get_file(fn):
+        vals = {
+            'socorro_revision.txt': '42',
+            'breakpad_revision.txt': '43'
+        }
+        return vals[fn]
+
+    old_get_file = server_status.get_file
+    server_status.get_file = mock_get_file
+    yield
+    server_status.get_file = old_get_file
 
 
 class IntegrationTestServerStatus(PostgreSQLTestCase):
@@ -18,15 +36,6 @@ class IntegrationTestServerStatus(PostgreSQLTestCase):
         """Set up this test class by populating the database with fake data.
         """
         super(IntegrationTestServerStatus, self).setUp()
-
-        # Create fake revision files
-        self.basedir = os.path.dirname(socorro.__file__)
-        open(os.path.join(
-            self.basedir, 'socorro_revision.txt'
-        ), 'w').write('42')
-        open(os.path.join(
-            self.basedir, 'breakpad_revision.txt'
-        ), 'w').write('43')
 
         cursor = self.connection.cursor()
 
@@ -47,19 +56,18 @@ class IntegrationTestServerStatus(PostgreSQLTestCase):
 
     def tearDown(self):
         """Clean up the database. """
-        # Delete fake revision files
-        os.remove(os.path.join(self.basedir, 'socorro_revision.txt'))
-        os.remove(os.path.join(self.basedir, 'breakpad_revision.txt'))
-
         cursor = self.connection.cursor()
         cursor.execute("TRUNCATE alembic_version CASCADE;")
         self.connection.commit()
         super(IntegrationTestServerStatus, self).tearDown()
 
     def test_get(self):
-        status = server_status.ServerStatus(config=self.config)
+        # NOTE(willkg): This mocks out the pkg_resources code that gets the
+        # files, so this test doesn't test that aspect of server_status.
+        with mock_get_file():
+            status = server_status.ServerStatus(config=self.config)
+            res = status.get()
 
-        res = status.get()
         res_expected = {
             "socorro_revision": "42",
             "breakpad_revision": "43",

--- a/socorro/unittest/external/postgresql/test_server_status.py
+++ b/socorro/unittest/external/postgresql/test_server_status.py
@@ -3,15 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import contextlib
-import tempfile
 
 from nose.tools import eq_
 
 from socorro.external.postgresql import server_status
 
 from unittestbase import PostgreSQLTestCase
-
-TEMP_DIR = tempfile.gettempdir()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
The postgresql server_status test stomped would overwrite two files, run the
test, and then delete the files altogether. This fixes that behavior by mocking
out the "read the file from disk" function so we're still testing the code
itself, but not stomping on the files in question.

There was another postgresql test that had the database host, username, and
password hardcoded. This changes those to use the relevant environment
variables.