### PR TITLE
Fixes bug 1366046 - speed up "make dockerbuild"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ DC := $(shell which docker-compose)
 	make dockerbuild
 
 dockerbuild:
+	${DC} build base
 	${DC} build processor
 	${DC} build webapp
-	${DC} build test
 	touch .docker-build
 
 # NOTE(willkg): We run setup in the webapp container because the webapp will own

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,13 @@
 # Note: Requires docker-comopse 1.10+.
 version: "2"
 services:
+  # Socorro base image
+  base:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    image: local/socorro_base
+
   # Processor app
   processor:
     build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:2.7.13-slim
+
+WORKDIR /app/
+RUN groupadd --gid 10001 app && useradd -g app --uid 10001 --shell /usr/sbin/nologin app
+
+# Install OS-level things
+COPY ./docker/set_up_ubuntu.sh /tmp/
+RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
+
+# Install Socorro Python requirements
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install -U 'pip>=8' && \
+    pip install --no-cache-dir -r requirements.txt
+
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONPATH /app

--- a/docker/Dockerfile.processor
+++ b/docker/Dockerfile.processor
@@ -1,11 +1,4 @@
-FROM python:2.7.13-slim
-
-WORKDIR /app/
-RUN groupadd --gid 10001 app && useradd -g app --uid 10001 --shell /usr/sbin/nologin app
-
-# Install OS-level things
-COPY ./docker/set_up_ubuntu.sh /tmp/
-RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
+FROM local/socorro_base
 
 # Install breakpad and stackwalk bits
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libcurl3 libcurl3-gnutls libcurl4-gnutls-dev
@@ -14,16 +7,7 @@ COPY ./minidump-stackwalk/ /tmp/minidump-stackwalk/
 COPY ./docker/set_up_stackwalk.sh /tmp
 RUN /tmp/set_up_stackwalk.sh
 
-# Install Socorro Python requirements
-COPY ./requirements.txt /app/requirements.txt
-RUN pip install -U 'pip>=8' && \
-    pip install --no-cache-dir -r requirements.txt
-
 COPY . /app/
-
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONPATH /app
 
 USER app
 

--- a/docker/Dockerfile.webapp
+++ b/docker/Dockerfile.webapp
@@ -1,23 +1,7 @@
-FROM python:2.7.13-slim
-
-WORKDIR /app/
-RUN groupadd --gid 10001 app && useradd -g app --uid 10001 --shell /usr/sbin/nologin app
-
-# Install OS-level things
-COPY ./docker/set_up_ubuntu.sh /tmp/set_up_ubuntu.sh
-RUN DEBIAN_FRONTEND=noninteractive /tmp/set_up_ubuntu.sh
+FROM local/socorro_base
 
 # Install nodejs and npm
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y npm nodejs nodejs-legacy
-
-# Install Socorro Python requirements
-COPY ./requirements.txt /tmp/requirements.txt
-RUN pip install -U 'pip>=8' && \
-    pip install --no-cache-dir -r /tmp/requirements.txt
-
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONPATH /app:/app/webapp-django
 
 ENV LESS_BINARY /usr/local/lib/node_modules/socorro-webapp-django/node_modules/.bin/lessc
 ENV UGLIFYJS_BINARY /usr/local/lib/node_modules/socorro-webapp-django/node_modules/.bin/uglifyjs


### PR DESCRIPTION
This nixes building the test service since it uses the same image as the webapp
service.

This pulls the redundant parts from building the processor and webapp images
into a base image and reorders some things to make that more convenient.

The end result is that it went from taking 15 minutes to 8 minutes to do "make
dockerbuild" on my local machine. I suspect/hope CircleCI gets similar results.

If this isn't sufficient, then I think future gains are going to be harder since
we'll need to reduce individual steps and I'm not sure what's left to cut/slim
down.