### PR TITLE
Upgrade 'requests' to latest version

### DIFF
--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -17,7 +17,7 @@ deps =
     pytest-variables==1.6.1
     pytest-xdist==1.16.0
     selenium==3.4.1
-    requests==2.13.0
+    requests==2.14.2
 commands = pytest \
     --junit-xml=results/{envname}.xml \
     --html=results/{envname}.html --self-contained-html \


### PR DESCRIPTION
We've been running with 2.14.x for a couple days now, across the rest of our Web-testing suites without issue.  Changelog here: http://docs.python-requests.org/en/latest/community/updates/#id3

Full passing run against staging, here: https://gist.github.com/stephendonner/572ef96548fd31b9d186b55264dc061f

@willkg / @m8ttyB r?