### PR TITLE
Bug 1364193 - Add MessageChannel::Clear to the skip list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -78,7 +78,9 @@ mozilla::CondVar::.*
 mozilla::ipc::LogicError
 mozilla::ipc::MessageChannel::AssertWorkerThread
 mozilla::ipc::MessageChannel::Call
+mozilla::ipc::MessageChannel::Clear
 mozilla::ipc::MessageChannel::CxxStackFrame::CxxStackFrame
+mozilla::ipc::MessageChannel::~MessageChannel
 mozilla::ipc::MessageChannel::Send
 mozilla::ipc::RPCChannel::Call
 mozilla::ipc::RPCChannel::CxxStackFrame::CxxStackFrame


### PR DESCRIPTION
Adding Clear() and the dtor are enough to split the crashes in different protocols into separate signatures.