### PR TITLE
Bug 1364982 - Add mozilla::detail::nsStringRepr::{First,Last} to prefix signature list

### DIFF
--- a/socorro/siglists/prefix_signature_re.txt
+++ b/socorro/siglists/prefix_signature_re.txt
@@ -76,6 +76,8 @@ mozalloc_handle_oom
 moz_free
 mozilla::AndroidBridge::AutoLocalJNIFrame::~AutoLocalJNIFrame
 mozilla::CondVar::.*
+mozilla::detail::nsStringRepr::First
+mozilla::detail::nsStringRepr::Last
 mozilla::ipc::LogicError
 mozilla::ipc::MessageChannel::AssertWorkerThread
 mozilla::ipc::MessageChannel::Call


### PR DESCRIPTION
This fixes [bug 1364982](https://bugzilla.mozilla.org/show_bug.cgi?id=1364982).