### PR TITLE
Fix filesystem tests

### DIFF
--- a/scripts/defaults
+++ b/scripts/defaults
@@ -12,6 +12,8 @@ if [ -z "$WORKSPACE" -o -z "$CI" ]; then
   export PATH=$JAVA_HOME/bin:$PATH
 fi
 
+export fs_root=${fs_root:-"./crashes"}
+
 export database_hostname=${database_hostname:-"localhost"}
 export database_username=${database_username:-"test"}
 export database_port=${database_port:-"5432"}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,6 +12,11 @@ ENV=env
 
 PYTHONPATH=.
 
+FS_RESOURCES=""
+if [ -n "$fs_root" ]; then
+    FS_RESOURCES="$FS_RESOURCES resource.fs.fs_root=$fs_root"
+fi
+
 PG_RESOURCES=""
 if [ -n "$database_url" ]; then
     echo database_url is present, specifying parameters on the command line is not necessary \( $database_url \)
@@ -95,7 +100,7 @@ PYTHONPATH=$PYTHONPATH ${VIRTUAL_ENV}/bin/alembic -c config/alembic.ini downgrad
 PYTHONPATH=$PYTHONPATH ${VIRTUAL_ENV}/bin/alembic -c config/alembic.ini upgrade heads
 
 # run tests
-$ENV $PG_RESOURCES $RMQ_RESOURCES $ES_RESOURCES PYTHONPATH=$PYTHONPATH $NOSE
+$ENV $FS_RESOURCES $PG_RESOURCES $RMQ_RESOURCES $ES_RESOURCES PYTHONPATH=$PYTHONPATH $NOSE
 
 # test webapp
 pushd webapp-django

--- a/socorro/unittest/external/fs/test_fsdatedradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fsdatedradixtreestorage.py
@@ -36,7 +36,8 @@ class TestFSDatedRadixTreeStorage(TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'minute_slice_interval': 1
+            'minute_slice_interval': 1,
+            'fs_root': os.environ['resource.fs.fs_root'],
           }],
           argv_source=[]
         )

--- a/socorro/unittest/external/fs/test_fslegacydatedradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fslegacydatedradixtreestorage.py
@@ -15,6 +15,9 @@ from socorro.external.crashstorage_base import (
 from socorro.unittest.testbase import TestCase
 
 
+FS_ROOT = os.environ['resource.fs.fs_root']
+
+
 class TestFSLegacyDatedRadixTreeStorage(TestCase):
     CRASH_ID_1 = "0bba929f-8721-460c-dead-a43c20071025"
     CRASH_ID_2 = "0bba929f-8721-460c-dead-a43c20071026"
@@ -38,7 +41,8 @@ class TestFSLegacyDatedRadixTreeStorage(TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'minute_slice_interval': 1
+            'minute_slice_interval': 1,
+            'fs_root': FS_ROOT,
           }],
           argv_source=[]
         )
@@ -185,7 +189,8 @@ class TestFSTemporaryStorage(TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'minute_slice_interval': 1
+            'minute_slice_interval': 1,
+            'fs_root': FS_ROOT,
           }],
           argv_source=[]
         )
@@ -325,13 +330,13 @@ class TestFSTemporaryStorage(TestCase):
         self._make_test_crash_3()
         self._make_test_crash_4()
         ok_(os.path.exists(
-            './crashes/25/date/00/00_01/0bba929f-8721-460c-dead-a43c20071025'
+            FS_ROOT + '/25/date/00/00_01/0bba929f-8721-460c-dead-a43c20071025'
         ))
         ok_(os.path.exists(
-            './crashes/25/date/00/00_01/0bba929f-8721-460c-dddd-a43c20071025'
+            FS_ROOT + '/25/date/00/00_01/0bba929f-8721-460c-dddd-a43c20071025'
         ))
         ok_(os.path.exists(
-            './crashes/25/date/00/00_01/0bba929f-8721-460c-dddd-a43c20071125'
+            FS_ROOT + '/25/date/00/00_01/0bba929f-8721-460c-dddd-a43c20071125'
         ))
         for x in self.fsrts.new_crashes():
             pass
@@ -347,7 +352,8 @@ class TestFSTemporaryStorage(TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-            'minute_slice_interval': 1
+            'minute_slice_interval': 1,
+            'fs_root': FS_ROOT
           }],
           argv_source=[]
         )
@@ -365,8 +371,7 @@ class TestFSTemporaryStorage(TestCase):
             self.fsrts.config.dump_field: 'baz'
         }), self.CRASH_ID_1)
         ok_(os.path.exists(
-            './crashes/20071025/date/00/00_00/0bba929f-8721-460c-dead-'
-            'a43c20071025'
+            FS_ROOT + '/20071025/date/00/00_00/0bba929f-8721-460c-dead-a43c20071025'
         ))
 
         self.fsrts._current_slot = lambda: ['00', '00_00']
@@ -374,7 +379,7 @@ class TestFSTemporaryStorage(TestCase):
         self._make_test_crash_3()
 
         ok_(os.path.exists(
-            './crashes/25/date/00/00_00/0bba929f-8721-460c-dddd-a43c20071025'
+            FS_ROOT + '/25/date/00/00_00/0bba929f-8721-460c-dddd-a43c20071025'
         ))
 
         # consume crashes
@@ -383,13 +388,12 @@ class TestFSTemporaryStorage(TestCase):
 
         # should be consumed because it isn't in our working tree or slot
         ok_(not os.path.exists(
-            './crashes/20071025/date/00/00_00/0bba929f-8721-460c-dead-'
-            'a43c20071025'
+            FS_ROOT + '/20071025/date/00/00_00/0bba929f-8721-460c-dead-a43c20071025'
         ))
 
         # should not be consumed, while in working tree, it is in active slot
         ok_(os.path.exists(
-            './crashes/25/date/00/00_00/0bba929f-8721-460c-dddd-a43c20071025'
+            FS_ROOT + '/25/date/00/00_00/0bba929f-8721-460c-dddd-a43c20071025'
         ))
 
         # switch to next active slot
@@ -401,5 +405,5 @@ class TestFSTemporaryStorage(TestCase):
 
         # should be consumed because it is in working tree and inactive slot
         ok_( not os.path.exists(
-            './crashes/25/date/00/00_00/0bba929f-8721-460c-dddd-a43c20071025'
+            FS_ROOT + '/25/date/00/00_00/0bba929f-8721-460c-dddd-a43c20071025'
         ))

--- a/socorro/unittest/external/fs/test_fsradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fsradixtreestorage.py
@@ -40,7 +40,7 @@ class TestFSRadixTreeStorage(TestCase):
           app_description='app description',
           values_source_list=[{
             'logger': mock_logging,
-           'fs_root': FS_ROOT,
+            'fs_root': FS_ROOT,
           }],
           argv_source=[]
         )

--- a/socorro/unittest/external/fs/test_fsradixtreestorage.py
+++ b/socorro/unittest/external/fs/test_fsradixtreestorage.py
@@ -12,6 +12,9 @@ from socorro.external.crashstorage_base import (
 from socorro.unittest.testbase import TestCase
 
 
+FS_ROOT = os.environ['resource.fs.fs_root']
+
+
 class TestFSRadixTreeStorage(TestCase):
     CRASH_ID_1 = "0bba929f-8721-460c-dead-a43c20071025"
     CRASH_ID_2 = "0bba929f-8721-460c-dead-a43c20071026"
@@ -36,7 +39,8 @@ class TestFSRadixTreeStorage(TestCase):
           app_version='1.0',
           app_description='app description',
           values_source_list=[{
-            'logger': mock_logging
+            'logger': mock_logging,
+           'fs_root': FS_ROOT,
           }],
           argv_source=[]
         )


### PR DESCRIPTION
The filesystem tests were modifying crash data in ./crashes. These code changes
add a resource.fs.fs_root environment variable and fix a bunch of tests that
were generating their own configuration to use it.