### PR TITLE
Update pytest, pytest-metadata, and selenium to latest

### DIFF
--- a/e2e-tests/tox.ini
+++ b/e2e-tests/tox.ini
@@ -9,14 +9,14 @@ deps =
     bidpom==2.0.1
     mozlog==3.4
     PyPOM==1.1.1
-    pytest==3.0.7
+    pytest==3.1.0
     pytest-base-url==1.3.0
     pytest-html==1.14.2
-    pytest-metadata==1.4.0
+    pytest-metadata==1.5.0
     pytest-selenium==1.10.0
     pytest-variables==1.6.1
     pytest-xdist==1.16.0
-    selenium==3.4.1
+    selenium==3.4.2
     requests==2.14.2
 commands = pytest \
     --junit-xml=results/{envname}.xml \


### PR DESCRIPTION
(As per usual, keeping these up-to-date along with our other Web-automation projects.)

@willkg fancy an r?

```Started by user Stephen Donner
Checking out git ${REPOSITORY} to read e2e-tests/Jenkinsfile
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/socorro.git
 > /usr/bin/git init /var/lib/jenkins/jobs/socorro.adhoc/workspace@script # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
 > /usr/bin/git --version # timeout=10
 > /usr/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
 > /usr/bin/git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > /usr/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
 > /usr/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/bin/git rev-parse origin/update-reqs^{commit} # timeout=10
Checking out Revision 64cdcb2cfba5e7de8743fda6ca4abbdc6350256a (origin/update-reqs)
 > /usr/bin/git config core.sparsecheckout # timeout=10
 > /usr/bin/git checkout -f 64cdcb2cfba5e7de8743fda6ca4abbdc6350256a
 > /usr/bin/git rev-list c657dbf555acc824e05719a51668dbe52c636ddb # timeout=10
First time build. Skipping changelog.
Loading library fxtest@1.6
 > /usr/bin/git rev-parse --is-inside-work-tree # timeout=10
Setting origin to https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/bin/git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
Fetching origin...
Fetching upstream changes from origin
 > /usr/bin/git --version # timeout=10
 > /usr/bin/git fetch --tags --progress origin +refs/heads/*:refs/remotes/origin/*
 > /usr/bin/git rev-parse 1.6^{commit} # timeout=10
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/bin/git init /var/lib/jenkins/jobs/socorro.adhoc/workspace@libs/fxtest # timeout=10
Fetching upstream changes from https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/bin/git --version # timeout=10
 > /usr/bin/git fetch --tags --progress https://github.com/mozilla/fxtest-jenkins-pipeline.git +refs/heads/*:refs/remotes/origin/*
 > /usr/bin/git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
 > /usr/bin/git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > /usr/bin/git config remote.origin.url https://github.com/mozilla/fxtest-jenkins-pipeline.git # timeout=10
Fetching upstream changes from https://github.com/mozilla/fxtest-jenkins-pipeline.git
 > /usr/bin/git fetch --tags --progress https://github.com/mozilla/fxtest-jenkins-pipeline.git +refs/heads/*:refs/remotes/origin/*
Checking out Revision 98cd38319db7273c62db6ae389b90eca3022c95e (1.6)
 > /usr/bin/git config core.sparsecheckout # timeout=10
 > /usr/bin/git checkout -f 98cd38319db7273c62db6ae389b90eca3022c95e
 > /usr/bin/git rev-list 98cd38319db7273c62db6ae389b90eca3022c95e # timeout=10
[Pipeline] node
Running on CL7-DOCKER-A in /home/jenkins/workspace/socorro.adhoc
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Declarative: Checkout SCM)
[Pipeline] checkout
Wiping out workspace first.
Cloning the remote Git repository
Cloning repository https://github.com/stephendonner/socorro.git
 > /usr/bin/git init /home/jenkins/workspace/socorro.adhoc # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
 > /usr/bin/git --version # timeout=10
 > /usr/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
 > /usr/bin/git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
 > /usr/bin/git config remote.origin.url https://github.com/stephendonner/socorro.git # timeout=10
Fetching upstream changes from https://github.com/stephendonner/socorro.git
 > /usr/bin/git fetch --tags --progress https://github.com/stephendonner/socorro.git +refs/heads/*:refs/remotes/origin/*
 > /usr/bin/git rev-parse origin/update-reqs^{commit} # timeout=10
Checking out Revision 64cdcb2cfba5e7de8743fda6ca4abbdc6350256a (origin/update-reqs)
 > /usr/bin/git config core.sparsecheckout # timeout=10
 > /usr/bin/git checkout -f 64cdcb2cfba5e7de8743fda6ca4abbdc6350256a
[Pipeline] }
[Pipeline] // stage
[Pipeline] withCredentials
[Pipeline] {
[Pipeline] withEnv
[Pipeline] {
[Pipeline] ansiColor
[Pipeline] {
[Pipeline] timestamps
[Pipeline] {
[Pipeline] timeout
Timeout set to expire in 1 hr 0 min
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Lint)
[Pipeline] sh
[socorro.adhoc] Running shell script
+ tox -c e2e-tests/tox.ini -e flake8
flake8 create: /home/jenkins/workspace/socorro.adhoc/e2e-tests/.tox/flake8
flake8 installdeps: flake8
flake8 installed: appdirs==1.4.3,configparser==3.5.0,enum34==1.1.6,flake8==3.3.0,mccabe==0.6.1,packaging==16.8,pycodestyle==2.3.1,pyflakes==1.5.0,pyparsing==2.2.0,six==1.10.0
flake8 runtests: PYTHONHASHSEED='2649756325'
flake8 runtests: commands[0] | flake8 .
___________________________________ summary ____________________________________
  flake8: commands succeeded
  congratulations :)
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Test)
[Pipeline] writeFile
[Pipeline] sh
[socorro.adhoc] Running shell script
+ tox -c e2e-tests/tox.ini -e py27
py27 create: /home/jenkins/workspace/socorro.adhoc/e2e-tests/.tox/py27
py27 installdeps: bidpom==2.0.1, mozlog==3.4, PyPOM==1.1.1, pytest==3.1.0, pytest-base-url==1.3.0, pytest-html==1.14.2, pytest-metadata==1.5.0, pytest-selenium==1.10.0, pytest-variables==1.6.1, pytest-xdist==1.16.0, selenium==3.4.2, requests==2.14.2
py27 installed: apipkg==1.4,appdirs==1.4.3,bidpom==2.0.1,blessings==1.6,execnet==1.4.1,mozlog==3.4,packaging==16.8,py==1.4.33,pyparsing==2.2.0,PyPOM==1.1.1,pytest==3.1.0,pytest-base-url==1.3.0,pytest-html==1.14.2,pytest-metadata==1.5.0,pytest-selenium==1.10.0,pytest-variables==1.6.1,pytest-xdist==1.16.0,requests==2.14.2,selenium==3.4.2,six==1.10.0,zope.component==4.3.0,zope.event==4.2.0,zope.interface==4.4.1
py27 runtests: PYTHONHASHSEED='3390244467'
py27 runtests: commands[0] | pytest --junit-xml=results/py27.xml --html=results/py27.html --self-contained-html --log-raw=results/py27_raw.txt --log-tbpl=results/py27_tbpl.txt
============================= test session starts ==============================
platform linux2 -- Python 2.7.5, pytest-3.1.0, py-1.4.33, pluggy-0.4.0 -- /home/jenkins/workspace/socorro.adhoc/e2e-tests/.tox/py27/bin/python2.7
cachedir: .cache
driver: SauceLabs
sensitiveurl: mozilla\.org
metadata: {'BUILD_NUMBER': '53', 'Packages': {'py': '1.4.33', 'pluggy': '0.4.0', 'pytest': '3.1.0'}, 'Platform': 'Linux-3.10.0-327.36.3.el7.x86_64-x86_64-with-centos-7.2.1511-Core', 'Capabilities': {u'version': u'47.0', u'platform': u'Windows 10', u'browserName': u'Firefox', u'public': u'public restricted', u'build': u'jenkins-socorro.adhoc-53'}, 'Python': '2.7.5', 'JENKINS_URL': 'https://fx-test-jenkins-dev.stage.mozaws.net:8443/', 'Base URL': 'https://crash-stats.allizom.org', 'Driver': 'SauceLabs', 'Plugins': {'selenium': '1.10.0', 'xdist': '1.16.0', 'metadata': '1.5.0', 'variables': '1.6.1', 'base-url': '1.3.0', 'mozlog': '3.4', 'html': '1.14.2'}, 'JOB_NAME': 'socorro.adhoc'}
baseurl: https://crash-stats.allizom.org
rootdir: /home/jenkins/workspace/socorro.adhoc/e2e-tests, inifile: tox.ini
plugins: xdist-1.16.0, variables-1.6.1, selenium-1.10.0, metadata-1.5.0, html-1.14.2, base-url-1.3.0, mozlog-3.4
gw0 I / gw1 I / gw2 I / gw3 I / gw4 I / gw5 I / gw6 I / gw7 I / gw8 I / gw9 I

[gw0] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw1] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw2] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw3] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw4] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw5] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw6] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw7] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw8] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw9] linux2 Python 2.7.5 cwd: /home/jenkins/workspace/socorro.adhoc/e2e-tests

[gw1] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw0] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw2] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw3] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw4] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw5] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw6] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw9] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw8] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

[gw7] Python 2.7.5 (default, Sep 15 2016, 22:37:39)  -- [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
gw0 [31] / gw1 [31] / gw2 [31] / gw3 [31] / gw4 [31] / gw5 [31] / gw6 [31] / gw7 [31] / gw8 [31] / gw9 [31]

scheduling tests via LoadScheduling

tests/test_api.py::TestAPI::test_public_api_navigation 
tests/test_api.py::TestAPI::test_supersearch_fields 
tests/test_api.py::TestAPI::test_crontabber 
tests/test_crash_reports.py::TestCrashReports::test_that_bugzilla_link_contain_current_site 
tests/test_crash_reports.py::TestCrashReports::test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users 
tests/test_crash_reports.py::TestCrashReports::test_that_products_are_sorted_correctly 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Firefox] 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Thunderbird] 
tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[FennecAndroid] 
tests/test_api.py::TestAPI::test_platforms 
[gw0] PASSED tests/test_api.py::TestAPI::test_crontabber 
[gw7] PASSED tests/test_api.py::TestAPI::test_platforms 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_all_return_results 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[FennecAndroid] 
[gw3] PASSED tests/test_api.py::TestAPI::test_supersearch_fields 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Thunderbird] 
[gw9] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_bugzilla_link_contain_current_site 
[gw2] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_plugin_return_results 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_browser_return_results 
[gw5] xfail tests/test_crash_reports.py::TestCrashReports::test_that_products_are_sorted_correctly 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Firefox] 
[gw4] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Firefox] 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Thunderbird] 
[gw8] PASSED tests/test_api.py::TestAPI::test_public_api_navigation 
tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Firefox] 
[gw0] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_all_return_results 
[gw7] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[FennecAndroid] 
[gw6] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[Thunderbird] 
tests/test_crash_reports.py::TestCrashReports::test_that_7_days_is_selected_default_for_nightlies 
tests/test_crash_reports.py::TestCrashReports::test_that_only_browser_reports_have_browser_icon 
tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[FennecAndroid] 
[gw1] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_reports_form_has_same_product[FennecAndroid] 
[gw3] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Thunderbird] 
[gw9] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_browser_return_results 
[gw2] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crasher_filter_plugin_return_results 
[gw0] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_7_days_is_selected_default_for_nightlies 
[gw8] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_current_version_selected_in_top_crashers_header[Firefox] 
[gw5] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Firefox] 
[gw6] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[FennecAndroid] 
[gw4] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_top_crashers_reports_links_work[Thunderbird] 
[gw7] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_only_browser_reports_have_browser_icon 
tests/test_search.py::TestSuperSearch::test_search_with_one_line 
tests/test_crash_reports.py::TestCrashReports::test_that_only_plugin_reports_have_plugin_icon 
tests/test_search.py::TestSuperSearch::test_search_with_multiple_lines 
tests/test_crash_reports.py::TestCrashReports::test_that_lowest_version_topcrashers_do_not_return_errors 
tests/test_search.py::TestSuperSearch::test_super_search_page_is_loaded 
tests/test_search.py::TestSuperSearch::test_search_change_facet 
tests/test_search.py::TestSuperSearch::test_search_change_column 
tests/test_search.py::TestSearchForSpecificResults::test_selecting_one_version_doesnt_show_other_versions 
tests/test_crash_reports.py::TestCrashReports::test_top_crasher_reports_tab_has_uuid_report 
tests/test_search.py::TestSearchForSpecificResults::test_search_for_valid_signature 
[gw2] PASSED tests/test_search.py::TestSuperSearch::test_super_search_page_is_loaded 
[gw8] PASSED tests/test_search.py::TestSuperSearch::test_search_with_one_line 
[gw7] PASSED tests/test_search.py::TestSearchForSpecificResults::test_search_for_valid_signature 
[gw5] PASSED tests/test_search.py::TestSuperSearch::test_search_change_facet 
[gw1] PASSED tests/test_crash_reports.py::TestCrashReports::test_top_crasher_reports_tab_has_uuid_report 
[gw0] PASSED tests/test_search.py::TestSuperSearch::test_search_with_multiple_lines 
[gw6] PASSED tests/test_search.py::TestSearchForSpecificResults::test_selecting_one_version_doesnt_show_other_versions 
[gw3] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_only_plugin_reports_have_plugin_icon 
[gw9] PASSED tests/test_crash_reports.py::TestCrashReports::test_that_lowest_version_topcrashers_do_not_return_errors 
Post stage
[gw4] PASSED tests/test_search.py::TestSuperSearch::test_search_change_column 

 generated xml file: /home/jenkins/workspace/socorro.adhoc/e2e-tests/results/py27.xml 
 generated html file: /home/jenkins/workspace/socorro.adhoc/e2e-tests/results/py27.html 
=========================== short test summary info ============================
XFAIL tests/test_crash_reports.py::TestCrashReports::()::test_that_products_are_sorted_correctly
  bug 1351757: Cease exposing SeaMonkey and bug 1292594: Fennec shouldn't be an option
==================== 30 passed, 1 xfailed in 140.77 seconds ====================
___________________________________ summary ____________________________________
  py27: commands succeeded
  congratulations :)
```