### PR TITLE
Fixes bug 1367071 - delete build artifacts before building

### DIFF
--- a/docker/set_up_stackwalk.sh
+++ b/docker/set_up_stackwalk.sh
@@ -26,6 +26,7 @@ fi
 
 # Now build stackwalk
 pushd minidump-stackwalk
+make clean
 make
 popd
 


### PR DESCRIPTION
It's possible for a developer to have build artifacts from building stackwalk on
their host machine which won't work when building in the container. This fixes
the script to delete build artifacts before building.