### PR TITLE
Fixes bug 1362048 - Redacted away StackTraces from raw_crash in ES.

### DIFF
--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -596,26 +596,26 @@ class PolyCrashStorage(CrashStorageBase):
             try:
                 actual_store = getattr(a_store, 'wrapped_object', a_store)
 
-                if (
-                    hasattr(actual_store, 'is_mutator') and
-                    actual_store.is_mutator()
-                ):
+                if hasattr(actual_store, 'is_mutator') and actual_store.is_mutator():
                     # We do this because `a_store.save_raw_and_processed`
                     # expects the processed crash to be a DotDict but
                     # you can't deepcopy those, so we deepcopy the
                     # pure dict version and then dress it back up as a
                     # DotDict.
-                    processed_crash = SocorroDotDict(
+                    my_processed_crash = SocorroDotDict(
                         copy.deepcopy(processed_crash_as_dict)
                     )
-                    raw_crash = SocorroDotDict(
+                    my_raw_crash = SocorroDotDict(
                         copy.deepcopy(raw_crash_as_dict)
                     )
+                else:
+                    my_processed_crash = processed_crash
+                    my_raw_crash = raw_crash
 
                 a_store.save_raw_and_processed(
-                    raw_crash,
+                    my_raw_crash,
                     dump,
-                    processed_crash,
+                    my_processed_crash,
                     crash_id
                 )
             except Exception:

--- a/socorro/external/crashstorage_base.py
+++ b/socorro/external/crashstorage_base.py
@@ -589,26 +589,33 @@ class PolyCrashStorage(CrashStorageBase):
         # processed crash which is a SocorroDotDict into a pure python
         # dict which we can more easily copy.deepcopy() operate on.
         processed_crash_as_dict = socorrodotdict_to_dict(processed_crash)
+        raw_crash_as_dict = socorrodotdict_to_dict(raw_crash)
 
         for a_store in self.stores.itervalues():
             self.quit_check()
             try:
                 actual_store = getattr(a_store, 'wrapped_object', a_store)
 
-                if hasattr(actual_store, 'is_mutator') and actual_store.is_mutator():
+                if (
+                    hasattr(actual_store, 'is_mutator') and
+                    actual_store.is_mutator()
+                ):
                     # We do this because `a_store.save_raw_and_processed`
                     # expects the processed crash to be a DotDict but
                     # you can't deepcopy those, so we deepcopy the
                     # pure dict version and then dress it back up as a
                     # DotDict.
-                    crash = SocorroDotDict(copy.deepcopy(processed_crash_as_dict))
-                else:
-                    crash = processed_crash
+                    processed_crash = SocorroDotDict(
+                        copy.deepcopy(processed_crash_as_dict)
+                    )
+                    raw_crash = SocorroDotDict(
+                        copy.deepcopy(raw_crash_as_dict)
+                    )
 
                 a_store.save_raw_and_processed(
                     raw_crash,
                     dump,
-                    crash,
+                    processed_crash,
                     crash_id
                 )
             except Exception:


### PR DESCRIPTION
The raw_crash nowadays contain a key called "StackTraces" that contains a pretty big string. Storing it in Elasticsearch has a pretty high cost in terms of disk space and memory. This thus adds a new redactor, specifically made for the raw_crash, that we want to use every time we send a crash to Elasticsearch.

@willkg this is quite opinionated, and I would like to know what you think about a few things in here. 

1. This means we will deepcopy the raw_crash as well as the processed_crash for every crash we process (only once, though, since the ES crashstorage is the only one that mutates crashes).
2. This means we modify the raw_crash, which is something we want to avoid, but in this case I don't think there's anyway around it (other than asking the Firefox team to not send that data in the first place, but we want to be able to handle this on our own). 
3. I don't like the fact that redacted keys are in config, so I made the RawCrashRedactor simply ignore whatever is in config and use a hard-coded list. I am very, very unsure about that. It is inconsistent with the rest of the app, _but_ it is also a lot easier to understand and maintain. And it is less bug-prone (the problem with the ``update_default`` function or whatever it's called isn't solved as far as I know). 

Also, the second commit just removes a bunch of decoration comments that I don't like and try to remove whenever I touch files that have them. 